### PR TITLE
tweak: disable deathmatch, enable greenshift and extended

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -74,7 +74,7 @@
   - extended
   - shittersafari
   name: extended-title
-  showInVote: false #2boring2vote
+  showInVote: true  # starcup: enable voting extended
   description: extended-description
   rules:
   - BasicStationEventScheduler
@@ -88,7 +88,7 @@
   - greenshift
   - shittersafarideluxeedition
   name: greenshift-title
-  showInVote: false #4boring4vote
+  showInVote: true  # starcup: enable voting greenshift
   description: greenshift-description
   rules:
   - SpaceTrafficControlFriendlyEventScheduler
@@ -165,7 +165,7 @@
   name: death-match-title
   description: death-match-description
   maxPlayers: 15
-  showInVote: true
+  showInVote: false  # starcup: disable voting deathmatch
   supportedMaps: DeathMatchMapPool
   rules:
     - DeathMatch31


### PR DESCRIPTION
Enable voting for Greenshift and Extended, disable voting for Deathmatch.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: enabled voting for Greenshift and Extended, disabled voting for Deathmatch
