### PR TITLE
fix: uncaught admin assistant pda bug

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/pda.yml
@@ -47,7 +47,7 @@
     appearanceDataInit:
       enum.PdaVisuals.PdaType:
         !type:String
-        pda-admin-assistant
+        pda
   - type: PdaBorderColor
     borderColor: "#1B67A5"
   - type: Icon


### PR DESCRIPTION
not all of the checks actually ran for some reason and so I missed this. giving the admin assistants the basic pda appearance for now as a stopgap until I can decipher the appearance code