### PR TITLE
feat: increase vulp temperature threshold

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -97,7 +97,7 @@
       Unsexed: MaleVulpkanin
   - type: DogVision
   - type: Temperature
-    heatDamageThreshold: 315 # 10 lower than base
+    heatDamageThreshold: 320 # 10 lower than base # Frontier: 315<320
     coldDamageThreshold: 220 # 40 lower than base, very insulating fur
 
 - type: entity


### PR DESCRIPTION
very small change ported from frontier, nudging up vulps' heat damage threshold so they aren't constantly overheating from everything