### PR TITLE
feat: adjust species sizes

### DIFF
--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -136,13 +136,15 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// The minimum height for this species
     /// </summary>
     [DataField("minHeight")]
-    public float MinHeight = 0.85f; // DeltaV - less trolling with the heights
+
+    public float MinHeight = 0.95f; // starcup: height adjustments
 
     /// <summary>
     /// The maximum height for this species
     /// </summary>
     [DataField("maxHeight")]
-    public float MaxHeight = 1.2f; // DeltaV - less trolling with the heights
+
+    public float MaxHeight = 1.05f; // starcup: height adjustments
 
     /// <summary>
     /// The default height for this species

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -11,6 +11,7 @@
   maleFirstNames: NamesMothFirstMale
   femaleFirstNames: NamesMothFirstFemale
   lastNames: NamesMothLast
+  baseScale: "0.95, 0.95" # starcup: height adjustments
 
 - type: speciesBaseSprites
   id: MobMothSprites

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -8,6 +8,11 @@
   markingLimits: MobSlimeMarkingLimits
   dollPrototype: MobSlimePersonDummy
   skinColoration: Hues
+# begin starcup: height adjustments
+  baseScale: "1.05, 1.05"
+  minHeight: 0.8
+  maxHeight: 1.1
+# end starcup
 
 - type: speciesBaseSprites
   id: MobSlimeSprites

--- a/Resources/Prototypes/_DeltaV/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Species/felinid.yml
@@ -8,6 +8,7 @@
   dollPrototype: MobFelinidDummy
   skinColoration: Hues # starcup
   baseScale: "0.8, 0.8"
+  minHeight: 0.9 # starcup: height adjustments
 
 - type: markingPoints
   id: MobFelinidMarkingLimits

--- a/Resources/Prototypes/_DeltaV/Species/harpy.yml
+++ b/Resources/Prototypes/_DeltaV/Species/harpy.yml
@@ -7,7 +7,7 @@
   markingLimits: MobHarpyMarkingLimits
   dollPrototype: MobHarpyDummy
   skinColoration: Hues # starcup
-  baseScale: "0.9, 0.9"
+  baseScale: "0.85, 0.85" # starcup: height adjustments
 
 - type: speciesBaseSprites
   id: MobHarpySprites

--- a/Resources/Prototypes/_DeltaV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DeltaV/Species/rodentia.yml
@@ -12,7 +12,10 @@
   femaleFirstNames: NamesRodentiaFemale
   lastNames: NamesRodentiaLast
   naming: LastFirst
-  baseScale: "0.8, 0.8"
+# begin starcup: height adjustments
+  baseScale: "0.75, 0.75"
+  minHeight: 0.9
+# end starcup
 
 - type: speciesBaseSprites
   id: MobRodentiaSprites

--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -17,6 +17,10 @@
   naming: FirstDashLast
   sexes:
   - Unsexed
+# begin starcup: height adjustments
+  minHeight: 0.85
+  maxHeight: 1.05
+# end starcup
 
 # The lack of a layer means that
 # this person cannot have round-start anything


### PR DESCRIPTION
changes species heights in accordance with the drafted species heights detailed in [this document](https://docs.google.com/spreadsheets/d/1cTkaZtIL5VWPRHXHOqLIQc3b206c8YQPGMk6KKssovU/edit?gid=585732893#gid=585732893) by catty!

**Changelog**
:cl:
- tweak: Tightened base height ranges
- tweak: Made harpies, moths, and rodentia a little smaller
- tweak: Expanded minimum heights for slimes, MKCs, and felinids

