### PR TITLE
fix: give felinids, harpies, and vulpekin the correct hand placements

### DIFF
--- a/Resources/Prototypes/_DeltaV/Body/Prototypes/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Body/Prototypes/felinid.yml
@@ -13,10 +13,10 @@
     torso:
       part: TorsoHuman
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
       organs:
         heart: OrganAnimalHeart
         lungs: OrganHumanLungs

--- a/Resources/Prototypes/_DeltaV/Body/Prototypes/harpy.yml
+++ b/Resources/Prototypes/_DeltaV/Body/Prototypes/harpy.yml
@@ -13,10 +13,10 @@
     torso:
       part: TorsoHarpy
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
       organs:
         heart: OrganHumanHeart
         lungs: OrganHarpyLungs

--- a/Resources/Prototypes/_DeltaV/Body/Prototypes/vulpkanin.yml
+++ b/Resources/Prototypes/_DeltaV/Body/Prototypes/vulpkanin.yml
@@ -19,10 +19,10 @@
         liver: OrganAnimalLiver
         kidneys: OrganHumanKidneys
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
     right arm:
       part: RightArmVulpkanin
       connections:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Fixes #36

Felinids, harpies, and vulpekin had their hands swapped. This pull request fixes that.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: felinids, harpies, and vulpekin hand placements are now correct
