### PR TITLE
tweak: remove thieving abilities from felinids

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
@@ -39,9 +39,9 @@
 #  - type: DiseaseCarrier
 #    naturalImmunities:
 #    - OwOnavirus
-  - type: Thieving
-    stealthy: true
-    stripTimeReduction: 1
+#  - type: Thieving
+#    stealthy: true
+#    stripTimeReduction: 1
   - type: Speech
     speechSounds: Alto
     speechVerb: Felinid

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
@@ -36,9 +36,6 @@
       types:
         Slash: 4
         Piercing: 1
-#  - type: DiseaseCarrier
-#    naturalImmunities:
-#    - OwOnavirus
 #  - type: Thieving
 #    stealthy: true
 #    stripTimeReduction: 1

--- a/Resources/ServerInfo/Guidebook/Mobs/_DeltaV/Felinid.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/_DeltaV/Felinid.xml
@@ -20,7 +20,6 @@
   - Able to eat mice and rats after picking them up. This has the benefit of regenerating the hairball ability and feeding them.
   - Uses their claws to do Slashing damage and Piercing damage.
   - Can walk completely silently, but only while barefooted.
-  - Immunity to the OwOnavirus disease.
 
   ## Drawbacks
 


### PR DESCRIPTION
comments out felinids' thieving component, which completely dodged my notice during the initial port of the species. 

**Changelog**
:cl:
- remove: Felinids no longer have the thieving gloves effect