### PR TITLE
fix: missing hunger/thirst components, base hunger rate

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.035f; // DeltaV: changed from 0.01666666666f
+    public float BaseDecayRate = 0.025f; // starcup: changed from 0.01666666666f (150% of standard)
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.01666666666f;
+    public float BaseDecayRate = 0.035f; // DeltaV: changed from 0.01666666666f
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/Oni.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseMobSpeciesOrganic
+  parent: BaseMobSpeciesOrganic # starcup: changed from BaseMobHuman for consistency
   name: Urist McOni
   id: MobOniBase
   abstract: true
@@ -27,8 +27,10 @@
         Slash: 1.2
         Piercing: 1.2
         Asphyxiation: 1.35
+# begin starcup: added for parental change
   - type: Hunger
   - type: Thirst
+# end starcup
   - type: Damageable
     damageModifierSet: Oni
   - type: Body

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/Oni.yml
@@ -27,6 +27,8 @@
         Slash: 1.2
         Piercing: 1.2
         Asphyxiation: 1.35
+  - type: Hunger
+  - type: Thirst
   - type: Damageable
     damageModifierSet: Oni
   - type: Body

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
@@ -26,6 +26,8 @@
         - MobLayer
   - type: Body
     prototype: Felinid
+  - type: Hunger
+  - type: Thirst
   - type: Damageable
     damageModifierSet: Felinid
   - type: MeleeWeapon

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McFelinid
-  parent: BaseMobSpeciesOrganic
+  parent: BaseMobSpeciesOrganic # starcup: changed from BaseMobHuman for consistency
   id: MobFelinidBase
   abstract: true
   components:
@@ -26,8 +26,10 @@
         - MobLayer
   - type: Body
     prototype: Felinid
+# begin starcup: added for parental change
   - type: Hunger
   - type: Thirst
+# end starcup
   - type: Damageable
     damageModifierSet: Felinid
   - type: MeleeWeapon

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/harpy.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McHarpy
-  parent: BaseMobSpeciesOrganic
+  parent: BaseMobSpeciesOrganic # starcup: changed from BaseMobHuman for consistency
   id: MobHarpyBase
   abstract: true
   components:
@@ -100,8 +100,10 @@
         - MobLayer
   - type: Body
     prototype: Harpy
+# begin starcup: added for parental change
   - type: Hunger
   - type: Thirst
+# end starcup
   - type: Damageable
     damageModifierSet: Harpy
   - type: MeleeWeapon

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/harpy.yml
@@ -100,6 +100,8 @@
         - MobLayer
   - type: Body
     prototype: Harpy
+  - type: Hunger
+  - type: Thirst
   - type: Damageable
     damageModifierSet: Harpy
   - type: MeleeWeapon

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/rodentia.yml
@@ -9,7 +9,7 @@
     species: Rodentia
   - type: Thirst
   - type: Hunger
-    baseDecayRate: 0.0467 # 33% faster than usual
+    baseDecayRate: 0.03325 # starcup: adjusted for changed base rate (still 33% faster than normal)
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Inventory
     speciesId: rodentia


### PR DESCRIPTION
adds the missing components to felinids, harpies, and oni, as well as increasing the hunger base decay rate per delta-v's numbers, thus indirectly fixing #37. also fixes #42

**Changelog**
:cl:
- fix: Felinids, harpies, and oni now feel hunger and thirst properly.
- tweak: The rate at which non-rodentia characters get hungry has been increased.
- tweak: Rodentia now get hungry slightly slower overall (but still 33% faster than everyone else)