### PR TITLE
fix: painkiller availability

### DIFF
--- a/Resources/Locale/en-US/_DeltaV/prototypes/catalog/fills/crates/medical-crates.ftl
+++ b/Resources/Locale/en-US/_DeltaV/prototypes/catalog/fills/crates/medical-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateMedicalPainkiller = Painkillers crate
+    .desc = Contains a number of painkiller options.

--- a/Resources/Prototypes/_CosmaticDrift/Reactions/medicine.yml
+++ b/Resources/Prototypes/_CosmaticDrift/Reactions/medicine.yml
@@ -1,0 +1,43 @@
+- type: reaction
+  id: Stubantazine
+  reactants:
+    Bicaridine:
+      amount: 1
+    Lithium:
+      amount: 1
+    Oil:
+      amount: 1
+  products:
+    Stubantazine: 3
+
+- type: reaction
+  id: Soretizone
+  minTemp: 340
+  reactants:
+    Bicaridine:
+      amount: 1
+    Phenol:
+      amount: 1
+    Iron:
+      amount: 1
+    TableSalt:
+      amount: 1
+      catalyst: true
+  products:
+    Soretizone: 3
+
+- type: reaction
+  id: Agonolexyne
+  minTemp: 350
+  reactants:
+    Bicaridine:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+    Sodium:
+      amount: 1
+    Plasma:
+      amount: 1
+      catalyst: true
+  products:
+    Agonolexyne: 3

--- a/Resources/Prototypes/_DeltaV/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_DeltaV/Catalog/Cargo/cargo_medical.yml
@@ -7,3 +7,13 @@
   cost: 1000
   category: Medical
   group: market
+
+- type: cargoProduct
+  id: PainkillerCrate
+  icon:
+    sprite: Objects/Specific/Chemistry/pills_canister.rsi
+    state: pill_canister
+  product: CratePainkillerBottles
+  cost: 1000
+  category: Medical
+  group: market

--- a/Resources/Prototypes/_DeltaV/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_DeltaV/Catalog/Fills/Crates/medical.yml
@@ -8,3 +8,14 @@
     contents:
     - id: Oilpack
       amount: 5
+
+- type: entity
+  id: CratePainkillerBottles
+  parent: CrateMedical
+  name: painkiller crate
+  description: Running out of these is not an option.
+  components:
+  - type: StorageFill
+    contents:
+    - id: PillCanisterStubantazine
+      amount: 3

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Medical/healing.yml
@@ -67,6 +67,37 @@
 
 - type: entity
   parent: Pill
+  id: PillStubantazine
+  suffix: Stubantazine 10u
+  components:
+  - type: Sprite
+    state: pill3
+  - type: Pill
+    pillType: 2
+  - type: Label
+    currentLabel: stubantazine 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Stubantazine
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterStubantazine
+  suffix: Stubantazine 10u, 5
+  components:
+  - type: Label
+    currentLabel: stubantazine 10u
+  - type: StorageFill
+    contents:
+    - id: PillStubantazine
+      amount: 5
+
+- type: entity
+  parent: Pill
   id: PillSoretizone
   suffix: Soretizone 10u
   components:
@@ -94,4 +125,35 @@
   - type: StorageFill
     contents:
     - id: PillSoretizone
+      amount: 5
+
+- type: entity
+  parent: Pill
+  id: PillAgonolexyne
+  suffix: agonolexyne 5u
+  components:
+  - type: Sprite
+    state: pill20
+  - type: Pill
+    pillType: 19
+  - type: Label
+    currentLabel: agonolexyne 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Agonolexyne
+          Quantity: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterAgonolexyne
+  suffix: Agonolexyne 5u, 5
+  components:
+  - type: Label
+    currentLabel: agonolexyne 5u
+  - type: StorageFill
+    contents:
+    - id: PillAgonolexyne
       amount: 5


### PR DESCRIPTION
added the missing painkiller reagent recipes, and also ported delta's painkiller crate as a logistics purchase in case there aren't any chemists available. fixes #38

**Changelog**
:cl:
- fix: Added missing chemistry recipes for stubantazine, soretizone, and agonolexyne.
- add: Added Delta-V's painkiller crate to the logistics catalog.
