### PR TITLE
tweak: mining quality of life updates

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -37,7 +37,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 100
+      RawGold: 300 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -103,7 +103,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 100
+      RawIron: 200 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -136,7 +136,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 100
+      RawPlasma: 500 # DeltaV - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -174,7 +174,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 100
+      RawSilver: 300 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -207,7 +207,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 100
+      RawQuartz: 200 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -240,7 +240,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 100
+      RawUranium: 300 # DeltaV
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -339,7 +339,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 100
+      Coal: 200 # DeltaV
   - type: Item
     heldPrefix: coal
 

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -240,7 +240,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 300 # DeltaV
+      RawUranium: 300 # DeltaV - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -339,7 +339,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 200 # DeltaV
+      Coal: 200 # DeltaV - was 100
   - type: Item
     heldPrefix: coal
 

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -51,7 +51,7 @@
           False: { visible: true }
   - type: Storage
     grid:
-    - 0,0,9,5
+    - 0,0,19,9 # DeltaV: Expanded to ore bag of holding storage
     maxItemSize: Normal
     storageOpenSound: /Audio/Effects/closetopen.ogg
     storageCloseSound: /Audio/Effects/closetclose.ogg


### PR DESCRIPTION
cherry-picks a few numerical adjustments from delta, increasing the amount of ore you find in veins as well as greatly expanding the storage of the ore box. pushing this out ahead of a more comprehensive port of delta's salvage reworks to help ease some of the more immediate balancing problems

**Changelog**
:cl:
- tweak: ore veins now provide more ore before depleting
- tweak: ore box storage greatly expanded
