### PR TITLE
fix: map vote options

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -8,6 +8,7 @@
   #- Core
   - Elkridge
   - Fland
+  - Glacier # starcup: ported from Delta-V. enabled.
   #- Gate
   - Loop
   - Marathon
@@ -17,4 +18,5 @@
   - Packed
   - Plasma
   - Reach
+  - Saltern # starcup: wasn't on the list for some reason? enabled.
   #- Train

--- a/Resources/Prototypes/_starcup/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_starcup/Maps/Pools/default.yml
@@ -1,5 +1,5 @@
 - type: gameMapPool
-  id: DefaultMapPool
+  id: StarcupDefaultMapPool
   maps:
   - Amber
   - Bagel
@@ -8,6 +8,7 @@
   #- Core
   - Elkridge
   - Fland
+  - Glacier # starcup: ported from Delta-V. enabled.
   #- Gate
   - Loop
   - Marathon
@@ -17,4 +18,5 @@
   - Packed
   - Plasma
   - Reach
+  - Saltern # starcup: wasn't on the list for some reason? enabled.
   #- Train

--- a/Resources/Prototypes/_starcup/Maps/glacier.yml
+++ b/Resources/Prototypes/_starcup/Maps/glacier.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_starcup/glacier.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 1  # starcup: 15 (Delta-V) -> 1
+  minPlayers: 0  # starcup: 15 (Delta-V) -> 0
   maxPlayers: 60
   stations:
     Glacier:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added Glacier and Saltern to map voting

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Low-population shifts were previously unable to vote for any map besides Reach. This adds two more maps to the pool to give players more variety.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
 - fix: added Glacier and Saltern to the map voting pool