### PR TITLE
tweak: remove redundant survival event scheduler

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -9,7 +9,7 @@
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
-    - # SpaceTrafficControlFriendlyEventScheduler # starcup: SpaceTrafficControlEventScheduler already spawns these.
+   # - SpaceTrafficControlFriendlyEventScheduler # starcup: SpaceTrafficControlEventScheduler already spawns these.
     - BasicRoundstartVariation
 
 - type: gamePreset

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -9,7 +9,7 @@
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
-    - SpaceTrafficControlFriendlyEventScheduler
+    - # SpaceTrafficControlFriendlyEventScheduler # starcup: SpaceTrafficControlEventScheduler already spawns these.
     - BasicRoundstartVariation
 
 - type: gamePreset


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Disables the SpaceTrafficControlFriendlyEventScheduler rule in Survival.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Survival already has an event scheduler that spawns Friendly, Freelance, and Hostile shuttles. Adding a second scheduler specifically for Friendly shuttles clutters the ghost roles and is unnecessary.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: removed a redundant survival event scheduler