### PR TITLE
tweak: disabled multiple ruins

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -61,17 +61,17 @@
           stationGrid: false
           paths:
           - /Maps/Ruins/abandoned_outpost.yml
-          - /Maps/Ruins/chunked_tcomms.yml
+          - # /Maps/Ruins/chunked_tcomms.yml # starcup: needs rework
           - /Maps/Ruins/biodome_satellite.yml
-          - /Maps/Ruins/derelict.yml
+          - # /Maps/Ruins/derelict.yml # starcup: disable pending merge of rework PRs
           - /Maps/Ruins/djstation.yml
-          - /Maps/Ruins/empty_flagship.yml
+          - # /Maps/Ruins/empty_flagship.yml # starcup: far too big
           - /Maps/Ruins/old_ai_sat.yml
-          - /Maps/Ruins/ruined_prison_ship.yml
-          - /Maps/Ruins/syndicate_dropship.yml
-          - /Maps/Ruins/whiteship_ancient.yml
+          - # /Maps/Ruins/ruined_prison_ship.yml # starcup: needs rework
+          - # /Maps/Ruins/syndicate_dropship.yml # starcup: needs outer turrets removed
+          - # /Maps/Ruins/whiteship_ancient.yml # starcup: disable pending merge of rework PRs
           - /Maps/Ruins/whiteship_bluespacejumper.yml
-          - /Maps/Ruins/wrecklaimer.yml
+          - # /Maps/Ruins/wrecklaimer.yml #starcup: disable pending rework of minimum spawn distance
         vgroid: !type:DungeonSpawnGroup
           minimumDistance: 300
           maximumDistance: 350

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -61,17 +61,17 @@
           stationGrid: false
           paths:
           - /Maps/Ruins/abandoned_outpost.yml
-          - # /Maps/Ruins/chunked_tcomms.yml # starcup: needs rework
+         # - /Maps/Ruins/chunked_tcomms.yml # starcup: needs rework
           - /Maps/Ruins/biodome_satellite.yml
-          - # /Maps/Ruins/derelict.yml # starcup: disable pending merge of rework PRs
+         # - /Maps/Ruins/derelict.yml # starcup: disable pending merge of rework PRs
           - /Maps/Ruins/djstation.yml
-          - # /Maps/Ruins/empty_flagship.yml # starcup: far too big
+         # - /Maps/Ruins/empty_flagship.yml # starcup: far too big
           - /Maps/Ruins/old_ai_sat.yml
-          - # /Maps/Ruins/ruined_prison_ship.yml # starcup: needs rework
-          - # /Maps/Ruins/syndicate_dropship.yml # starcup: needs outer turrets removed
-          - # /Maps/Ruins/whiteship_ancient.yml # starcup: disable pending merge of rework PRs
+         # - /Maps/Ruins/ruined_prison_ship.yml # starcup: needs rework
+         # - /Maps/Ruins/syndicate_dropship.yml # starcup: needs outer turrets removed
+         # - /Maps/Ruins/whiteship_ancient.yml # starcup: disable pending merge of rework PRs
           - /Maps/Ruins/whiteship_bluespacejumper.yml
-          - # /Maps/Ruins/wrecklaimer.yml #starcup: disable pending rework of minimum spawn distance
+         # - /Maps/Ruins/wrecklaimer.yml #starcup: disable pending rework of minimum spawn distance
         vgroid: !type:DungeonSpawnGroup
           minimumDistance: 300
           maximumDistance: 350


### PR DESCRIPTION
Disabled various ruins in base.yml for balance/rework purposes

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Disabled spawning for the following ruins:
- chunked_tcomms
- derelict
- empty_flagship
- ruined_prison_ship
- syndicate_dropship
- whiteship_ancient
- wrecklaimer

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Many of these ruins are either too large, too empty, or too dangerous to keep around. The ruin syndicate_dropship in particular has a problem when spawned too close to the station due to its external turrets, which have caused issues on multiple shifts thus far.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: disabled spawning for multiple ruins