### PR TITLE
feat: drinkable sinks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -37,6 +37,8 @@
   - type: ReagentTank
   - type: Drain
     autoDrain: false
+  - type: Drink
+    solution: tank
   - type: DumpableSolution
     solution: drainBuffer
   - type: Damageable


### PR DESCRIPTION
Added the Drink component to sinks

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Sinks now have the Drink component, allowing you to drink from them without requiring you to transfer the water to a container first.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Sinks are flavored as having leaky faucets, implying that there is no manual interaction required to get water from them. Rather, they are constantly filling with water, and so should be treated as an open water source similar to buckets, beakers, and other containers. This also gives creatures without hands easier access to water, which is otherwise difficult to come by without aid from another player.

## Technical details
<!-- Summary of code changes for easier review. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- feat: gave sinks the Drink component