### PR TITLE
tweak: disabled some unknown shuttles

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -5,11 +5,11 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: UnknownShuttleCargoLost
-    - id: UnknownShuttleTravelingCuisine
+   # - id: UnknownShuttleTravelingCuisine #starcup: disabled
     - id: UnknownShuttleDisasterEvacPod
-    - id: UnknownShuttleHonki
-    - id: UnknownShuttleNTQuark
-    - id: UnknownShuttleCruiser
+   # - id: UnknownShuttleHonki # starcup: disabled pending rework of clown loot (and possible removal of honkbots)
+   # - id: UnknownShuttleNTQuark # starcup: great concept, but the time limit to detonation makes it less ideal for a random spawn
+   # - id: UnknownShuttleCruiser # starcup: shaped like a penis. come on, people.
     - id: UnknownShuttleCryptid
     - id: UnknownShuttleEternal
     - id: UnknownShuttleFlatline
@@ -18,8 +18,8 @@
     - id: UnknownShuttleJoe
     - id: UnknownShuttleLambordeere
     - id: UnknownShuttleMeatZone
-    - id: UnknownShuttleMicroshuttle
-    - id: UnknownShuttleSpacebus
+   # - id: UnknownShuttleMicroshuttle # starcup: disabled pending rework making it turn slower
+   # - id: UnknownShuttleSpacebus # starcup: disabled
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
@@ -31,9 +31,9 @@
   id: UnknownShuttlesHostileTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    - id: LoneOpsSpawn
+   # - id: LoneOpsSpawn # starcup: disabled to prevent undesired random loneop spawns
     - id: UnknownShuttleManOWar
-    - id: UnknownShuttleInstigator
+   # - id: UnknownShuttleInstigator # starcup: disabled for balance purposes
 
 # Shuttle Game Rules
 


### PR DESCRIPTION
Disabled a portion of the unknown shuttle spawns

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR disables some shuttles from being spawned as a result of the Unknown Shuttles event. The following shuttles were disabled:
- TravelingCuisine
- Honki
- NTQuark
- Cruiser
- Microshuttle
- Spacebus
- LoneOpsSpawn
- Instigator

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some shuttles need reworks, others don't fit the tone of the server, and some are more appropriate as telegraphed events than random spawns.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: disabled some unknown shuttles