### PR TITLE
fix: felinid stomach fixes

### DIFF
--- a/Resources/Prototypes/_DeltaV/Body/Prototypes/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Body/Prototypes/felinid.yml
@@ -20,7 +20,7 @@
       organs:
         heart: OrganAnimalHeart
         lungs: OrganHumanLungs
-        stomach: OrganReptilianStomach
+        stomach: OrganAnimalStomach # starcup
         liver:  OrganAnimalLiver
         kidneys: OrganHumanKidneys
     right arm:


### PR DESCRIPTION
felinids were given the reptilian stomach prototype for some reason?? so I changed it to the animal stomach, which should also fix the weird dietary restrictions they were dealing with

**Changelog**
:cl:
- fix: felinids will now be poisoned by theobromine as intended
- fix: felinids are no longer incapable of eating veggies and other such foods