### PR TITLE
fix: add missing carriable components

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/Oni.yml
@@ -30,6 +30,7 @@
 # begin starcup: added for parental change
   - type: Hunger
   - type: Thirst
+  - type: Carriable
 # end starcup
   - type: Damageable
     damageModifierSet: Oni

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/felinid.yml
@@ -29,6 +29,7 @@
 # begin starcup: added for parental change
   - type: Hunger
   - type: Thirst
+  - type: Carriable
 # end starcup
   - type: Damageable
     damageModifierSet: Felinid

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/harpy.yml
@@ -103,6 +103,7 @@
 # begin starcup: added for parental change
   - type: Hunger
   - type: Thirst
+  - type: Carriable
 # end starcup
   - type: Damageable
     damageModifierSet: Harpy

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -310,7 +310,7 @@
       priority: 1
       lightningExplode: false
     - type: ComplexInteraction
-    #- type: Carriable
+    - type: Carriable
     #- type: Targeting
     #- type: SurgeryTarget
     #- type: LayingDown


### PR DESCRIPTION
resolved another uncaught error as a result of the change in parent prototype for felinids, harpies, and oni. also uncommented the carriable component for mkcs now that it's no longer in conflict

**Changelog**
:cl:
- fix: felinids, harpies, oni, and mkc's can be carried
