### PR TITLE
tweak: adjusted some jobs' roundstart gear

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -16,7 +16,7 @@
     - id: HandheldGPSBasic
     - id: RadioHandheld
     - id: AppraisalTool
-    - id: MiniJetpackFilled
+    - id: MiniJetpackFilled # starcup: give salvage mini jetpacks at roundstart
     # - id: FireExtinguisher # starcup: replaced by MiniJetpackFilled
     - id: Flare
       prob: 0.3

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -16,7 +16,8 @@
     - id: HandheldGPSBasic
     - id: RadioHandheld
     - id: AppraisalTool
-    - id: FireExtinguisher
+    - id: MiniJetpackFilled
+    # - id: FireExtinguisher # starcup: replaced by MiniJetpackFilled
     - id: Flare
       prob: 0.3
       rolls: !type:ConstantNumberSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -16,8 +16,8 @@
     - id: HandheldGPSBasic
     - id: RadioHandheld
     - id: AppraisalTool
-    - id: MiniJetpackFilled # starcup: give salvage mini jetpacks at roundstart
-    # - id: FireExtinguisher # starcup: replaced by MiniJetpackFilled
+    - id: JetpackMiniFilled # starcup: give salvage mini jetpacks at roundstart
+    # - id: FireExtinguisher # starcup: replaced by JetpackMiniFilled
     - id: Flare
       prob: 0.3
       rolls: !type:ConstantNumberSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -91,6 +91,7 @@
       - id: ClothingMaskGasAtmos
       - id: ClothingOuterSuitAtmosFire
       - id: ClothingHeadHelmetAtmosFire
+      - id: ClothingHandsGlovesColorYellow # starcup: atmos techs should have insuls
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
@@ -107,6 +108,7 @@
       - id: ClothingMaskGasAtmos
       - id: ClothingOuterSuitAtmosFire
       - id: ClothingHeadHelmetAtmosFire
+      - id: ClothingHandsGlovesColorYellow # starcup: atmos techs should have insuls
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -125,7 +125,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
-        - id: ClothingShoesBootsMag
+        - id: ClothingShoesBootsMag # starcup: give atmos techs magboots
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
   - type: AccessReader

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -125,6 +125,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: ClothingShoesBootsMag
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -138,9 +139,9 @@
   components:
   - type: StorageFill
     contents:
-        - id: OxygenTankFilled
-        - id: ClothingOuterHardsuitSecurity
-        - id: ClothingMaskBreath
+      - id: OxygenTankFilled
+      - id: ClothingOuterHardsuitSecurity
+      - id: ClothingMaskBreath
   - type: AccessReader
     access: [["Security"]]
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -22,6 +22,7 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
+    JugWeldingFuel: 1 # starcup: don't force chemists to hunt maints for welding fuel
   contrabandInventory:
     DrinkLithiumFlask: 1
     StrangePill: 3


### PR DESCRIPTION
Changed starting items in some jobs' lockers and machines

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the following items to the following lockers / machines:
- Insulated Gloves -> Atmos Tech's locker
- Magboots -> Atmos Tech's suit storage locker
- Mini Jetpack -> Salvage Specialist's locker
- Jug (Welding Fuel) -> ChemVend

Removed the following item from the following locker:
- Fire Extinguisher -> Salvage Specialist's locker

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Atmos Techs should have insuls and magboots. Salvage is a painful experience at roundstart without propulsion. Chemists need welding fuel, and maps typically don't provide it to them. None of these roles are made more engaging by lacking this equipment.

Fire extinguishers were removed from the Salvage Specialist's locker as they were intended to be a pre-jetpack method of propulsion, and thus are no longer needed.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: added insulated gloves to atmos tech lockers
- tweak: added magboots to atmos tech suit storage lockers
- tweak: added mini jetpacks to salvage specialists lockers
- tweak: removed fire extinguishers from salvage specialist lockers
- tweak: added a welding fuel jug to chemvends