### PR TITLE
tweak: meteor event minimum player increase

### DIFF
--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -70,7 +70,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 600 # 10 min 
+    minimumTimeUntilFirstEvent: 600 # 10 min
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min
@@ -107,7 +107,7 @@
   - type: StationEvent
     weight: 44
     earliestStart: 2
-    minimumPlayers: 0
+    minimumPlayers: 10
   - type: MeteorSwarm
     announcement: null
     announcementSound: null
@@ -127,7 +127,7 @@
   components:
   - type: StationEvent
     weight: 22
-    minimumPlayers: 0
+    minimumPlayers: 10
   - type: MeteorSwarm
     announcement: station-event-space-dust-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -107,7 +107,7 @@
   - type: StationEvent
     weight: 44
     earliestStart: 2
-    minimumPlayers: 10
+    minimumPlayers: 10 # starcup: increased from 0 -> 10
   - type: MeteorSwarm
     announcement: null
     announcementSound: null
@@ -127,7 +127,7 @@
   components:
   - type: StationEvent
     weight: 22
-    minimumPlayers: 10
+    minimumPlayers: 10 # starcup: increased from 0 -> 10
   - type: MeteorSwarm
     announcement: station-event-space-dust-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
minimumPlayers for the Minor and Major Space Dust events have been increased from 0 -> 10.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Low player counts have difficulties dealing with the amount of damage dealt by Space Dust meteor events. Increasing their minimum player requirements up to 10 will hopefully help ensure that at least one engineer (if not two) are on board to address the damage they cause.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: increased the minimum player requirements for space dust events