### PR TITLE
tweak: ramping event scheduler adjustments

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -10,14 +10,14 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     ///     Max chaos chosen for a round will deviate from this
     /// </summary>
     [DataField]
-    public float AverageChaos = 12f;
+    public float AverageChaos = 4.5f; /// starcup: 12 -> 4.5
 
     /// <summary>
     ///     Average time (in minutes) for when the ramping event scheduler should stop increasing the chaos modifier.
     ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     [DataField]
-    public float AverageEndTime = 90f;
+    public float AverageEndTime = 150f; /// starcup: 90 -> 150
 
     [DataField]
     public float EndTime;

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -30,9 +30,18 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
 
         // Worlds shittiest probability distribution
         // Got a complaint? Send them to
-        component.MaxChaos = _random.NextFloat(component.AverageChaos - component.AverageChaos / 4, component.AverageChaos + component.AverageChaos / 4);
+        // Begin starcup changes
+        // component.MaxChaos = _random.NextFloat(component.AverageChaos - component.AverageChaos / 4, component.AverageChaos + component.AverageChaos / 4);
         // This is in minutes, so *60 for seconds (for the chaos calc)
-        component.EndTime = _random.NextFloat(component.AverageEndTime - component.AverageEndTime / 4, component.AverageEndTime + component.AverageEndTime / 4) * 60f;
+        // component.EndTime = _random.NextFloat(component.AverageEndTime - component.AverageEndTime / 4, component.AverageEndTime + component.AverageEndTime / 4) * 60f;
+        // starcup: Removed and replaced with simplified formulas
+
+        component.MaxChaos = _random.NextFloat(component.AverageChaos * 0.9f, component.AverageChaos * 1.25f);
+        // starcup: 0.75 -> 0.9. Ensures that MaxChaos is always at least 4.0 to prevent rounds from being too slow-paced.
+        component.EndTime = _random.NextFloat(component.AverageEndTime * 0.75f, component.AverageEndTime) * 60f;
+        // starcup: component.AverageEndTime * 1.25 -> component.AverageEndTime. Ensures that EndTime will never be longer than our AverageEndTime of 150 minutes.
+        // End starcup changes
+
         component.StartingChaos = component.MaxChaos / 10;
 
         PickNextEventTime(uid, component);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes variables and formulas found in the RampingStationEventScheduler used by Survival to reduce the rate of events to a level more appropriate for our server. Additionally, the formulas for MaxChaos and EndTime were simplified for readability.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Upstream's default settings for Survival are designed for a chaotic server with an average round time of 90 minutes. Our server favors a more slow-paced approach and longer round times, and these changes seek to strike a balance that fits those goals while still putting pressure on the players to adapt and handle an ever-escalating pace of events.

## Technical details
<!-- Summary of code changes for easier review. -->
MaxChaos and EndTime formulas were both changed from an x - x/4 and x + x/4 format to equivalent percentage multipliers (x * 0.75 and x * 1.25 respectively) to simplify the formulas, improve readability, and make adjustments simpler in the future.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Survival: AverageChaos decreased from 12 -> 4.5
- tweak: Survival: AverageEndTime increased from 90 -> 150
- tweak: Survival: MaxChaos and EndTime formulas simplified for readability
- tweak: Survival: MaxChaos range tightened to remove low-intensity rounds
- tweak: Survival: EndTime range tightened to prevent slow-scaling rounds