### PR TITLE
feat: add janitor loadout option for flashlights/lanterns

### DIFF
--- a/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
@@ -1,0 +1,1 @@
+loadout-group-janitor-light = Janitor flashlight

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -82,7 +82,7 @@
       - id: SprayBottleSpaceCleaner
       - id: CleanerGrenade
         amount: 2
-      - id: FlashlightLantern
+ #     - id: FlashlightLantern # starcup: removed for redundancy with new flashlight/lantern loadout options.
       - id: LightReplacer
 
 - type: entity

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -138,6 +138,7 @@
   - JanitorGloves
   - CommonBackpack
   - JanitorOuterClothing
+  - JanitorLight # starcup: adds a choice between flashlights/lanterns. who goers there
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/janitor.yml
@@ -1,0 +1,10 @@
+# Janitor flashlight
+- type: loadout
+  id: JanitorFlashlight
+  equipment:
+    pocket1: FlashlightLantern
+
+- type: loadout
+  id: JanitorLantern
+  equipment:
+    pocket1: Lantern

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/janitor.yml
@@ -7,4 +7,4 @@
 - type: loadout
   id: JanitorLantern
   equipment:
-    pocket1: Lantern
+    pocket1: Lantern # They're in the pocket because the filled Janitor belt wasn't cooperating w/loadout.

--- a/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
@@ -1,0 +1,7 @@
+- type: loadoutGroup
+  id: JanitorLight
+  name: loadout-group-janitor-light
+  minLimit: 0
+  loadouts:
+  - JanitorFlashlight
+  - JanitorLantern


### PR DESCRIPTION
## About the PR
Removes flashlights from the Janitor's filled belt and added a Loadout tab for them to choose between a flashlight and a lantern.

Notably, it is now possible to create a janitor without any flashlight. Set the loadout group's minimum to 1 if you wanna change that.

## Why / Balance
Lanterns are very useful and some may prefer their more even light spread over the flashlight's longer-range and facing-dependent conical beam. Also, lanterns are cool!

## Technical details
**Changelog**
:cl:
- add: Gave Janitors the option of a lantern or flashlight in Loadouts.
- tweak: lantern/flashlight will appear in Pocket1 rather than the Janitor Belt.