### PR TITLE
tweak: added spare IDs to department head lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -329,7 +329,7 @@
     - id: ClothingShoesBootsJack
     - id: DoorRemoteSecurity
     - id: HoloprojectorSecurity
-    - id: HoSIDCard
+    - id: HoSIDCard # starcup: added spare ID
     - id: RubberStampHos
     - id: SecurityTechFabCircuitboard
     - id: WeaponDisabler

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -14,7 +14,7 @@
       prob: 0.50
     - id: ClothingHeadsetAltCargo
     - id: DoorRemoteCargo
-    - id: QuartermasterIDCard
+    - id: QuartermasterIDCard # starcup: added spare ID
     - id: RubberStampApproved
     - id: RubberStampDenied
     - id: RubberStampQm
@@ -153,7 +153,7 @@
     children:
     - id: AccessConfigurator
     - id: BoxEncryptionKeyEngineering
-    - id: CEIDCard
+    - id: CEIDCard # starcup: added spare ID
     - id: CigarCase
       prob: 0.15
     - id: ClothingBeltChiefEngineerFilled
@@ -215,7 +215,7 @@
     - id: ClothingHeadHatBeretCmo
     - id: ClothingHeadsetAltMedical
     - id: ClothingMaskSterile
-    - id: CMOIDCard
+    - id: CMOIDCard # starcup: added spare ID
     - id: DoorRemoteMedical
     - id: HandheldCrewMonitor
     - id: Hypospray
@@ -272,7 +272,7 @@
     - id: DoorRemoteResearch
     - id: HandTeleporter
     - id: ProtolatheMachineCircuitboard
-    - id: RDIDCard
+    - id: RDIDCard # starcup: added spare ID
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -14,6 +14,7 @@
       prob: 0.50
     - id: ClothingHeadsetAltCargo
     - id: DoorRemoteCargo
+    - id: QuartermasterIDCard
     - id: RubberStampApproved
     - id: RubberStampDenied
     - id: RubberStampQm
@@ -152,6 +153,7 @@
     children:
     - id: AccessConfigurator
     - id: BoxEncryptionKeyEngineering
+    - id: CEIDCard
     - id: CigarCase
       prob: 0.15
     - id: ClothingBeltChiefEngineerFilled
@@ -213,6 +215,7 @@
     - id: ClothingHeadHatBeretCmo
     - id: ClothingHeadsetAltMedical
     - id: ClothingMaskSterile
+    - id: CMOIDCard
     - id: DoorRemoteMedical
     - id: HandheldCrewMonitor
     - id: Hypospray
@@ -269,6 +272,7 @@
     - id: DoorRemoteResearch
     - id: HandTeleporter
     - id: ProtolatheMachineCircuitboard
+    - id: RDIDCard
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
 
@@ -325,6 +329,7 @@
     - id: ClothingShoesBootsJack
     - id: DoorRemoteSecurity
     - id: HoloprojectorSecurity
+    - id: HoSIDCard
     - id: RubberStampHos
     - id: SecurityTechFabCircuitboard
     - id: WeaponDisabler


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Chief Engineer, Head of Security, Quartermaster, and Research Director will now have spare IDs in their lockers.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously, only the Captain and Head of Personnel had spare IDs in their lockers. This change makes promotions and theft-induced ID replacements less time-consuming and gives antagonists another potential route to gain departmental access.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: added spare IDs to department head lockers