### PR TITLE
tweak: added jetpacks to sec suit storage units

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -140,6 +140,7 @@
   - type: StorageFill
     contents:
       - id: OxygenTankFilled
+      - id: JetpackSecurityFilled # starcup: give sec jetpacks
       - id: ClothingOuterHardsuitSecurity
       - id: ClothingMaskBreath
   - type: AccessReader


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the security jetpack to security suit storage units

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Without jetpacks, Security is dead in the water out in space. Giving them mobility outside the station enables them to perform search-and-rescue operations, pursue antagonists into space, and search for contraband and threats in unconventional locations if necessary. This also saves Cargo the trouble of ordering multiple jetpack crates per shift.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: added security jetpacks to sec suit storage units