### PR TITLE
tweak: swapped janibelt's soap for trashbag

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -78,12 +78,13 @@
   components:
   - type: StorageFill
     contents:
-      - id: Soap #Make a soap group and pick between when i'm not lazy
+ #     - id: Soap #Make a soap group and pick between when i'm not lazy # starcup: removed this because soap isn't really needed to start with.
       - id: SprayBottleSpaceCleaner
       - id: CleanerGrenade
         amount: 2
       - id: FlashlightLantern
       - id: LightReplacer
+      - id: TrashBag # starcup: picking up trash is basically the first thing a janitor does at shift start
 
 - type: entity
   id: ClothingBeltMedicalFilled


### PR DESCRIPTION
## About the PR
Janitors' belt will now spawn with a trashbag rather than a bar of soap.

## Why / Balance
Janitors don't really use soap often, especially in early game, while the trashbag is a critical tool they can start using from the moment they spawn in Arrivals.

**Changelog**
:cl:
- tweak: removed Soap from ClothingBeltJanitorFilled
- tweak: added Trashbag to ClothingBeltJanitorFilled