### PR TITLE
tweak: added space medipens to survival boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -10,6 +10,7 @@
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # starcup: added to help players survive spacings
       - id: Flare
       - id: FoodPSB # DeltaV - replace nutribrick with PSB
       - id: DrinkWaterBottleFull


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a space medipen to the survival box contents.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Players didn't have a way to respond to unexpected spacings, which could lead to a swift death if they got caught. This gives them a single-use medipen that will at least give them time to get out a warning or attempt to get back into a pressurized area.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: added space medipens to survival boxes