### PR TITLE
tweak: engineering goggles now give +70% vision correction

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -65,6 +65,8 @@
   - type: EyeProtection
   - type: IdentityBlocker
     coverage: EYES
+  - type: VisionCorrection  # starcup: engineering goggles correct for short-sightedness (with slight nerf, default 2.0)
+    correctionPower: 1.7
 
 - type: entity
   parent: ClothingEyesBase


### PR DESCRIPTION
engineers with the short-sighted trait no longer have to switch between glasses as often

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
 - tweak: engineering goggles now give +70% vision correction