### PR TITLE
Tweak: add loadout scarves and trinkets

### DIFF
--- a/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
@@ -11,22 +11,6 @@ loadout-group-mime-neck = Mime neck
 
 loadout-group-musician-neck = Musician neck
 
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
-loadout-group-botanist-neck
-
 # Command
 loadout-group-admin-assistant-head = Administrative Assistant head
 loadout-group-admin-assistant-jumpsuit = Administrative Assistant jumpsuit

--- a/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
@@ -36,6 +36,8 @@ loadout-group-cargo-assistant-shoes = Cargo Assistant shoes
 
 loadout-group-salvage-specialist-neck = Salvage Specialist neck
 
+loadout-group-cargo-technician-neck = Cargo Technician neck
+
 # Security
 loadout-group-security-cadet-head = Security Cadet head
 

--- a/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
@@ -1,3 +1,32 @@
+# Service
+loadout-group-bartender-neck = Bartender neck
+
+loadout-group-librarian-neck = Librarian neck
+
+loadout-group-janitor-neck = Janitor neck
+
+loadout-group-botanist-neck = Botanist neck
+
+loadout-group-mime-neck = Mime neck
+
+loadout-group-musician-neck = Musician neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
+loadout-group-botanist-neck
+
 # Command
 loadout-group-admin-assistant-head = Administrative Assistant head
 loadout-group-admin-assistant-jumpsuit = Administrative Assistant jumpsuit
@@ -15,10 +44,32 @@ loadout-group-courier-backpack = Courier backpack
 loadout-group-courier-id = Courier PDA
 
 loadout-group-cargo-assistant-head = Cargo Assistant head
+loadout-group-cargo-assistant-neck = Cargo Assistant neck
 loadout-group-cargo-assistant-jumpsuit = Cargo Assistant jumpsuit
 loadout-group-cargo-assistant-backpack = Cargo Assistant backpack
 loadout-group-cargo-assistant-outerclothing = Cargo Assistant outer clothing
 loadout-group-cargo-assistant-shoes = Cargo Assistant shoes
 
+loadout-group-salvage-specialist-neck = Salvage Specialist neck
+
+# Security
+loadout-group-security-cadet-head = Security Cadet head
+
+loadout-group-security-neck = Security neck
+
+loadout-group-medical-doctor-neck = Medical Doctor neck
+
+loadout-group-chemist-neck = Chemist neck
+
+# Engineering
+loadout-group-station-engineer-neck = Station Engineer neck
+
+loadout-group-atmospheric-technician-neck = Atmospheric Technician neck
+
+
+
 # Species
 loadout-group-humanoid-silicon = Silicon-friendly survival box
+
+# Scarfs
+loadout-group-scarfs = Scarves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -51,6 +51,9 @@
   - TowelColorWhite
   - TowelColorYellow
   - AACTablet # DeltaV
+  - GoldRing # DeltaV
+  - SilverRing # DeltaV
+  - HandheldStationMap # starcup
   - Cane # DeltaV
   - WhiteCane #DeltaV
 
@@ -1340,6 +1343,7 @@
   - YellowBoxingGloves
 
 # Other
+
 - type: loadoutGroup
   id: SurvivalSyndicate
   name: loadout-group-survival-syndicate

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -40,6 +40,7 @@
 - type: roleLoadout
   id: JobPassenger
   groups:
+  - Scarfs # DeltaV
   - GroupTankHarness
   - PassengerJumpsuit
   - CommonBackpack
@@ -58,6 +59,7 @@
   groups:
   - GroupTankHarness
   - BartenderHead
+  - BartenderNeck # DeltaV
   - BartenderJumpsuit
   - CommonBackpack
   - BartenderOuterClothing
@@ -69,6 +71,7 @@
 - type: roleLoadout
   id: JobServiceWorker
   groups:
+  - Scarfs # DeltaV
   - GroupTankHarness
   - BartenderJumpsuit
   - CommonBackpack
@@ -94,6 +97,7 @@
 - type: roleLoadout
   id: JobLibrarian
   groups:
+  - LibrarianNeck # DeltaV
   - GroupTankHarness
   - LibrarianJumpsuit
   - CommonBackpack
@@ -134,6 +138,7 @@
   groups:
   - GroupTankHarness
   - JanitorHead
+  - JanitorNeck # DeltaV
   - JanitorJumpsuit
   - JanitorGloves
   - CommonBackpack
@@ -149,6 +154,7 @@
   groups:
   - GroupTankHarness
   - BotanistHead
+  - BotanistNeck # DeltaV
   - BotanistJumpsuit
   - BotanistBackpack
   - BotanistOuterClothing
@@ -162,6 +168,7 @@
   groups:
   - GroupTankHarness
   - ClownHead
+  - Scarfs # DeltaV
   - ClownJumpsuit
   - ClownBackpack
   - ClownOuterClothing
@@ -176,6 +183,7 @@
   - GroupTankHarness
   - MimeHead
   - MimeMask
+  - MimeNeck # DeltaV
   - MimeJumpsuit
   - MimeBackpack
   - MimeOuterClothing
@@ -218,6 +226,7 @@
   groups:
   - GroupTankHarness
   - CargoTechnicianHead
+  - CargoTechnicianNeck # DeltaV
   - CargoTechnicianJumpsuit
   - CargoTechnicianBackpack
   - CargoTechnicianOuterClothing
@@ -231,6 +240,7 @@
   id: JobSalvageSpecialist
   groups:
   - GroupTankHarness
+  - SalvageSpecialistNeck # DeltaV
   - SalvageSpecialistBackpack
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
@@ -269,6 +279,7 @@
   groups:
   - GroupTankHarness
   - StationEngineerHead
+  - StationEngineerNeck # DeltaV
   - StationEngineerJumpsuit
   - StationEngineerBackpack
   - StationEngineerOuterClothing
@@ -282,6 +293,7 @@
   id: JobAtmosphericTechnician
   groups:
   - GroupTankHarness
+  - AtmosphericTechnicianNeck # DeltaV
   - AtmosphericTechnicianJumpsuit
   - AtmosphericTechnicianBackpack
   - AtmosphericTechnicianOuterClothing
@@ -355,6 +367,7 @@
   id: JobWarden
   groups:
   - WardenHead
+  - SecurityNeck # DeltaV
   - WardenJumpsuit
   - SecurityBackpack
   - SecurityBelt
@@ -369,6 +382,7 @@
   id: JobSecurityOfficer
   groups:
   - SecurityHead
+  - SecurityNeck # DeltaV
   - SecurityJumpsuit
   - SecurityBackpack
   - SecurityOuterClothing
@@ -384,7 +398,8 @@
   id: JobDetective
   groups:
   - DetectiveHead
-  - DetectiveNeck
+# - DetectiveNeck
+  - SecurityNeck # DeltaV - replace DetectiveNeck for incongruence
   - DetectiveJumpsuit
   - SecurityBackpack
   - DetectiveOuterClothing
@@ -397,6 +412,8 @@
 - type: roleLoadout
   id: JobSecurityCadet
   groups:
+  - SecurityCadetHead # DeltaV
+  - SecurityNeck # DeltaV
   - SecurityCadetJumpsuit
   - SecurityBackpack
   - SurvivalSecurity
@@ -426,6 +443,7 @@
   groups:
   - GroupTankHarness
   - MedicalDoctorHead
+  - MedicalDoctorNeck # DeltaV
   - MedicalMask
   - MedicalDoctorJumpsuit
   - MedicalGloves
@@ -453,6 +471,7 @@
   id: JobChemist
   groups:
   - GroupTankHarness
+  - ChemistNeck # DeltaV
   - MedicalMask
   - ChemistJumpsuit
   - MedicalGloves
@@ -469,6 +488,7 @@
   - GroupTankHarness
   - ParamedicHead
   - MedicalMask
+  - MedicalDoctorNeck # DeltaV
   - ParamedicJumpsuit
   - MedicalGloves
   - MedicalBackpack
@@ -504,6 +524,7 @@
 - type: roleLoadout
   id: JobPsychologist
   groups:
+  - Scarfs # DeltaV
   - GroupTankHarness
   - PsychologistJumpsuit
   - MedicalBackpack

--- a/Resources/Prototypes/_DeltaV/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/Jobs/Medical/chemist.yml
@@ -1,5 +1,0 @@
-# Neck
-- type: loadout
-  id: ChemistTie
-  equipment:
-    neck: ClothingNeckTieChem

--- a/Resources/Prototypes/_DeltaV/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/Jobs/Medical/chemist.yml
@@ -1,0 +1,5 @@
+# Neck
+- type: loadout
+  id: ChemistTie
+  equipment:
+    neck: ClothingNeckTieChem

--- a/Resources/Prototypes/_DeltaV/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -1,0 +1,5 @@
+# Neck
+- type: loadout
+  id: Stethoscope
+  equipment:
+    neck: ClothingNeckStethoscope

--- a/Resources/Prototypes/_DeltaV/Loadouts/Miscellaneous/scarfs.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/Miscellaneous/scarfs.yml
@@ -1,0 +1,110 @@
+# Neck
+#Red
+- type: loadout
+  id: ScarfRed
+  equipment:
+    neck: ClothingNeckScarfStripedRed
+
+#Blue
+- type: loadout
+  id: ScarfBlue
+  equipment:
+    neck: ClothingNeckScarfStripedBlue
+
+#LightBlue
+- type: loadout
+  id: ScarfLightBlue
+  equipment:
+    neck: ClothingNeckScarfStripedLightBlue
+
+#Green
+- type: loadout
+  id: ScarfGreen
+  equipment:
+    neck: ClothingNeckScarfStripedGreen
+
+#Purple
+- type: loadout
+  id: ScarfPurple
+  equipment:
+    neck: ClothingNeckScarfStripedPurple
+
+#Brown
+- type: loadout
+  id: ScarfBrown
+  equipment:
+    neck: ClothingNeckScarfStripedBrown
+
+#Orange
+- type: loadout
+  id: ScarfOrange
+  equipment:
+    neck: ClothingNeckScarfStripedOrange
+
+#Black
+- type: loadout
+  id: ScarfBlack
+  equipment:
+    neck: ClothingNeckScarfStripedBlack
+
+#Zebra
+- type: loadout
+  id: ScarfZebra
+  equipment:
+    neck: ClothingNeckScarfStripedZebra
+
+#SyndieGreen
+- type: loadout
+  id: ScarfSyndieGreen # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedSyndieGreen
+
+#SyndieRed
+- type: loadout
+  id: ScarfSyndieRed # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedSyndieRed
+
+#Ace
+- type: loadout
+  id: ScarfAce # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedAce
+
+#Bi
+- type: loadout
+  id: ScarfBi # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedBiSexual
+
+#Lesbian
+- type: loadout
+  id: ScarfLesbian # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedLesbian
+
+#Pan
+- type: loadout
+  id: ScarfPan # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedPan
+
+#Nonbinary
+- type: loadout
+  id: ScarfNonbinary # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedNonBinary
+
+#Rainbow
+- type: loadout
+  id: ScarfRainbow # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedRainbow
+
+#Trans
+- type: loadout
+  id: ScarfTrans # starcup
+  equipment:
+    neck: ClothingNeckScarfStripedTrans
+
+# no real need to stop at these pride flags, I just arbitrarily kept the list narrow.

--- a/Resources/Prototypes/_DeltaV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/Miscellaneous/trinkets.yml
@@ -5,6 +5,18 @@
     - AACTablet
 
 - type: loadout
+  id: GoldRing
+  storage:
+    back:
+    - GoldRing
+
+- type: loadout
+  id: SilverRing
+  storage:
+    back:
+    - SilverRing
+
+- type: loadout
   id: Cane
   storage:
     back:

--- a/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
@@ -1,3 +1,69 @@
+## Bartender
+- type: loadoutGroup
+  id: BartenderNeck
+  name: loadout-group-bartender-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBlack
+  - ScarfPurple
+  - ScarfNonbinary #starcup
+  - ScarfRainbow #starcup
+
+## Librarian
+- type: loadoutGroup
+  id: LibrarianNeck
+  name: loadout-group-librarian-neck
+  minLimit: 0
+  loadouts:
+  - ScarfGreen
+  - ScarfRed
+  - ScarfLesbian #starcup
+  - ScarfNonbinary #starcup
+
+## Janitor
+- type: loadoutGroup
+  id: JanitorNeck
+  name: loadout-group-janitor-neck
+  minLimit: 0
+  loadouts:
+  - ScarfPurple
+  - ScarfAce #starcup
+  - ScarfNonbinary #starcup
+
+## Botanist
+- type: loadoutGroup
+  id: BotanistNeck
+  name: loadout-group-botanist-neck
+  minLimit: 0
+  loadouts:
+  - ScarfGreen
+  - ScarfBrown
+  - ScarfSyndieGreen #starcup
+
+## Mime
+- type: loadoutGroup
+  id: MimeNeck
+  name: loadout-group-mime-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBlack
+  - ScarfZebra
+  - ScarfAce # starcup
+
+## Musician
+- type: loadoutGroup
+  id: MusicianNeck
+  name: loadout-group-musician-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBlack
+  - ScarfPurple
+  - ScarfZebra
+  - ScarfTrans # starcup
+  - ScarfNonbinary #starcup
+  - ScarfRainbow #starcup
+  - ScarfLesbian #starcup
+
 # Logistics
 ## Courier
 - type: loadoutGroup
@@ -9,13 +75,14 @@
   - MailCarrierHead
 
 # starcup - commenting out for now
-#- type: loadoutGroup
-#  id: CourierNeck
-#  name: loadout-group-courier-neck
-#  minLimit: 0
-#  loadouts:
-#  - ScarfBrown
-#  - ScarfBlue
+# also starcup - adding back in, it's scarf time baby!!
+- type: loadoutGroup
+  id: CourierNeck
+  name: loadout-group-courier-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBrown
+  - ScarfBlue
 
 - type: loadoutGroup
   id: CourierJumpsuit
@@ -41,6 +108,14 @@
   - CargoTechnicianBackpack
   - CargoTechnicianSatchel
   - CargoTechnicianDuffel
+
+  ## Cargo Technician
+- type: loadoutGroup
+  id: CargoTechnicianNeck
+  name: loadout-group-cargo-technician-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBrown
 
 - type: loadoutGroup
   id: CourierShoes
@@ -94,6 +169,16 @@
   - BlackShoes
   - CargoWinterBoots
 
+## Salvage Specialist
+- type: loadoutGroup
+  id: SalvageSpecialistNeck
+  name: loadout-group-salvage-specialist-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBrown
+  - ScarfLesbian # starcup
+  - ScarfBisexual # starcup - it's the axes is the thing
+
 # Command
 ## Administrative Assistant
 - type: loadoutGroup
@@ -125,6 +210,95 @@
   loadouts:
   - HoPGloves
   - InspectionGloves
+
+# Security
+## Security Cadet
+- type: loadoutGroup
+  id: SecurityCadetHead
+  name: loadout-group-security-cadet-head
+  minLimit: 0
+  loadouts:
+  - MimeFrenchBeret
+  - SecurityHelmet # starcup
+
+## Security Officer
+- type: loadoutGroup
+  id: SecurityNeck
+  name: loadout-group-security-neck
+  minLimit: 0
+  loadouts:
+  - ScarfRed
+  - ScarfSyndieRed # starcup
+
+# Medical
+## Medical Doctor
+- type: loadoutGroup
+  id: MedicalDoctorNeck
+  name: loadout-group-medical-doctor-neck
+  minLimit: 0
+  loadouts:
+  - Stethoscope
+  - ScarfBlue
+  - ScarfPan #starcup
+  - ScarfTrans #starcup
+
+## Chemist
+- type: loadoutGroup
+  id: ChemistNeck
+  name: loadout-group-chemist-neck
+  minLimit: 0
+  loadouts:
+  - ChemistTie
+  - ScarfOrange
+  - ScarfTrans # starcup
+  - ScarfBlue
+
+# Engineering
+## Station Engineer
+- type: loadoutGroup
+  id: StationEngineerNeck
+  name: loadout-group-station-engineer-neck
+  minLimit: 0
+  loadouts:
+  - ScarfOrange
+  - ScarfLesbian #starcup
+
+## Atmospheric Technician
+- type: loadoutGroup
+  id: AtmosphericTechnicianNeck
+  name: loadout-group-atmospheric-technician-neck
+  minLimit: 0
+  loadouts:
+  - ScarfLightBlue
+  - ScarfOrange
+  - ScarfLesbian #starcup
+  - ScarfRainbow # starcup - I'm sure at this point you understand I won't be justifying any of these assignments
+
+# Misc
+## DeltaV
+- type: loadoutGroup
+  id: Scarfs
+  name: loadout-group-scarfs
+  minLimit: 0
+  loadouts:
+  - ScarfRed
+  - ScarfBlue
+  - ScarfLightBlue
+  - ScarfGreen
+  - ScarfPurple
+  - ScarfBrown
+  - ScarfOrange
+  - ScarfBlack
+  - ScarfZebra
+  - ScarfSyndieRed #starcup
+  - ScarfSyndieGreen #starcup
+  - ScarfAce # starcup
+  - ScarfBiSexual # starcup
+  - ScarfLesbian # starcup
+  - ScarfPan # starcup
+  - ScarfNonbinary # starcup
+  - ScarfRainbow # starcup
+  - ScarfTrans # scarfcup - why not take some pride in our beautiful loadout display?
 
 # Species
 - type: loadoutGroup

--- a/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
@@ -74,8 +74,6 @@
   - CourierHead
   - MailCarrierHead
 
-# starcup - commenting out for now
-# also starcup - adding back in, it's scarf time baby!!
 - type: loadoutGroup
   id: CourierNeck
   name: loadout-group-courier-neck

--- a/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
@@ -248,7 +248,6 @@
   name: loadout-group-chemist-neck
   minLimit: 0
   loadouts:
-  - ChemistTie
   - ScarfOrange
   - ScarfTrans # starcup
   - ScarfBlue

--- a/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
@@ -177,7 +177,7 @@
   loadouts:
   - ScarfBrown
   - ScarfLesbian # starcup
-  - ScarfBisexual # starcup - it's the axes is the thing
+  - ScarfBi # starcup - it's the axes is the thing
 
 # Command
 ## Administrative Assistant
@@ -293,7 +293,7 @@
   - ScarfSyndieRed #starcup
   - ScarfSyndieGreen #starcup
   - ScarfAce # starcup
-  - ScarfBiSexual # starcup
+  - ScarfBi # starcup
   - ScarfLesbian # starcup
   - ScarfPan # starcup
   - ScarfNonbinary # starcup

--- a/Resources/Prototypes/_DeltaV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/role_loadouts.yml
@@ -4,7 +4,7 @@
   groups:
   - GroupTankHarness
   - CourierHead
-#  - CourierNeck # starcup - commented out for now
+  - CourierNeck # starcup - commented out for now # and then commented back in >:)
   - CourierJumpsuit
   - CourierOuterClothing
   - CourierPDA

--- a/Resources/Prototypes/_DeltaV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/role_loadouts.yml
@@ -4,7 +4,7 @@
   groups:
   - GroupTankHarness
   - CourierHead
-  - CourierNeck # starcup - commented out for now # and then commented back in >:)
+  - CourierNeck
   - CourierJumpsuit
   - CourierOuterClothing
   - CourierPDA

--- a/Resources/Prototypes/_starcup/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Miscellaneous/trinkets.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: HandheldStationMap
+  storage:
+    back:
+    - HandheldStationMap


### PR DESCRIPTION
## About the PR
I ported over Delta-V's scarf loadouts for various jobs, as well as their gold and silver ring trinkets. I also added the handheld station map to trinkets and added a bunch of pride/syndie scarves to those loadouts.

## Why / Balance
The scarves and rings enhance player customization, and the map greatly improves accessibility for new players, blind characters, and anyone on an unfamiliar map.

## Technical details

**Changelog**
:cl:
- Tweak: Scarves can be selected for most job loadouts including lots of pride/syndie flags.
- Tweak: Added silver gold ring trinkets and a handheld station map trinket.
- Tweak: Security Cadets can now choose between a mime beret and a basic helmet.
