### PR TITLE
tweak: basic calm and antag event rebalancing

### DIFF
--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -43,5 +43,5 @@ public sealed partial class GasLeakRuleComponent : Component
 
     public int MinimumGas = 1000;
     public int MaximumGas = 4000;
-    public float SparkChance = 0.05f;
+    public float SparkChance = 0.00f; // starcup: 0.05f -> 0.00f, removed to prevent random plasma/trit fires and spark-related deaths
 }

--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -15,7 +15,8 @@ public sealed partial class VentClogRuleComponent : Component
     [DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<ReagentPrototype>))]
     public IReadOnlyList<string> SafeishVentChemicals = new[]
     {
-        "Water", "Blood", "Slime", "SpaceDrugs", "SpaceCleaner", "Nutriment", "Sugar", "SpaceLube", "Ephedrine", "Ale", "Beer", "SpaceGlue"
+        "Water", "Blood", "Slime", "SpaceDrugs", "SpaceCleaner", "Nutriment", "Sugar", "SpaceLube", "Ale", "Beer", "SpaceGlue"
+        // starcup: removed "Ephedrine" from the list.
     };
 
     /// <summary>

--- a/Content.Server/StationEvents/Events/GasLeakRule.cs
+++ b/Content.Server/StationEvents/Events/GasLeakRule.cs
@@ -70,7 +70,7 @@ namespace Content.Server.StationEvents.Events
 
         private void Spark(EntityUid uid, GasLeakRuleComponent component)
         {
-            if (RobustRandom.NextFloat() <= component.SparkChance)
+            if (RobustRandom.NextFloat() <= component.SparkChance) // # starcup: this chance was effectively removed in GasLeakRuleComponents.cs for balance
             {
                 if (!component.FoundTile ||
                     component.TargetGrid == default ||

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -14,7 +14,7 @@
     - id: IonStorm # its calm like 90% of the time smh
     - id: KudzuGrowth
     - id: MassHallucinations
-    - id: MimicVendorRule
+   # - id: MimicVendorRule # starcup: disabled
     - id: MouseMigration
     - id: PowerGridCheck
     - id: RandomSentience
@@ -35,11 +35,11 @@
     - id: NinjaSpawn
     - id: ParadoxCloneSpawn
     - id: RevenantSpawn
-    - id: SleeperAgents
+    - id: SleeperAgents # starcup: will be removing from extended / survival at a later date
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn
-    - id: WizardSpawn
+   # - id: WizardSpawn # starcup: disabled pending quality control
 
 - type: entity
   id: BaseStationEvent
@@ -80,6 +80,7 @@
     startAudio:
       path: /Audio/Announcements/announce.ogg
     weight: 8
+    reoccurrenceDelay: 5 # starcup: prevents anomaly event spamming on lowpop survival
     duration: 35
   - type: AnomalySpawnRule
 
@@ -105,7 +106,7 @@
   components:
   - type: StationEvent
     weight: 2
-    reoccurrenceDelay: 5
+    reoccurrenceDelay: 15 # starcup: 5 -> 15 to prevent lowpop survival spam
     earliestStart: 1
     duration: 1
   - type: BluespaceLockerRule
@@ -127,7 +128,7 @@
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
     minimumPlayers: 25
-    weight: 3
+    weight: 5 # starcup: 3 -> 5
     duration: 1
   - type: BureaucraticErrorRule
     ignoredJobs:
@@ -140,7 +141,7 @@
   - type: StationEvent
     startAnnouncement: station-event-clerical-error-announcement
     minimumPlayers: 15
-    weight: 5
+    weight: 3 # starcup: 5 -> 3
     duration: 1
   - type: ClericalErrorRule
 
@@ -151,7 +152,7 @@
   - type: StationEvent
     weight: 5
     duration: 1
-    minimumPlayers: 10
+    minimumPlayers: 0 # starcup: 15 -> 0, closet skeletons aren't antags here
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 
@@ -160,10 +161,10 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 6.5
-    earliestStart: 40
+    weight: 2 # starcup: 6.5 -> 2, dragons are too dangerous to be that common
+    earliestStart: 60
     reoccurrenceDelay: 20
-    minimumPlayers: 20
+    minimumPlayers: 35 # starcup: 20 -> 35, may need to increase further pending tests
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
@@ -189,10 +190,10 @@
   id: NinjaSpawn
   components:
   - type: StationEvent
-    weight: 6
+    weight: 4.5 # starcup: 6 -> 4.5, reduced chance compared to standard events
     duration: null
-    earliestStart: 30
-    reoccurrenceDelay: 20
+    earliestStart: 45 # starcup: 30 -> 45, later spawns for antags
+    reoccurrenceDelay: 60 # starcup: 20 -> 60
     minimumPlayers: 30
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
@@ -274,7 +275,7 @@
   id: RevenantSpawn
   components:
   - type: StationEvent
-    weight: 7.5
+    weight: 6 # starcup: 7.5 -> 6, reduced antag spawn chance
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -347,7 +348,8 @@
   components:
   - type: StationEvent
     earliestStart: 15
-    minimumPlayers: 15
+    minimumPlayers: 10 # starcup: 15 -> 10, kudzu is annoying but not dangerous. we need more lowpop events.
+    reoccurrenceDelay: 5 # starcup: added. hopefully will prevent the station from being overrun by kudzy in lowpop survival.
     weight: 7
     duration: 240
   - type: KudzuGrowthRule
@@ -366,6 +368,7 @@
         volume: -4
     duration: 60
     maxDuration: 120
+    reoccurrenceDelay: 5 # starcup: added to prevent constant power outages on lowpop survival
   - type: PowerGridCheckRule
 
 - type: entity
@@ -378,8 +381,8 @@
     endAnnouncement: station-event-solar-flare-end-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    duration: 120
-    maxDuration: 240
+    duration: 90 # starcup: 120 -> 90, don't want to reduce the low end too much
+    maxDuration: 180 # starcup: 240 -> 180, cut the high end by a minute to reduce lengthy outages (this + powergridcheck is a nightmare for comms)
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -405,7 +408,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
-    minimumPlayers: 15
+    minimumPlayers: 10 # starcup: 15 -> 10
     weight: 5
     duration: 60
   - type: VentClogRule
@@ -524,9 +527,10 @@
   id: LoneOpsSpawn
   components:
   - type: StationEvent
-    earliestStart: 35
-    weight: 5.5
+    earliestStart: 45 # starcup: 35 -> 45, give the crew a little more time before random loneop spawns
+    weight: 3.5 # starcup: 5.5 -> 3.5, don't want loneops being a very common event
     minimumPlayers: 20
+    maxOccurrences: 3 # starcup: added, don't want a revolving door of loneop events on survival
     duration: 1
   - type: RuleGrids
   - type: LoadMapRule
@@ -560,8 +564,8 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 8
-    minimumPlayers: 15
+    weight: 6 # starcup: 8 -> 6
+    minimumPlayers: 25 # starcup: 15 -> 25, lowpop sleeper agents just aren't as engaging
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception
     startAudio:
@@ -627,7 +631,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 5
-    minimumPlayers: 25
+    minimumPlayers: 15 # starcup: 25 -> 15, this event isn't disruptive enough to require 25 players and gives command/engi more work
     reoccurrenceDelay: 20
   - type: GreytideVirusRule
     accessGroups:
@@ -648,7 +652,7 @@
     weight: 5
     earliestStart: 15
     reoccurrenceDelay: 20
-    minimumPlayers: 4
+    minimumPlayers: 0 # starcup: 4 -> 0, these are barely antagonists already and a limit of 4 is too low to realistically matter
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0


### PR DESCRIPTION
Adjusted several events' variables for balance purposes

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the event weights, minimum player requirements, earliest start times, and reoccurrence delays for several events.
Added reoccurrence delays and maximum occurrence limits to some events. 
Adjusted the duration of the Solar Flare event.
Removed the spark chance from the GasLeak event.
Removed ephedrine from the list of safe chemicals that VentClog events could use.
Disabled the MimicVendor and WizardSpawn events until further notice.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Upstream has a decidedly more fast-paced and chaotic environment, and we want to tone that down a bit and ensure that dangerous events don't happen to early or too frequently, disruptive events don't have a chance to reoccur immediately after they're finished, and safer events can occur at lower player counts to give low-population shifts more variety.

The spark chance was removed from GasLeak events to prevent random plasma/tritium fires and avoid accidental spark-related deaths.

Ephedrine was removed from the VentClog events as it is very harmful to ingest in large quantities, and a 100u cloud could potentially prove fatal if you happen to be in the wrong spot.

MimicVendor and WizardSpawn were disabled for quality control, pending review and rebalance if necessary.

## Technical details
<!-- Summary of code changes for easier review. -->
- Changed SparkChance in GasLeakRuleComponent.cs from 0.05f -> 0.00f instead of removing the variable entirely

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: rebalanced basic calm and antag events
- remove: disabled MimicVendor and WizardSpawn events