### PR TITLE
tweak: wizards removed, minPlayers increased for revs + zombies

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -22,8 +22,8 @@
     rules:
     - id: Thief
       prob: 0.5
-    - id: SubWizard
-      prob: 0.05
+   # - id: SubWizard # starcup: removed pending reworks for balance
+   #   prob: 0.05
 
 - type: entity
   parent: BaseGameRule
@@ -236,7 +236,7 @@
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3
-      playerRatio: 15
+      playerRatio: 25 # starcup: 15 -> 25, antags that target specific roles need larger shifts to ensure those roles are actually filled
       briefing:
         text: head-rev-role-greeting
         color: CornflowerBlue
@@ -315,7 +315,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 30 # starcup: 20 -> 30, zombie gamemode wants more players than others
     delay:
       min: 600
       max: 900


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Revolutionaries and Zombies game modes now require more players. Wizard game mode is now fully disabled.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Revs are a game mode that targets command directly, but with a minimum player count of 15 you might only have one or two command players if any. Upping the minimum player count will hopefully ensure more interesting rounds.

Zombies are best on stations with moderate player counts or higher, and at 20 players the event runs the risk of both being too short-lived and too boring. Updating the minimum player count will ensure these rounds are more exciting.

Wizards are frankly extremely broken and cause far too much chaos in their current state. If you give free agents access to abilities that cause mass structural damage, instantly kill targets without counterplay, and completely disrupt other players' gameplay, they will find reasons to use them. This needs to be seriously reworked before it's in a state where we'd be comfortable enabling it.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: increased minimum player requirements for revolutionaries and zombie game modes
- removed: wizard game mode disabled