### PR TITLE
tweak: updated figurine voice line overhaul

### DIFF
--- a/Resources/Locale/en-US/datasets/figurines.ftl
+++ b/Resources/Locale/en-US/datasets/figurines.ftl
@@ -270,7 +270,7 @@ figurines-cmo-2 = You have HOW MUCH toxin damage?!
 figurines-cmo-3 = Oh, is it the salvagers again?
 figurines-cmo-4 = Tell Death I said "Better luck next time".
 
-# starcup: removed figurines-chemist-2 through 6 
+# starcup: removed figurines-chemist-2 through 6
 # figurines-chemist-2 = We need to cook.
 # figurines-chemist-3 = I am the one who knocks!
 # figurines-chemist-4 = Say my name.
@@ -297,8 +297,8 @@ figurines-paramedic-3 = Be there in a jiffy!
 figurines-paramedic-4 = Don't worry, I've got you!
 
 # starcup: removed figurines-doctor-4 through 5
-figurines-doctor-4 = Just a week away...
-figurines-doctor-5 = I knew it...
+# figurines-doctor-4 = Just a week away...
+# figurines-doctor-5 = I knew it...
 
 # starcup: added figurines-doctor-4
 figurines-doctor-1 = The patient is already dead!
@@ -322,7 +322,7 @@ figurines-librarian-13 = ...It's a tale as old as time...
 figurines-librarian-14 = ...That's all she wrote.
 
 # starcup: removed figurines-chaplain-5
-figurines-chaplain-5 = Anyone want to be sacrificed?
+# figurines-chaplain-5 = Anyone want to be sacrificed?
 
 # starcup: added figurines-chaplain-5, fixed formatting on figurines-chaplain-2
 figurines-chaplain-1 = Would you like to join my cul-- I mean religion.
@@ -333,8 +333,8 @@ figurines-chaplain-5 = There are more things in space than are dreamt of in your
 figurines-chaplain-6 = Vampires aren't real.
 
 # starcup: removed figurines-chef-4 and 6
-figurines-chef-4 = That'll be 1000 spesos
-figurines-chef-6 = Where'd Pun Pun go? No idea...
+# figurines-chef-4 = That'll be 1000 spesos
+# figurines-chef-6 = Where'd Pun Pun go? No idea...
 
 # starcup: added figurines-chef-4 and 6
 figurines-chef-1 = I swear it's not human meat.

--- a/Resources/Locale/en-US/datasets/figurines.ftl
+++ b/Resources/Locale/en-US/datasets/figurines.ftl
@@ -1,28 +1,47 @@
+# starcup: removed figurines-hop-4
+# figurines-hop-4 = You can get AA if you fill out the form.
+
+# starcup: added figurines-hop-4
 figurines-hop-1 = Papers, please.
 figurines-hop-2 = You are fired.
 figurines-hop-3 = BRB.
-figurines-hop-4 = You can get AA if you fill out the form.
+figurines-hop-4 = IANLOOSE!
 figurines-hop-5 = I was gone for two seconds...
 
+# starcup: removed figurines-passenger-4 through 5
+# figurines-passenger-4 = I'm no tider.
+# figurines-passenger-5 = How much for a toolbelt?
+
+# starcup: added figurines-passenger-4
 figurines-passenger-1 = Insuls please.
 figurines-passenger-2 = Call evac.
 figurines-passenger-3 = HELP MAINTS!!
-figurines-passenger-4 = I'm no tider.
-figurines-passenger-5 = How much for a toolbelt?
+figurines-passenger-4 = Why's this firelock closed?
 
-figurines-greytider-1 = Man, this party stinks. I fucking hate these people.
-figurines-greytider-2 = Uh-oh, who's lost their stunbaton?
-figurines-greytider-3 = Robust.
-figurines-greytider-4 = I'm not me without a toolbox.
+# starcup: removed figurines-greytider-1, 2, 3, 4, and 6
+# figurines-greytider-1 = Man, this party stinks. I fucking hate these people.
+# figurines-greytider-2 = Uh-oh, who's lost their stunbaton?
+# figurines-greytider-3 = Robust.
+# figurines-greytider-4 = I'm not me without a toolbox.
+# figurines-greytider-6 = Viva la revolution.
+
+# starcup: added figurines-greytider-1 through 4
+figurines-greytider-1 = I'm bored. Let's spice things up a bit.
+figurines-greytider-2 = Insuls? No thanks, I've got some already.
+figurines-greytider-3 = Party in the maints bar!
+figurines-greytider-4 = I need six plushie crates. It's urgent.
 figurines-greytider-5 = Grey tide station wide!
-figurines-greytider-6 = Viva la revolution.
 
+# starcup: removed figurines-clown-6
+# figurines-clown-6 = Can I have AA? Please?
+
+# starcup: added figurines-clown-6
 figurines-clown-1 = Honk!
 figurines-clown-2 = Banana!
 figurines-clown-3 = Soap!
 figurines-clown-4 = HoP has one clown, HoS has the whole department.
 figurines-clown-5 = Do I annoy you?
-figurines-clown-6 = Can I have AA? Please?
+figurines-clown-6 = Chef! More pies please!
 figurines-clown-7 = I'm a clown, but you're the whole circus!
 
 figurines-holoclown-1 = I'm helping my older brother.
@@ -43,11 +62,14 @@ figurines-mime-7 = !!!
 figurines-mime-8 = ....!
 figurines-mime-9 = ???
 
+# starcup: added figurines-musician-6 through 7
 figurines-musician-1 = Never gonna give you up!
 figurines-musician-2 = Never gonna let you down!
 figurines-musician-3 = Music is an art.
 figurines-musician-4 = Thank you, I'll be here all night.
 figurines-musician-5 = I'm a one man band.
+figurines-musician-6 = No, I'm not playing Free Bird.
+figurines-musician-7 = Anyway, here's Wonderwall.
 
 figurines-boxer-1 = The first rule of Fight Club is...
 figurines-boxer-2 = We settle this in the ring, alright?
@@ -55,74 +77,125 @@ figurines-boxer-3 = I. AM. THE. CHAMPION!!
 figurines-boxer-4 = Don't look at me; he was shot, not punched.
 figurines-boxer-5 = 1v1 me, captain.
 
-figurines-captain-1 = Glory to NT!
+# starcup: removed figurines-captain-1, 5, 6, 7, and 8
+# figurines-captain-1 = Glory to NT!
+# figurines-captain-5 = Everything is under control.
+# figurines-captain-6 = The disk was in my bag last I checked.
+# figurines-captain-7 = The chain of command starts and ends with me.
+# figurines-captain-8 = It's hard being at the top.
+
+# starcup: added figurines-captain-1 and 5
+figurines-captain-1 = Glory to the Syndicate!
 figurines-captain-2 = How did I get hired? Yes.
 figurines-captain-3 = The nuclear disk is secure. Where? Somewhere.
 figurines-captain-4 = Where did my ID go?
-figurines-captain-5 = Everything is under control.
-figurines-captain-6 = The disk was in my bag last I checked.
-figurines-captain-7 = The chain of command starts and ends with me.
-figurines-captain-8 = It's hard being at the top.
+figurines-captain-5 = It's been an honor and a privilege.
 
-figurines-hos-1 = Space law? What?
-figurines-hos-2 = Shoot the clown.
-figurines-hos-3 = Yes, I shot the clown. No, I don't regret it.
-figurines-hos-4 = Clown is now KOS.
-figurines-hos-5 = Armory is now open to the public!
+# starcup: removed figurines-hos-1 through 5
+# figurines-hos-1 = Space law? What?
+# figurines-hos-2 = Shoot the clown.
+# figurines-hos-3 = Yes, I shot the clown. No, I don't regret it.
+# figurines-hos-4 = Clown is now KOS.
+# figurines-hos-5 = Armory is now open to the public!
 
-figurines-warden-1 = Execute him for breaking in!
-figurines-warden-2 = Perma the fucker for insulting me!
-figurines-warden-3 = We totally treat everyone fairly and do NOT mistreat our prisoners.
-figurines-warden-4 = Brig is my home. My home is brig. My brig is home. Stop, what?
-figurines-warden-5 = Soap is now contraband.
-figurines-warden-6 = You're going away for a long time, buddy.
+# starcup: added figurines-hos-1 through 4
+figurines-hos-1 = Which statute was that again?
+figurines-hos-2 = [sighs] Someone arrest the clown.
+figurines-hos-3 = Warden? Go get the big gun.
+figurines-hos-4 = Crew, arm up!
 
+# starcup: removed figurines-warden-1 through 6
+# figurines-warden-1 = Execute him for breaking in!
+# figurines-warden-2 = Perma the fucker for insulting me!
+# figurines-warden-3 = We totally treat everyone fairly and do NOT mistreat our prisoners.
+# figurines-warden-4 = Brig is my home. My home is brig. My brig is home. Stop, what?
+# figurines-warden-5 = Soap is now contraband.
+# figurines-warden-6 = You're going away for a long time, buddy.
+
+# starcup: added figurines-warden-1 through 4
+figurines-warden-1 = You prisoners need anything? Some water? More crayons?
+figurines-warden-2 = Do you want to go for a walk? Please say yes.
+figurines-warden-3 = No, you don't need lethals for that.
+figurines-warden-4 = Outside? Where's that?
+
+starcup: added figurines-detective-6
 figurines-detective-1 = The butler did it.
 figurines-detective-2 = I need some whiskey after this.
 figurines-detective-3 = Chameleon fibers? How did a chameleon get in here?
 figurines-detective-4 = Go go gadget!
 figurines-detective-5 = Of course I checked the door logs!
+figurines-detective-6 = Just one more thing...
 
-figurines-security-1 = I am the law!
+# starcup: removed figurines-security-1 and 3, 4, 5, 6, 7, 8, 9, and 10
+# figurines-security-1 = I am the law!
+# figurines-security-3 = Whenever I get bored I use the clown as target practice.
+# figurines-security-4 = You have two rights: to remain silent and to cry about it.
+# figurines-security-5 = Harmbaton? It sure as hell harms!
+# figurines-security-6 = Space law? Never heard of it.
+# figurines-security-7 = Random search! Hand it over.
+# figurines-security-8 = I love donuts.
+# figurines-security-9 = Greytide this, motherfucker.
+# figurines-security-10 = Do not resist.
+
+# starcup: added figurines-security-1, 3, and 4
+figurines-security-1 = You definitely need a permit for that.
 figurines-security-2 = You have violated article 1984.
-figurines-security-3 = Whenever I get bored I use the clown as target practice.
-figurines-security-4 = You have two rights: to remain silent and to cry about it.
-figurines-security-5 = Harmbaton? It sure as hell harms!
-figurines-security-6 = Space law? Never heard of it.
-figurines-security-7 = Random search! Hand it over.
-figurines-security-8 = I love donuts.
-figurines-security-9 = Greytide this, motherfucker.
-figurines-security-10 = Do not resist.
+figurines-security-3 = I'd trade my salary for some no-slips.
+figurines-security-4 = Baton on, THEN swing.
 
-figurines-lawyer-1 = Better Call Saul!
+# starcup: removed figurines-lawyer-1
+# figurines-lawyer-1 = Better Call Saul!
+
+# starcup: added figurines-lawyer-1 and 6
+figurines-lawyer-1 = This isn't legal advice.
 figurines-lawyer-2 = Objection!
 figurines-lawyer-3 = Did you know that you have rights?
 figurines-lawyer-4 = Space law says!
 figurines-lawyer-5 = Sign the contract first.
+figurines-lawyer-6 = I'll take this case pro bono.
 
+# starcup: removed figurines-cargotech-2, 3, 5, and 6
+# figurines-cargotech-2 = I sold the station!
+# figurines-cargotech-3 = Brain bounty? I don't have a brain.
+# figurines-cargotech-5 = Vegetable bounty? Nobody eats those anyways.
+# figurines-cargotech-6 = WE ARE SECEDING!! ALL HAIL CARGONIA!!
+
+# starcup: added figurines-cargotech-2 through 3
 figurines-cargotech-1 = DRAGON ON ATS!
-figurines-cargotech-2 = I sold the station!
-figurines-cargotech-3 = Brain bounty? I don't have a brain.
+figurines-cargotech-2 = It's for a bounty, I swear!
+figurines-cargotech-3 = Should we order lasers?
 figurines-cargotech-4 = You're worth 3000 spesos. Congrats.
-figurines-cargotech-5 = Vegetable bounty? Nobody eats those anyways.
-figurines-cargotech-6 = WE ARE SECEDING!! ALL HAIL CARGONIA!!
 
-figurines-salvage-1 = Megafauna? It was mega easy.
-figurines-salvage-2 = We're lost. Anyone bring a GPS?
-figurines-salvage-3 = Anyone have oxygen?
-figurines-salvage-4 = I found a blood-red and e-sword!
+# starcup: removed figurines-salvage-1
+# figurines-salvage-1 = Megafauna? It was mega easy.
+# figurines-salvage-2 = We're lost. Anyone bring a GPS?
+# figurines-salvage-3 = Anyone have oxygen?
+# figurines-salvage-4 = I found a blood-red and e-sword!
+
+# starcup: added figurines-salvage-1 through 4
+figurines-salvage-1 = Whoops. I might need a pick-up.
+figurines-salvage-2 = Your materials, my pleasure.
+figurines-salvage-3 = Wait, why are we on Code Red?
+figurines-salvage-4 = It's just a dragon, what's the worst that could happen?
 figurines-salvage-5 = There's bears in space?
 figurines-salvage-6 = Crusher? I barely know her!
 
+# starcup: removed figurines-qm-2, 5, 6, 7, 8, and 9
+# figurines-qm-2 = I won't approve the guns.
+# figurines-qm-5 = Time to spent all money on gambling.
+# figurines-qm-6 = Viva La Cargonia!
+# figurines-qm-7 = Fill the form.
+# figurines-qm-8 = Where'd all our money go?
+# figurines-qm-9 = 99% of gamblers quit right before they hit it big!
+
+# starcup: added figurines-qm-2, 5, 6, and 7
 figurines-qm-1 = Who stole the shuttle?
-figurines-qm-2 = I won't approve the guns.
+figurines-qm-2 = I'm not approving that.
 figurines-qm-3 = I didn't buy those guns!
 figurines-qm-4 = One toys crate for ma fellow clown!
-figurines-qm-5 = Time to spent all money on gambling.
-figurines-qm-6 = Viva La Cargonia!
-figurines-qm-7 = Fill the form.
-figurines-qm-8 = Where'd all our money go?
-figurines-qm-9 = 99% of gamblers quit right before they hit it big!
+figurines-qm-5 = Let's go gambling!
+figurines-qm-6 = Has anyone heard from the salvagers lately?
+figurines-qm-7 = Fill out this form, please.
 
 figurines-ce-1 = Everyone to the briefing!
 figurines-ce-2 = Wire the solars!
@@ -131,60 +204,107 @@ figurines-ce-4 = SINGULOOSE!
 figurines-ce-5 = TESLOOSE!
 figurines-ce-6 = Power's out again.
 
+# starcup: removed figurines-engineer-4, 6, and 7
+# figurines-engineer-4 = Free insuls at engineering
+# figurines-engineer-6 = Someone bombed medbay... again...
+# figurines-engineer-7 = Well, why don't you come and fix it?
+
+# starcup: added figurines-engineer-4
 figurines-engineer-1 = SINGULOOSE!
 figurines-engineer-2 = TESLOOSE!
 figurines-engineer-3 = What is AME?
-figurines-engineer-4 = Free insuls at engineering
+figurines-engineer-4 = I solve practical problems.
 figurines-engineer-5 = Where'd the power go?
-figurines-engineer-6 = Someone bombed medbay... again...
-figurines-engineer-7 = Well, why don't you come and fix it?
 
-figurines-atmostech-1 = I put plasma in distro.
-figurines-atmostech-2 = I will burn you in a burn chamber.
+# starcup: removed figurines-atmostech-1, 2, 5, 6, and 7
+# figurines-atmostech-1 = I put plasma in distro.
+# figurines-atmostech-2 = I will burn you in a burn chamber.
+# figurines-atmostech-5 = Glory to Atmosia!
+# figurines-atmostech-6 = Distro? That's short for disposal.
+# figurines-atmostech-7 = TEG: Thermal Energy? Gone!
+
+# starcup: added figurines-atmostech-1, 2, and 5
+figurines-atmostech-1 = Stop opening firelocks!
+figurines-atmostech-2 = This setup is actually three percent more efficient.
 figurines-atmostech-3 = Frezon...
 figurines-atmostech-4 = Tritium...
-figurines-atmostech-5 = Glory to Atmosia!
-figurines-atmostech-6 = Distro? That's short for disposal.
-figurines-atmostech-7 = TEG: Thermal Energy? Gone!
+figurines-atmostech-5 = Temperature, pressure, volume.
 
-figurines-rd-1 = Blowing up all of the borgs!
+# starcup: removed figurines-rd-1, 5, and 6
+# figurines-rd-1 = Blowing up all of the borgs!
+# figurines-rd-5 = The cake is a lie!
+# figurines-rd-6 = The trait I look for in a scientist is expendability.
+
+# starcup: added figurines-rd-1, 5, 6, and 7
+figurines-rd-1 = No AI left behind!
 figurines-rd-2 = Tier 3 arsenal? No way.
 figurines-rd-3 = Now where did I leave my hardsuit...?
 figurines-rd-4 = Now you're thinking with portals!
-figurines-rd-5 = The cake is a lie!
-figurines-rd-6 = The trait I look for in a scientist is expendability.
+figurines-rd-5 = Raiding the vault probably isn't illegal... right?
+figurines-rd-6 = That's it, I'm making a portal straight to the bar.
+figurines-rd-7 = Just a tiny bit more uranium? Please?
 
-figurines-scientist-1 = Someone else must have made those bombs!
-figurines-scientist-2 = He asked to be borged!
+# starcup: removed figurines-scientist-1, 2, 5, and 6
+# figurines-scientist-1 = Someone else must have made those bombs!
+# figurines-scientist-2 = He asked to be borged!
+# figurines-scientist-5 = The anomaly blew up!
+# figurines-scientist-6 = The anomaly exploded!
+
+# starcup: added figurines-scientist-1, 2, and 6
+figurines-scientist-1 = But-- But it was only Depth 3!
+figurines-scientist-2 = Don't worry, I've got this anomaly under control.
 figurines-scientist-3 = Carp at sci!
 figurines-scientist-4 = Explosion at sci!
 figurines-scientist-5 = Anyone seen an anomaly?
-figurines-scientist-6 = The anomaly exploded!
+figurines-scientist-6 = IT CRIT!
 
+# starcup: removed figurines-cmo-2 through 5
+# figurines-cmo-2 = Why do we have meth?
+# figurines-cmo-3 = Who drank all the chems?
+# figurines-cmo-4 = Desoxyephedrine? Sounds healthy.
+# figurines-cmo-5 = No, you're not getting my hypospray.
+
+# starcup: added figurines-cmo-2 through 4
 figurines-cmo-1 = Suit sensors!
-figurines-cmo-2 = Why do we have meth?
-figurines-cmo-3 = Who drank all the chems?
-figurines-cmo-4 = Desoxyephedrine? Sounds healthy.
-figurines-cmo-5 = No, you're not getting my hypospray.
+figurines-cmo-2 = You have HOW MUCH toxin damage?!
+figurines-cmo-3 = Oh, is it the salvagers again?
+figurines-cmo-4 = Tell Death I said "Better luck next time".
 
+# starcup: removed figurines-chemist-2 through 6 
+# figurines-chemist-2 = We need to cook.
+# figurines-chemist-3 = I am the one who knocks!
+# figurines-chemist-4 = Say my name.
+# figurines-chemist-5 = 99.8% purity.
+# figurines-chemist-6 = Epinephrine? Didn't you say methamphetamine?
+
+# starcup: added figurines-chemist-2 through 4
 figurines-chemist-1 = Get your pills!
-figurines-chemist-2 = We need to cook.
-figurines-chemist-3 = I am the one who knocks!
-figurines-chemist-4 = Say my name.
-figurines-chemist-5 = 99.8% purity.
-figurines-chemist-6 = Epinephrine? Didn't you say methamphetamine?
+figurines-chemist-2 = Can I get a ChemVend restock?
+figurines-chemist-3 = The average person probably only knows the formulas for bic and derma. And cryox, of course.
+figurines-chemist-4 = Can you pass me the sodium chloride?
 
-figurines-paramedic-1 = Insuls and tools!
-figurines-paramedic-2 = I need AA for saving people!
-figurines-paramedic-3 = SUIT SENSORS!!
-figurines-paramedic-4 = I need the hypospray for saving people!
-figurines-paramedic-5 = 14 dead in the clown's room.
+# starcup: removed figurines-paramedic-1 through 5
+# figurines-paramedic-1 = Insuls and tools!
+# figurines-paramedic-2 = I need AA for saving people!
+# figurines-paramedic-3 = SUIT SENSORS!!
+# figurines-paramedic-4 = I need the hypospray for saving people!
+# figurines-paramedic-5 = 14 dead in the clown's room.
 
+# starcup: added figurines-paramedic-1 through 4
+figurines-paramedic-1 = Wee woo wee woo wee woo!
+figurines-paramedic-2 = Turn on your coords or else!
+figurines-paramedic-3 = Be there in a jiffy!
+figurines-paramedic-4 = Don't worry, I've got you!
+
+# starcup: removed figurines-doctor-4 through 5
+figurines-doctor-4 = Just a week away...
+figurines-doctor-5 = I knew it...
+
+# starcup: added figurines-doctor-4
 figurines-doctor-1 = The patient is already dead!
 figurines-doctor-2 = CLEAR!
 figurines-doctor-3 = Saw makes BRRR.
-figurines-doctor-4 = Just a week away...
-figurines-doctor-5 = I knew it...
+figurines-doctor-4 = Not apples! I'm allergic!
 
 figurines-librarian-1 = Silence!
 figurines-librarian-2 = One day while...
@@ -201,43 +321,74 @@ figurines-librarian-12 = Gather round...
 figurines-librarian-13 = ...It's a tale as old as time...
 figurines-librarian-14 = ...That's all she wrote.
 
-figurines-chaplain-1 = Would you like to join my cul- I mean religion.
+# starcup: removed figurines-chaplain-5
+figurines-chaplain-5 = Anyone want to be sacrificed?
+
+# starcup: added figurines-chaplain-5, fixed formatting on figurines-chaplain-2
+figurines-chaplain-1 = Would you like to join my cul-- I mean religion.
 figurines-chaplain-2 = Gods make me a killing machine please!
 figurines-chaplain-3 = God exists!
 figurines-chaplain-4 = Those aren't blood runes, I drew them in crayon.
-figurines-chaplain-5 = Anyone want to be sacrificed?
+figurines-chaplain-5 = There are more things in space than are dreamt of in your philosophy.
 figurines-chaplain-6 = Vampires aren't real.
 
+# starcup: removed figurines-chef-4 and 6
+figurines-chef-4 = That'll be 1000 spesos
+figurines-chef-6 = Where'd Pun Pun go? No idea...
+
+# starcup: added figurines-chef-4 and 6
 figurines-chef-1 = I swear it's not human meat.
 figurines-chef-2 = More banana cream pies?
 figurines-chef-3 = How does rotary sushi sound?
-figurines-chef-4 = That'll be 1000 spesos
+figurines-chef-4 = I do NOT have a rat on my head!
 figurines-chef-5 = For here or to go?
-figurines-chef-6 = Where'd Pun Pun go? No idea...
+figurines-chef-6 = Janitor! More mousetraps please!
 
+# starcup: removed figurines-bartender-3 through 7
+# figurines-bartender-3 = I mixed a little something in there...
+# figurines-bartender-4 = The recipe? Plasma and vomit. Why?
+# figurines-bartender-5 = I need those toxins for my drinks, officer!
+# figurines-bartender-6 = Read the room.
+# figurines-bartender-7 = I've got a shotgun.
+
+# starcup: added figurines-bartender-3 through 6
 figurines-bartender-1 = Where's my monkey?
 figurines-bartender-2 = Sec won't drink.
-figurines-bartender-3 = I mixed a little something in there...
-figurines-bartender-4 = The recipe? Plasma and vomit. Why?
-figurines-bartender-5 = I need those toxins for my drinks, officer!
-figurines-bartender-6 = Read the room.
-figurines-bartender-7 = I've got a shotgun.
+figurines-bartender-3 = Alright, I'm cutting you off.
+figurines-bartender-4 = Time for renovations!
+figurines-bartender-5 = So what's your story, stranger?
+figurines-bartender-6 = HEY! TAKE IT OUTSIDE!
 
-figurines-botanist-1 = I don't have any weed, officer!
-figurines-botanist-2 = Dude, I see colors...
-figurines-botanist-3 = Is it just me, or is that weed glowing?
+# starcup: removed figurines-botanist-1 through 3
+# figurines-botanist-1 = I don't have any weed, officer!
+# figurines-botanist-2 = Dude, I see colors...
+# figurines-botanist-3 = Is it just me, or is that weed glowing?
+
+# starcup: added figurines-botanist-1 through 3
+figurines-botanist-1 = I assure you, the screaming is normal.
+figurines-botanist-2 = Oh hey, they're making frezon again!
+figurines-botanist-3 = KUDZU!
 figurines-botanist-4 = 50 more units of mutagen. That should be enough.
 figurines-botanist-5 = More bananas for my favorite clown!
 
-figurines-janitor-1 = Clown stole my soap. Again.
-figurines-janitor-2 = Look at the signs, you idiot.
-figurines-janitor-3 = I've never seen this much lube in my life.
-figurines-janitor-4 = Another day, another spill.
-figurines-janitor-5 = I'm not even paid for this.
+# starcup: removed figurines-janitor-1 through 5, 7, 8, and 9
+# figurines-janitor-1 = Clown stole my soap. Again.
+# figurines-janitor-2 = Look at the signs, you idiot.
+# figurines-janitor-3 = I've never seen this much lube in my life.
+# figurines-janitor-4 = Another day, another spill.
+# figurines-janitor-5 = I'm not even paid for this.
+# figurines-janitor-7 = My only friend is my mop.
+# figurines-janitor-8 = That better not be what I think it is...
+# figurines-janitor-9 = Another day, another body.
+
+
+# starcup: added figurines-janitor-1 through 5
+figurines-janitor-1 = Maid outfit or bust.
+figurines-janitor-2 = Read the wet floor signs!
+figurines-janitor-3 = You don't dilute your space cleaner?
+figurines-janitor-4 = Hello? Can someone come let me out? HELLO?
+figurines-janitor-5 = ...Wait, is that potassiu--
 figurines-janitor-6 = This blood wasn't evidence, right?
-figurines-janitor-7 = My only friend is my mop.
-figurines-janitor-8 = That better not be what I think it is...
-figurines-janitor-9 = Another day, another body.
 
 figurines-nukie-1 = I got the disk!
 figurines-nukie-2 = Whiskey, Echo, Whiskey.
@@ -245,29 +396,40 @@ figurines-nukie-3 = The nuke makes boom.
 figurines-nukie-4 = What's the code?
 figurines-nukie-5 = Commander...? ...That's a balloon...
 
-figurines-nukie-elite-1 = Not a word in nanotrasen.
+# starcup: removed figurines-nukie-elite-5
+# figurines-nukie-elite-5 = Leave no survivors.
+
+# starcup: added figurines-nukie-elite-5, fixed capitalization on figurines-nukie-elite-1, added comma to figurines-nukie-elite-3
+figurines-nukie-elite-1 = Not a word in NanoTrasen.
 figurines-nukie-elite-2 = THAT'S A KEG!
-figurines-nukie-elite-3 = Guys are you alive?
+figurines-nukie-elite-3 = Guys, are you alive?
 figurines-nukie-elite-4 = Breach and clear!
-figurines-nukie-elite-5 = Leave no survivors.
+figurines-nukie-elite-5 = Someone cover me!
 figurines-nukie-elite-6 = Good work, team.
 
+# starcup: removed figurines-nukie-commander-2
+# figurines-nukie-commander-2 = Fuckin' flukies.
+
+# starcup: added figurines-nukie-commander-2
 figurines-nukie-commander-1 = GET DAT FUKKEN DISK!
-figurines-nukie-commander-2 = Fuckin' flukies.
+figurines-nukie-commander-2 = Well played, Captain.
 figurines-nukie-commander-3 = The syndicate sends its regards.
 figurines-nukie-commander-4 = Failure is not an option.
 figurines-nukie-commander-5 = Whoops.
 
+# starcup: fixed capitalization on figurines-footsoldier-4 and 5
 figurines-footsoldier-1 = I'm an evil boy. Less boy every day, more evil every day.
 figurines-footsoldier-2 = Who will you choose? Them or us? Us or them?
 figurines-footsoldier-3 = Glory to the syndicate!
-figurines-footsoldier-4 = Down with Nanotrasen!
-figurines-footsoldier-5 = I'd rather die than join Nanotrasen.
+figurines-footsoldier-4 = Down with NanoTrasen!
+figurines-footsoldier-5 = I'd rather die than join NanoTrasen.
 
+# starcup: added figurines-wizard-5
 figurines-wizard-1 = Ei Nath!!
 figurines-wizard-2 = Real wizards support trans rights.
 figurines-wizard-3 = Skidaddle skadoodle!
 figurines-wizard-4 = FIREBALL!
+figurines-wizard-5 = Earthsea did it better.
 
 figurines-space-dragon-1 = Fish will consume the station.
 figurines-space-dragon-2 = Dragon de- Actually, nevermind.

--- a/Resources/Locale/en-US/datasets/figurines.ftl
+++ b/Resources/Locale/en-US/datasets/figurines.ftl
@@ -1,3 +1,4 @@
+
 # starcup: removed figurines-hop-4
 # figurines-hop-4 = You can get AA if you fill out the form.
 
@@ -118,7 +119,7 @@ figurines-warden-2 = Do you want to go for a walk? Please say yes.
 figurines-warden-3 = No, you don't need lethals for that.
 figurines-warden-4 = Outside? Where's that?
 
-starcup: added figurines-detective-6
+# starcup: added figurines-detective-6
 figurines-detective-1 = The butler did it.
 figurines-detective-2 = I need some whiskey after this.
 figurines-detective-3 = Chameleon fibers? How did a chameleon get in here?

--- a/Resources/Prototypes/Datasets/figurines.yml
+++ b/Resources/Prototypes/Datasets/figurines.yml
@@ -8,13 +8,13 @@
   id: FigurinesPassenger
   values:
     prefix: figurines-passenger-
-    count: 5
+    count: 4 # starcup: 5 -> 4
 
 - type: localizedDataset
   id: FigurinesGreytider
   values:
     prefix: figurines-greytider-
-    count: 6
+    count: 5 # starcup: 6 -> 5
 
 - type: localizedDataset
   id: FigurinesClown
@@ -38,7 +38,7 @@
   id: FigurinesMusician
   values:
     prefix: figurines-musician-
-    count: 5
+    count: 7 # starcup: 5 -> 7
 
 - type: localizedDataset
   id: FigurinesBoxer
@@ -50,43 +50,43 @@
   id: FigurinesCaptain
   values:
     prefix: figurines-captain-
-    count: 8
+    count: 5 # starcup: 8 -> 5
 
 - type: localizedDataset
   id: FigurinesHoS
   values:
     prefix: figurines-hos-
-    count: 5
+    count: 4 # starcup: 5 -> 4
 
 - type: localizedDataset
   id: FigurinesWarden
   values:
     prefix: figurines-warden-
-    count: 6
+    count: 4 # starcup: 6 -> 4
 
 - type: localizedDataset
   id: FigurinesDetective
   values:
     prefix: figurines-detective-
-    count: 5
+    count: 6 # starcup: 5 -> 6
 
 - type: localizedDataset
   id: FigurinesSecurity
   values:
     prefix: figurines-security-
-    count: 10
+    count: 4 # starcup: 10 -> 4
 
 - type: localizedDataset
   id: FigurinesLawyer
   values:
     prefix: figurines-lawyer-
-    count: 5
+    count: 6 # starcup: 5 -> 6
 
 - type: localizedDataset
   id: FigurinesCargoTech
   values:
     prefix: figurines-cargotech-
-    count: 6
+    count: 4 # starcup: 6 -> 4
 
 - type: localizedDataset
   id: FigurinesSalvage
@@ -98,7 +98,7 @@
   id: FigurinesQM
   values:
     prefix: figurines-qm-
-    count: 9
+    count: 7 # starcup: 9 -> 7
 
 - type: localizedDataset
   id: FigurinesCE
@@ -110,19 +110,19 @@
   id: FigurinesEngineer
   values:
     prefix: figurines-engineer-
-    count: 7
+    count: 5 # starcup: 7 -> 5
 
 - type: localizedDataset
   id: FigurinesAtmosTech
   values:
     prefix: figurines-atmostech-
-    count: 7
+    count: 5 # starcup: 7 -> 5
 
 - type: localizedDataset
   id: FigurinesRD
   values:
     prefix: figurines-rd-
-    count: 6
+    count: 7 # starcup: 6 -> 7
 
 - type: localizedDataset
   id: FigurinesScientist
@@ -134,25 +134,25 @@
   id: FigurinesCMO
   values:
     prefix: figurines-cmo-
-    count: 5
+    count: 4 # starcup: 5 -> 4
 
 - type: localizedDataset
   id: FigurinesChemist
   values:
     prefix: figurines-chemist-
-    count: 6
+    count: 4 # starcup: 6 -> 4
 
 - type: localizedDataset
   id: FigurinesParamedic
   values:
     prefix: figurines-paramedic-
-    count: 5
+    count: 4 # starcup: 5 -> 4
 
 - type: localizedDataset
   id: FigurinesDoctor
   values:
     prefix: figurines-doctor-
-    count: 5
+    count: 4 # starcup: 5 -> 4
 
 - type: localizedDataset
   id: FigurinesLibrarian
@@ -176,7 +176,7 @@
   id: FigurinesBartender
   values:
     prefix: figurines-bartender-
-    count: 7
+    count: 6 # starcup: 7 -> 6
 
 - type: localizedDataset
   id: FigurinesBotanist
@@ -188,7 +188,7 @@
   id: FigurinesJanitor
   values:
     prefix: figurines-janitor-
-    count: 9
+    count: 6 # starcup: 9 -> 6
 
 - type: localizedDataset
   id: FigurinesNukie
@@ -218,7 +218,7 @@
   id: FigurinesWizard
   values:
     prefix: figurines-wizard-
-    count: 4
+    count: 5 # starcup: 4 -> 5
 
 - type: localizedDataset
   id: FigurinesSpaceDragon


### PR DESCRIPTION
Changes figurine voice lines to fit intended server culture (now updated to include recent upstream additions)
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed and replaced many figurine voice lines, and added many new voice lines to those with a small list of options.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The lines that figurines say when used are largely references to a more chaotic culture that we would like to leave behind as we develop our own community and establish expectations of behavior. To that end, many of the old figurine lines have been removed (references to security abusing their power and mistreating prisoners, greytiders being assholes that antagonize security, low-effort jokes about making meth/weed, etc) and replaced with lines more appropriate for the server culture we would prefer to see here on starcup.

As an added bonus, many figurines have been given more lines than they originally had to give them greater variety and make them more interesting finds.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: changed many figurine voice lines
- added new figurine voice lines