### PR TITLE
tweak: add space medipen to more survival boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -29,6 +29,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -51,6 +52,7 @@
     - id: ClothingMaskBreath
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodPSB # DeltaV - replace nutribrick with PSB
     - id: DrinkWaterBottleFull
@@ -69,6 +71,7 @@
     - id: ClothingMaskBreath
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -92,6 +95,7 @@
     - id: ClothingMaskGasSecurity
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodPSB # DeltaV - replace nutribrick with PSB
     - id: DrinkWaterBottleFull
@@ -110,6 +114,7 @@
     - id: ClothingMaskGasSecurity
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodPSB # DeltaV - replace nutribrick with PSB
     - id: DrinkWaterBottleFull
@@ -133,6 +138,7 @@
     - id: ClothingMaskBreathMedical
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodPSB # DeltaV - replace nutribrick with PSB
     - id: DrinkWaterBottleFull
@@ -151,6 +157,7 @@
     - id: ClothingMaskBreathMedical
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -179,6 +186,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyFunnyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodPSB # DeltaV - replace nutribrick with PSB
     - id: DrinkWaterBottleFull
@@ -196,6 +204,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -212,6 +221,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
@@ -226,6 +236,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
@@ -246,6 +257,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodBreadBaguetteCotton
     - id: DrinkWaterBottleFull
@@ -262,6 +274,7 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodSnackNutribrick
   - type: Sprite
@@ -279,6 +292,7 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
     - id: FoodSnackNutribrick
   - type: Sprite

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -31,7 +31,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -73,7 +73,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -159,7 +159,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -206,7 +206,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-nitrogen
@@ -223,7 +223,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodBreadBaguette
+    - id: FoodPSB # starcup: replace baguettes with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
 
 - type: entity
@@ -238,7 +238,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodBreadBaguette
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -259,7 +259,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodBreadBaguetteCotton
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
     - id: DrinkWaterBottleFull
 
 - type: entity
@@ -276,7 +276,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
   - type: Sprite
     layers:
     - state: internals
@@ -294,7 +294,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen # starcup: added to help players survive spacings
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodPSB # starcup: replaces nutribricks with PSBs to make room for SpaceMedipen
   - type: Sprite
     layers:
     - state: internals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the space medipen to all non-basic survival boxes (including nitrogen boxes, job-specific boxes, and syndicate boxes)
Replaces nutribricks and non-standard food items with PSBs to make room for space medipens (sorry, mimes)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Space medipens were originally added to the basic survival box, but they were intended to be added to all survival boxes. This PR aims to correct that mistake by actually adding the space medipen to all non-silicon survival boxes.

In order for the space medipen to fit in many survival boxes, their nutribricks had to be replaced with PSBs. This also includes survival boxes with different nonstandard 2x1 foods (mostly mimes). In the future, I would love for survival box contents to be filled out based on what the player wants to start with, but that is outside the scope of this PR.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: space medipen added to most survival boxes
- tweak: nutribricks and baguettes replaced with PSBs in most survival boxes