### PR TITLE
tweak: fix new shuttle screen timers

### DIFF
--- a/Resources/Maps/_starcup/Shuttles/SYND_EmergencyShuttle.yml
+++ b/Resources/Maps/_starcup/Shuttles/SYND_EmergencyShuttle.yml
@@ -50,6 +50,11 @@ entities:
       bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyID: ShuttleTimer
+      deviceNetID: Wireless
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle

--- a/Resources/Maps/_starcup/Shuttles/SYND_EvacShip.yml
+++ b/Resources/Maps/_starcup/Shuttles/SYND_EvacShip.yml
@@ -67,6 +67,11 @@ entities:
       bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyID: ShuttleTimer
+      deviceNetID: Wireless
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the DeviceNetwork component to the SYND_EmergencyShuttle and SYND_EvacShip, gave them the ShuttleTimer transmitFrequencyID, and set their deviceNetID to Wireless

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These shuttles still don't show the countdown for either when they're expected to leave the station _or_ when they're expected to arrive at SyndiComm. This component is something that other shuttles have, and we suspect that adding it _might_ fix the issue. Unfortunately, due to the way the debug console works, there's not really any way to test whether it works before merging.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: made screens in new shuttles show timers