### PR TITLE
add: port of Delta-V mapping action presets

### DIFF
--- a/Resources/mapping_actions_alarms.yml
+++ b/Resources/mapping_actions_alarms.yml
@@ -1,0 +1,139 @@
+- action: !type:InstantActionComponent
+    icon:
+      entity: AirAlarm
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: AirAlarm
+  assignments:
+  - 0: 1
+  name: Air Alarm
+- action: !type:InstantActionComponent
+    icon:
+      entity: FireAlarm
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: FireAlarm
+  assignments:
+  - 0: 2
+  name: Fire Alarm
+- action: !type:InstantActionComponent
+    icon:
+      entity: AirSensor
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: AirSensor
+  assignments:
+  - 0: 3
+  name: Air Sensor
+- action: !type:InstantActionComponent
+    icon:
+      entity: Firelock
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Firelock
+  assignments:
+  - 0: 4
+  name: Firelock
+- action: !type:InstantActionComponent
+    icon:
+      entity: FirelockGlass
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: FirelockGlass
+  assignments:
+  - 0: 5
+  name: Firelock Glass
+- action: !type:InstantActionComponent
+    icon:
+      entity: FirelockEdge
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: FirelockEdge
+  assignments:
+  - 0: 6
+  name: Firelock Edge
+- action: !type:InstantActionComponent
+    icon:
+      entity: Multitool
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Multitool
+  assignments:
+  - 0: 7
+  name: Multitool
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasVentScrubber
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasVentScrubber
+  assignments:
+  - 0: 8
+  name: Gas Vent Scrubber
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasVentPump
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasVentPump
+  assignments:
+  - 0: 9
+  name: Gas Vent Pump
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 0: 0
+  name: action-name-mapping-erase
+...

--- a/Resources/mapping_actions_alarms.yml
+++ b/Resources/mapping_actions_alarms.yml
@@ -1,3 +1,4 @@
+# starcup
 - action: !type:InstantActionComponent
     icon:
       entity: AirAlarm

--- a/Resources/mapping_actions_disposals.yml
+++ b/Resources/mapping_actions_disposals.yml
@@ -1,0 +1,140 @@
+
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalUnit
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalUnit
+  assignments:
+  - 0: 1
+  name: Disposal Unit
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalTrunk
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalTrunk
+  assignments:
+  - 0: 2
+  name: Disposal Trunk
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalPipe
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalPipe
+  assignments:
+  - 0: 3
+  name: Disposal Pipe
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalBend
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalBend
+  assignments:
+  - 0: 4
+  name: Disposal Bend
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalJunction
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalJunction
+  assignments:
+  - 0: 5
+  name: Disposal Junction
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalJunctionFlipped
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalJunctionFlipped
+  assignments:
+  - 0: 6
+  name: Disposal Junction Flipped
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalYJunction
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalYJunction
+  assignments:
+  - 0: 7
+  name: Disposal Y-Junction
+- action: !type:InstantActionComponent
+    icon:
+      entity: DisposalTagger
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: DisposalTagger
+  assignments:
+  - 0: 8
+  name: Disposal Tagger
+- action: !type:InstantActionComponent
+    icon:
+      entity: SignDisposalSpace
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: SignDisposalSpace
+  assignments:
+  - 0: 9
+  name: Sign Disposal Space
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 0: 0
+  name: action-name-mapping-erase
+...

--- a/Resources/mapping_actions_disposals.yml
+++ b/Resources/mapping_actions_disposals.yml
@@ -1,4 +1,4 @@
-
+# starcup
 - action: !type:InstantActionComponent
     icon:
       entity: DisposalUnit

--- a/Resources/mapping_actions_pipes.yml
+++ b/Resources/mapping_actions_pipes.yml
@@ -1,0 +1,153 @@
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasPipeStraight
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPipeStraight
+  assignments:
+  - 0: 1
+  name: Gas Pipe Straight
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasPipeBend
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPipeBend
+  assignments:
+  - 0: 2
+  name: Gas Pipe Bend
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasPipeTJunction
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPipeTJunction
+  assignments:
+  - 0: 3
+  name: Gas Pipe T-Junction
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasPipeFourway
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPipeFourway
+  assignments:
+  - 0: 4
+  name: Gas Pipe Fourway
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasVentScrubber
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasVentScrubber
+  assignments:
+  - 0: 5
+  name: Gas Vent Scrubber
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasVentPump
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasVentPump
+  assignments:
+  - 0: 6
+  name: Gas Vent Pump
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasPassiveVent
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPassiveVent
+  assignments:
+  - 0: 7
+  name: Gas Passive Vent
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasVolumePump
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasVolumePump
+  assignments:
+  - 0: 8
+  name: Gas Volume Pump
+- action: !type:InstantActionComponent
+    icon:
+      entity: GasPressurePump
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPressurePump
+  assignments:
+  - 0: 9
+  name: Gas Pressure Pump
+- action: !type:InstantActionComponent
+    EntityIcon:
+      entity: GasPort
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GasPort
+  assignments:
+  - 0: 0
+  name: Gas Port
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 1: 1
+  name: action-name-mapping-erase
+...

--- a/Resources/mapping_actions_pipes.yml
+++ b/Resources/mapping_actions_pipes.yml
@@ -1,3 +1,4 @@
+# starcup
 - action: !type:InstantActionComponent
     icon:
       entity: GasPipeStraight

--- a/Resources/mapping_actions_power.yml
+++ b/Resources/mapping_actions_power.yml
@@ -1,3 +1,4 @@
+# starcup
 - action: !type:InstantActionComponent
     icon:
       entity: APCBasic

--- a/Resources/mapping_actions_power.yml
+++ b/Resources/mapping_actions_power.yml
@@ -1,0 +1,167 @@
+- action: !type:InstantActionComponent
+    icon:
+      entity: APCBasic
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: APCBasic
+  assignments:
+  - 0: 1
+  name: APC Basic
+- action: !type:InstantActionComponent
+    icon:
+      entity: CableApcExtension
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: CableApcExtension
+  assignments:
+  - 0: 2
+  name: Cable LV
+- action: !type:InstantActionComponent
+    icon:
+      entity: CableMV
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: CableMV
+  assignments:
+  - 0: 3
+  name: Cable MV
+- action: !type:InstantActionComponent
+    icon:
+      entity: CableHV
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: CableHV
+  assignments:
+  - 0: 4
+  name: Cable HV
+- action: !type:InstantActionComponent
+    icon:
+      entity: SubstationBasic
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: SubstationBasic
+  assignments:
+  - 0: 5
+  name: Substation Basic
+- action: !type:InstantActionComponent
+    icon:
+      entity: SMESBasic
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: SMESBasic
+  assignments:
+  - 0: 6
+  name: SMES Basic
+- action: !type:InstantActionComponent
+    icon:
+      entity: CableTerminal
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: CableTerminal
+  assignments:
+  - 0: 7
+  name: Cable Terminal
+- action: !type:InstantActionComponent
+    icon:
+      entity: Poweredlight
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Poweredlight
+  assignments:
+  - 0: 8
+  name: Powered Light
+- action: !type:InstantActionComponent
+    icon:
+      entity: PoweredlightExterior
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: PoweredlightExterior
+  assignments:
+  - 0: 9
+  name: Powered Light [Exterior]
+- action: !type:InstantActionComponent
+    icon:
+      entity: PoweredLightPostSmall
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: PoweredLightPostSmall
+  assignments:
+  - 0: 0
+  name: Post Light
+- action: !type:InstantActionComponent
+    icon:
+      entity: PoweredDimSmallLight
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: PoweredDimSmallLight
+  assignments:
+  - 1: 1
+  name: Small Light [Dim]
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 1: 2
+  name: action-name-mapping-erase
+...

--- a/Resources/mapping_actions_power.yml
+++ b/Resources/mapping_actions_power.yml
@@ -123,7 +123,7 @@
       entityType: PoweredlightExterior
   assignments:
   - 0: 9
-  name: Powered Light [Exterior]
+  name: Powered Light Exterior
 - action: !type:InstantActionComponent
     icon:
       entity: PoweredLightPostSmall
@@ -151,7 +151,7 @@
       entityType: PoweredDimSmallLight
   assignments:
   - 1: 1
-  name: Small Light [Dim]
+  name: Small Light Dim
 - action: !type:InstantActionComponent
     icon: Interface/VerbIcons/delete.svg.192dpi.png
     keywords: []

--- a/Resources/mapping_actions_shuttles.yml
+++ b/Resources/mapping_actions_shuttles.yml
@@ -1,3 +1,4 @@
+# starcup
 - action: !type:InstantActionComponent
     icon: /Textures/Tiles/cropped_parallax.png
     keywords: []

--- a/Resources/mapping_actions_shuttles.yml
+++ b/Resources/mapping_actions_shuttles.yml
@@ -1,0 +1,149 @@
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/cropped_parallax.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Space
+  assignments:
+  - 0: 0
+  name: space
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/plating.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Plating
+  assignments:
+  - 0: 1
+  name: plating
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/lattice.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Lattice
+  assignments:
+  - 0: 2
+  name: lattice
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/steel.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: FloorSteel
+  assignments:
+  - 0: 3
+  name: steel floor
+- action: !type:InstantActionComponent
+    icon:
+      entity: WallShuttle
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: WallShuttle
+  assignments:
+  - 0: 4
+  name: Wall Shuttle
+- action: !type:InstantActionComponent
+    icon:
+      entity: Grille
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Grille
+  assignments:
+  - 0: 5
+  name: Grille
+- action: !type:InstantActionComponent
+    icon:
+      entity: ShuttleWindow
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: ShuttleWindow
+  assignments:
+  - 0: 6
+  name: Window Shuttle
+- action: !type:InstantActionComponent
+    icon:
+      entity: WallShuttleDiagonal
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: WallShuttleDiagonal
+  assignments:
+  - 0: 7
+  name: Wall Shuttle Diagonal
+- action: !type:InstantActionComponent
+    icon:
+      entity: GrilleDiagonal
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: GrilleDiagonal
+  assignments:
+  - 0: 8
+  name: Grille Diagonal
+- action: !type:InstantActionComponent
+    icon:
+      entity: ShuttleWindowDiagonal
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: ShuttleWindowDiagonal
+  assignments:
+  - 0: 9
+  name: Window Shuttle Diagonal
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 0: 10
+  name: action-name-mapping-erase
+...

--- a/Resources/mapping_actions_starcup.yml
+++ b/Resources/mapping_actions_starcup.yml
@@ -1,3 +1,4 @@
+# starcup
 - action: !type:InstantActionComponent
     icon: /Textures/Tiles/cropped_parallax.png
     keywords: []

--- a/Resources/mapping_actions_starcup.yml
+++ b/Resources/mapping_actions_starcup.yml
@@ -1,0 +1,136 @@
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/cropped_parallax.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Space
+  assignments:
+  - 0: 1
+  name: space
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/plating.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Plating
+  assignments:
+  - 0: 2
+  name: plating
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/steel.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: FloorSteel
+  assignments:
+  - 0: 3
+  name: steel floor
+- action: !type:InstantActionComponent
+    icon:
+      entity: WallSolid
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: WallSolid
+  assignments:
+  - 0: 4
+  name: Wall Solid
+- action: !type:InstantActionComponent
+    icon:
+      entity: WallReinforced
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: WallReinforced
+  assignments:
+  - 0: 5
+  name: WallReinforced
+- action: !type:InstantActionComponent
+    icon:
+      entity: Grille
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Grille
+  assignments:
+  - 0: 6
+  name: Grille
+- action: !type:InstantActionComponent
+    icon:
+      entity: Window
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Window
+  assignments:
+  - 0: 7
+  name: Window
+- action: !type:InstantActionComponent
+    icon:
+      entity: ReinforcedWindow
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: ReinforcedWindow
+  assignments:
+  - 0: 8
+  name: ReinforcedWindow
+- action: !type:InstantActionComponent
+    icon:
+      entity: Firelock
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: Firelock
+  assignments:
+  - 0: 9
+  name: Firelock
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 0: 0
+  name: action-name-mapping-erase
+...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ported Delta-V's custom mapping action preset files, then removed or replaced entities which don't exist on starcup, added new entities to presets that were lacking in utility, and reorganized action button layout for improved workflow.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The default mapping_actions.yml file used upstream is far too broad and covers a wide range of options that are _broadly_ useful, but which don't do a good job providing a tailored list of readily-accessible actions for mappers. Delta-V's custom action preset files divide the main mapping actions into multiple smaller, more focused preset files, allowing the user to load up presets for a specific task such as setting up power, lights, pipe networks, and more. Over time, I would like to add more presets to expand on these options.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: ported and adjusted Delta-V's custom mapping presets