### PR TITLE
tweak(map): minor SYND_EvacShip fixes

### DIFF
--- a/Resources/Maps/_starcup/Shuttles/SYND_EvacShip.yml
+++ b/Resources/Maps/_starcup/Shuttles/SYND_EvacShip.yml
@@ -2,10 +2,10 @@ meta:
   format: 7
   category: Grid
   engineVersion: 260.0.0
-  forkId: starcup
-  forkVersion: c7444ab815c37ad5c5f3a5623e27e39e4b304ed2
-  time: 05/30/2025 06:00:32
-  entityCount: 955
+  forkId: ""
+  forkVersion: ""
+  time: 06/02/2025 09:37:10
+  entityCount: 959
 maps: []
 grids:
 - 1
@@ -900,9 +900,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -1365.7528
-      state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -1790,6 +1787,26 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-3.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 13.5,6.5
       parent: 1
 - proto: CableHV
   entities:
@@ -4976,53 +4993,33 @@ entities:
     - type: Transform
       pos: 12.669952,-15.234908
       parent: 1
-- proto: HospitalCurtains
+- proto: HospitalCurtainsOpen
   entities:
   - uid: 635
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-16.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -2421.2498
-      state: Opening
   - uid: 636
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-14.5
+      pos: 12.5,-16.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -2422.6162
-      state: Opening
   - uid: 637
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-12.5
+      pos: 12.5,-14.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -2425.4163
-      state: Opening
   - uid: 638
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,-14.5
+      pos: 9.5,-12.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -2419.383
-      state: Opening
   - uid: 639
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,-16.5
+      pos: 9.5,-14.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -12361.958
-      state: Opening
 - proto: KitchenMicrowave
   entities:
   - uid: 640


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Added LV Cables to ensure all thrusters were powered
- Replaced medbay's hospital curtains with open variants
- Removed a component on a medbay door that caused it to open when the shuttle was initialized

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Minor bug fixes and improvements

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/63d25228-f94d-45ee-a8f4-f3d4b7f9968a)
Remember to extend your LV Cable networks, folks.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: ensured all thrusters had power on SYND_EvacShip
- tweak: made medbay's hospital curtains opened by default on SYND_EvacShip
- tweak: stopped medbay's airlock from opening on shuttle arrival on SYND_EvacShip