### PR TITLE
Loadout fixes

### DIFF
--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Access.Components;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
+using Content.Shared.Access.Components; // DeltaV
 using Content.Shared.Access.Systems;
 using Content.Shared.Roles;
 using Content.Shared.StatusIcon;
@@ -79,10 +80,14 @@ public sealed class PresetIdCardSystem : EntitySystem
 
         _accessSystem.SetAccessToJob(uid, job, extended);
 
-        _cardSystem.TryChangeJobTitle(uid, job.LocalizedName);
+        var card = Comp<IdCardComponent>(uid); // DeltaV
+
+        if (card.JobTitle == null) // DeltaV: only set job title if id card doesnt have one already
+            _cardSystem.TryChangeJobTitle(uid, job.LocalizedName);
         _cardSystem.TryChangeJobDepartment(uid, job);
 
-        if (_prototypeManager.TryIndex(job.Icon, out var jobIcon))
+        // DeltaV: only set to the job's icon if the id doesn't specify one
+        if (card.JobIcon == "JobIconUnknown" && _prototypeManager.TryIndex(job.Icon, out var jobIcon))
             _cardSystem.TryChangeJobIcon(uid, jobIcon);
     }
 }

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -196,9 +196,11 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             return;
 
         _cardSystem.TryChangeFullName(cardId, characterName, card);
-        _cardSystem.TryChangeJobTitle(cardId, jobPrototype.LocalizedName, card);
+        if (card.JobTitle == null) // DeltaV
+            _cardSystem.TryChangeJobTitle(cardId, jobPrototype.LocalizedName, card);
 
-        if (_prototypeManager.TryIndex(jobPrototype.Icon, out var jobIcon))
+        // DeltaV
+        if (card.JobIcon == "JobIconUnknown" && _prototypeManager.TryIndex(jobPrototype.Icon, out var jobIcon))
             _cardSystem.TryChangeJobIcon(cardId, jobIcon, card);
 
         var extendedAccess = false;

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Server.Access.Systems;
 using Content.Server.Forensics;
 using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems; // DeltaV
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
@@ -152,12 +153,17 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
             return;
         }
 
+        // DeltaV - use id card if possible
+        Entity<IdCardComponent>? card = null;
+        if (idUid != null && _idCard.TryFindIdCard(idUid.Value, out var card2))
+            card = card2;
+
         var record = new GeneralStationRecord()
         {
             Name = name,
             Age = age,
-            JobTitle = jobPrototype.LocalizedName,
-            JobIcon = jobPrototype.Icon,
+            JobTitle = card?.Comp.LocalizedJobTitle ?? jobPrototype.LocalizedName, // DeltaV
+            JobIcon = card?.Comp.JobIcon ?? jobPrototype.Icon, // DeltaV
             JobPrototype = jobId,
             Species = species,
             Gender = gender,

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Devices/pda.yml
@@ -19,8 +19,7 @@
     borderColor: "#e39751"
     accentVColor: "#050c4d"
   - type: Icon
-    sprite: _DeltaV/Objects/Devices/pda.rsi
-    state: pda-mailcarrier
+    state: pda-cargo
   - type: CartridgeLoader # DeltaV - Courier Performance
     preinstalled:
     - CrewManifestCartridge

--- a/Resources/Prototypes/_DeltaV/Roles/Jobs/Cargo/courier.yml
+++ b/Resources/Prototypes/_DeltaV/Roles/Jobs/Cargo/courier.yml
@@ -14,6 +14,5 @@
 - type: startingGear
   id: CourierGear
   equipment:
-    id: CourierPDA
     ears: ClothingHeadsetCargo
     belt: CourierBag


### PR DESCRIPTION
fixes the various issues with the mail carrier alt job; no more duplicate pda spawns, and the alternate job title actually renders now thanks to some relevant tweaks from delta-v code! this should help implement more alt titles in future

**Changelog**
:cl:
- fix: couriers now no longer spawn with a duplicate PDA
- fix: selecting the mail carrier PDA now properly changes the character's job title