### PR TITLE
Ports DV's security firearm loadout choices and lets pacifists use disablers.

### DIFF
--- a/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DeltaV/preferences/loadout-groups.ftl
@@ -43,6 +43,14 @@ loadout-group-security-cadet-head = Security Cadet head
 
 loadout-group-security-neck = Security neck
 
+loadout-group-security-gun = Security Sidearm
+loadout-group-revolver-gun = Security Revolver
+loadout-group-all-gun = Security Sidearm
+loadout-group-security-gun-ammo = Ammunition
+loadout-group-revolver-ammo = Ammunition
+loadout-group-all-ammo = Ammunition
+
+# Medical
 loadout-group-medical-doctor-neck = Medical Doctor neck
 
 loadout-group-chemist-neck = Chemist neck

--- a/Resources/Prototypes/DeltaV/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Jobs/Security/detective.yml
@@ -1,0 +1,50 @@
+﻿- type: loadout
+  id: SecurityRevolverWeaponRevolverLucky
+  storage:
+    belt:
+    - WeaponRevolverLucky
+
+- type: loadout
+  id: SecurityRevolverInspector
+  storage:
+    belt:
+    - WeaponRevolverInspector
+
+- type: loadout
+  id: SecurityFirearmSpeedLoaderMagnumRubber
+  storage:
+    back:
+    - SpeedLoaderMagnumRubber
+
+- type: loadout
+  id: SecurityFirearmSpeedLoaderMagnum
+  storage:
+    back:
+    - SpeedLoaderMagnum
+
+- type: loadout
+  id: SecurityFirearmSpeedLoaderSpecialRubber
+  storage:
+    back:
+    - SpeedLoaderSpecialRubber
+
+- type: loadout
+  id: SecurityFirearmSpeedLoaderSpecial
+  storage:
+    back:
+    - SpeedLoaderSpecial
+
+- type: loadout
+  id: SecurityFirearmWeaponRevolverFitz
+  equipment:
+    pocket1: WeaponRevolverFitz
+
+- type: loadout
+  id: SecurityFirearmWeaponRevolverK38Master
+  equipment:
+    pocket1: WeaponRevolverK38Master
+
+- type: loadout
+  id: SecurityFirearmWeaponRevolverDeckard
+  equipment:
+    pocket1: WeaponRevolverDeckard

--- a/Resources/Prototypes/DeltaV/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Jobs/Security/security_officer.yml
@@ -1,0 +1,31 @@
+﻿- type: loadout
+  id: SecurityFirearmWeaponPistolPollock
+  equipment:
+    pocket1: WeaponPistolPollock
+
+- type: loadout
+  id: SecurityFirearmWeaponPistolSLP57
+  equipment:
+    pocket1: WeaponPistolSLP57
+
+- type: loadout
+  id: SecurityFirearmWeaponPistolMk58
+  equipment:
+    pocket1: WeaponPistolMk58
+
+- type: loadout
+  id: SecurityFirearmWeaponDisabler
+  equipment:
+    pocket1: WeaponDisabler
+
+- type: loadout
+  id: SecurityFirearmMagazinePistolRubber
+  storage:
+    back:
+    - MagazinePistolRubber
+
+- type: loadout
+  id: SecurityFirearmMagazinePistol
+  storage:
+    back:
+    - MagazinePistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -476,6 +476,7 @@
     tags:
     - Taser
     - Sidearm
+  - type: PacifismAllowedGun # DeltaV - allow pacifist to use the disabler
 
 - type: entity
   name: disabler
@@ -542,6 +543,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 260
+  - type: PacifismAllowedGun # DeltaV - allow pacifist to use the disabler
 
 - type: entity
   name: taser

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -365,6 +365,8 @@
   - Trinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - SecurityAllFirearm # DeltaV - loadouts
+  - SecurityAllAmmo # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobWarden
@@ -380,6 +382,8 @@
   - Trinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - SecurityAllFirearm # DeltaV - loadouts
+  - SecurityAllAmmo # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobSecurityOfficer
@@ -396,6 +400,8 @@
   - Trinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - SecurityFirearm # DeltaV - loadouts
+  - SecurityFirearmAmmo # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobDetective
@@ -411,6 +417,8 @@
   - Trinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - SecurityRevolverFirearm # DeltaV - loadouts
+  - SecurityRevolverAmmo # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobSecurityCadet

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -29,7 +29,7 @@
     eyes: ClothingEyesGlassesSecurity
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltHolsterFilled
+    belt: ClothingBeltHolster # DeltaV - loadouts
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -48,8 +48,8 @@
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
     ears: ClothingHeadsetAltSecurity
-    pocket1: WeaponPistolMk58
+  #  pocket1: WeaponPistolMk58Nonlethal # DeltaV - loadouts
   storage:
     back:
     - Flash
-    - MagazinePistol
+  # - MagazinePistol # DeltaV - loadouts

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -35,7 +35,7 @@
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled
-    pocket1: WeaponPistolMk58
+    pocket1: WeaponDisabler # DeltaV - loadouts, Security Cadet doesn't spawn with a gun
     pocket2: BookSecurity
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -27,8 +27,8 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     ears: ClothingHeadsetSecurity
-    pocket1: WeaponPistolMk58
+  #  pocket1: WeaponPistolMk58Nonlethal # DeltaV - loadouts
   storage:
     back:
     - Flash
-    - MagazinePistol
+  #  - MagazinePistol # DeltaV - loadouts

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -31,8 +31,8 @@
     eyes: ClothingEyesGlassesSecurity
     id: WardenPDA
     ears: ClothingHeadsetSecurity
-    pocket1: WeaponPistolMk58
+  #  pocket1: WeaponPistolMk58Nonlethal # DeltaV - loadouts
   storage:
     back:
     - Flash
-    - MagazinePistol
+  # - MagazinePistol # DeltaV - loadouts

--- a/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
@@ -219,6 +219,77 @@
   - MimeFrenchBeret
   - SecurityHelmet # starcup
 
+## Security Guns
+- type: loadoutGroup
+  id: SecurityFirearm
+  name: loadout-group-security-gun
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+ # - SecurityFirearmWeaponPistolPollock # starcup - we don't have this yet
+ # - SecurityFirearmWeaponPistolSLP57 # starcup - we don't have this yet
+  - SecurityFirearmWeaponPistolMk58
+  - SecurityFirearmWeaponDisabler
+
+- type: loadoutGroup
+  id: SecurityRevolverFirearm
+  name: loadout-group-revolver-gun
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+  - SecurityRevolverInspector
+ # - SecurityFirearmWeaponRevolverFitz # starcup - we don't have this yet
+ # - SecurityRevolverWeaponRevolverLucky # starcup - we don't have this yet
+
+- type: loadoutGroup
+  id: SecurityFirearmAmmo
+  name: loadout-group-security-gun-ammo
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - SecurityFirearmMagazinePistol
+  - SecurityFirearmMagazinePistolRubber
+
+- type: loadoutGroup
+  id: SecurityRevolverAmmo
+  name: loadout-group-revolver-ammo
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - SecurityFirearmSpeedLoaderMagnumRubber
+  - SecurityFirearmSpeedLoaderMagnum
+ # - SecurityFirearmSpeedLoaderSpecialRubber # starcup - we don't have this yet
+ # - SecurityFirearmSpeedLoaderSpecial # starcup - we don't have this yet
+
+- type: loadoutGroup
+  id: SecurityAllFirearm
+  name: loadout-group-all-gun
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+#  - SecurityFirearmWeaponPistolPollock # starcup - we don't have this one yet
+#  - SecurityFirearmWeaponPistolSLP57 # starcup - we don't have this one yet
+  - SecurityFirearmWeaponPistolMk58
+  - SecurityFirearmWeaponDisabler
+  - SecurityRevolverInspector
+ # - SecurityFirearmWeaponRevolverFitz # starcup - we don't have this one yet
+ # - SecurityRevolverWeaponRevolverLucky # starcup - we don't have this one yet
+  - SecurityFirearmWeaponRevolverDeckard
+ # - SecurityFirearmWeaponRevolverK38Master # starcup - we don't have this one yet
+
+- type: loadoutGroup
+  id: SecurityAllAmmo
+  name: loadout-group-all-ammo
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - SecurityFirearmMagazinePistol
+  - SecurityFirearmMagazinePistolRubber
+  - SecurityFirearmSpeedLoaderMagnumRubber
+  - SecurityFirearmSpeedLoaderMagnum
+ # - SecurityFirearmSpeedLoaderSpecialRubber # starcup - we don't have this yet
+ # - SecurityFirearmSpeedLoaderSpecial # starcup - we don't have this yet
+
 ## Security Officer
 - type: loadoutGroup
   id: SecurityNeck


### PR DESCRIPTION
Notably exempted DV's extra firearms from this port for now and left out nonexistant jobs like Prison Guard.

Still need to:
- remove disabler damage
- add rubber bullets.

## Why / Balance
Not all Security players want to be violent, and pacifist security is actually fairly common on our server. Additionally, pacifists deserve more ways to defend themselves.

**Changelog**
:cl:
- tweak: disablers are now available for pacifist use.
- add: non-cadet security can now choose between various or no firearms.
