### PR TITLE
fix: declare data definition for VendingMachineInventoryEntry

### DIFF
--- a/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
+++ b/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml.cs
@@ -120,21 +120,21 @@ namespace Content.Client.VendingMachines.UI
             {
                 var entry = inventory[i];
 
-                if (!_prototypeManager.TryIndex(entry.ID, out var prototype))
+                if (!_prototypeManager.TryIndex(entry.Id, out var prototype))
                 {
-                    _amounts[entry.ID] = 0;
+                    _amounts[entry.Id] = 0;
                     continue;
                 }
 
-                if (!_dummies.TryGetValue(entry.ID, out var dummy))
+                if (!_dummies.TryGetValue(entry.Id, out var dummy))
                 {
-                    dummy = _entityManager.Spawn(entry.ID);
-                    _dummies.Add(entry.ID, dummy);
+                    dummy = _entityManager.Spawn(entry.Id);
+                    _dummies.Add(entry.Id, dummy);
                 }
 
                 var itemName = Identity.Name(dummy, _entityManager);
                 var itemText = $"{itemName} [{entry.Amount}]";
-                _amounts[entry.ID] = entry.Amount;
+                _amounts[entry.Id] = entry.Amount;
 
                 if (itemText.Length > longestEntry.Length)
                     longestEntry = itemText;
@@ -163,7 +163,7 @@ namespace Content.Client.VendingMachines.UI
                     continue;
 
                 var dummy = _dummies[proto];
-                if (!cachedInventory.TryFirstOrDefault(o => o.ID == proto, out var entry))
+                if (!cachedInventory.TryFirstOrDefault(o => o.Id == proto, out var entry))
                     continue;
                 var amount = entry.Amount;
                 // Could be better? Problem is all inventory entries get squashed.

--- a/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
+++ b/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
@@ -64,7 +64,7 @@ namespace Content.Client.VendingMachines
             if (selectedItem == null)
                 return;
 
-            SendPredictedMessage(new VendingMachineEjectMessage(selectedItem.Type, selectedItem.ID));
+            SendPredictedMessage(new VendingMachineEjectMessage(selectedItem.Type, selectedItem.Id));
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -57,9 +57,9 @@ namespace Content.Server.VendingMachines
 
             foreach (var entry in component.Inventory.Values)
             {
-                if (!PrototypeManager.TryIndex<EntityPrototype>(entry.ID, out var proto))
+                if (!PrototypeManager.TryIndex<EntityPrototype>(entry.Id, out var proto))
                 {
-                    Log.Error($"Unable to find entity prototype {entry.ID} on {ToPrettyString(uid)} vending.");
+                    Log.Error($"Unable to find entity prototype {entry.Id} on {ToPrettyString(uid)} vending.");
                     continue;
                 }
 
@@ -197,16 +197,16 @@ namespace Content.Server.VendingMachines
 
             if (forceEject)
             {
-                vendComponent.NextItemToEject = item.ID;
+                vendComponent.NextItemToEject = item.Id;
                 vendComponent.ThrowNextItem = throwItem;
-                var entry = GetEntry(uid, item.ID, item.Type, vendComponent);
+                var entry = GetEntry(uid, item.Id, item.Type, vendComponent);
                 if (entry != null)
                     entry.Amount--;
                 EjectItem(uid, vendComponent, forceEject);
             }
             else
             {
-                TryEjectVendorItem(uid, item.Type, item.ID, throwItem, user: null, vendComponent: vendComponent);
+                TryEjectVendorItem(uid, item.Type, item.Id, throwItem, user: null, vendComponent: vendComponent);
             }
         }
 

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -203,7 +203,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
         var entry = GetEntry(uid, itemId, type, vendComponent);
 
-        if (string.IsNullOrEmpty(entry?.ID))
+        if (string.IsNullOrEmpty(entry?.Id))
         {
             Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-invalid-item"), uid);
             Deny((uid, vendComponent));
@@ -219,7 +219,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
         // Start Ejecting, and prevent users from ordering while anim playing
         vendComponent.EjectEnd = Timing.CurTime + vendComponent.EjectDelay;
-        vendComponent.NextItemToEject = entry.ID;
+        vendComponent.NextItemToEject = entry.Id;
         vendComponent.ThrowNextItem = throwItem;
 
         if (TryComp(uid, out SpeakOnUIClosedComponent? speakComponent))

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -193,26 +193,23 @@ namespace Content.Shared.VendingMachines
         #endregion
     }
 
-    [Serializable, NetSerializable]
-    public sealed class VendingMachineInventoryEntry
+    [Serializable, NetSerializable, DataDefinition]
+    public sealed partial class VendingMachineInventoryEntry
     {
-        [ViewVariables(VVAccess.ReadWrite)]
         public InventoryType Type;
-        [ViewVariables(VVAccess.ReadWrite)]
-        public string ID;
-        [ViewVariables(VVAccess.ReadWrite)]
+        public string Id;
         public uint Amount;
         public VendingMachineInventoryEntry(InventoryType type, string id, uint amount)
         {
             Type = type;
-            ID = id;
+            Id = id;
             Amount = amount;
         }
 
         public VendingMachineInventoryEntry(VendingMachineInventoryEntry entry)
         {
             Type = entry.Type;
-            ID = entry.ID;
+            Id = entry.Id;
             Amount = entry.Amount;
         }
     }


### PR DESCRIPTION
This fix addresses an inability to save post-init maps with vending machines.