### PR TITLE
tweak: disable random characters in dev environment

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -39,6 +39,6 @@ preload_grids = false
 see_own_notes = true
 
 [ic]
-random_characters = true
+random_characters = false
 random_species_weights = ""
 ssd_sleep_time = 3600


### PR DESCRIPTION
sets the server config option for random characters to false, so you can be allowed to spawn in with specific characters and test the functions thereof. this made trying to test loadouts a major pain and I'm not entirely clear on whether it's more helpful to us right now so I figure it should be switched back off