### PR TITLE
fix: render weather over steel herringbone tiles

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -171,6 +171,7 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteelHerringbone
   heatCapacity: 10000
+  weather: true  # starcup - render weather over this for glacier station
 
 - type: tile
   id: FloorSteelDiagonalMini


### PR DESCRIPTION
We need this to render snow weather outside on Glacier station. The weather system at this point is very incomplete and could use a lot of dedicated care of its own. We don't have any means to explicitly render weather over a tile like we can explicitly block it, so this change is an ad-hoc "better-case" change.
