### PR TITLE
tweak: nerf cold protection of winter coats

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -10,7 +10,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
   - type: TemperatureProtection
     heatingCoefficient: 1.1
-    coolingCoefficient: 0.1
+    coolingCoefficient: 0.5  # starcup: nerf cold protection on winter coats
   - type: Item
     size: Normal
   - type: Armor


### PR DESCRIPTION
Winter coats currently negate 90% of cooling on their wearer. This change decreases that negation to 50%.

This means...

* For humans, a winter coat alone does not provide enough insulation to survive forever in the cold on Glacier station. It should take around five minutes before the player begins to take damage... at a rate of about 0.02 cold damage per second.
* For vulpekin, a winter coat alone is just fine. On Glacier station, their body temperature sinks no lower than about 257 K. They do not take damage at this temperature.
* For MKC, a winter coat is exceptionally sufficient. I don't believe their body temperature even drops below zero. No damage.

Other species are untested. I would expect humans to have the least cold protection, so any issues that crop up from this shouldn't be serious. Remember that raising your coat's hood will give you an extra 30% reduction to cooling.

But neither scarves nor winter boots grant any cooling reduction. Let's change that in the future, and then we'll further nerf winter coat protection again to compensate for that. We want vulnerable players to have to bundle up!



:cl:
- tweak: cooling insulation on winter coats has been nerfed somewhat