### PR TITLE
tweak: tone champagne ethanol content way the hell down

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -452,7 +452,7 @@
         factor: 3
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.3
+        amount: 0.06 # starcup
   fizziness: 0.8
 
 # Mixed Alcohol


### PR DESCRIPTION
## About the PR
brings the ethanol per tick of champagne from 0.3 down to 0.06, equivalent to wine

## Why / Balance
in what fucking world does champagne have more alcohol content than vodka. I'm bringing champagne's alcohol levels down to that of wine, because it is literally just wine, and so the crew can celebrate without dying of alcohol poisoning

**Changelog**
:cl:
- tweak: sharply reduced champagne's alcohol content to lower the fatality rate of celebrations at the bar