### PR TITLE
Add: Cold-weather clothing for pets!

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/pet_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/pet_inventory_template.yml
@@ -22,4 +22,23 @@
       components:
         - GasTank
 
+  - name: outerClothing
+    slotTexture: suit
+    slotFlags: OUTERCLOTHING
+    stripTime: 6
+    uiWindowPos: 1,1
+    strippingWindowPos: 1,2
+    displayName: Suit
+    whitelist:
+      tags:
+      - PetWearable
 
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 1,3
+    strippingWindowPos: 1,0
+    displayName: Head
+    whitelist:
+      tags:
+      - PetWearable


### PR DESCRIPTION
This PR will be adding cold-weather clothing for pets--a mix of winter coats and potentially one or two thematic hats.

The select hat/s (such as beanie or ushanka) perhaps ought to be given TemperatureProtection, but this change may be slightly beyond the scope of this PR.

## About the PR
[X] ~~Pets have a equipment slot for PetWearable outer clothing~~
[X] ~~Pets have an equipment slot for PetWearable hats.~~
[ ] At least 1 winter coat has been given sprites for the nine pets (cat, dog, fox, hamster, kangaroo, pig, possum, puppy, and sloth). Remember the hoods!
   [ ] Bonus Points: Create sprites for every departmental winter coat, so every department pet can be properly attired.
[ ] 1-2 winter-themed hats (such as beanies or ushankas) have been given sprites for the nine pets.

Likely outside the scope of the PR: Those winter-themed hats ought to be given some form of TemperatureProtection similar to that of hoods.

## Why / Balance
This change is obviously primarily about reducing friction on the Glacier map, where pets dying due to cold weather is extremely common and frustrating for all involved. "Pets just don't work on Glacier" is currently a common refrain.

This change also improves early gameplay, as characters can busy themselves at the start of Glacier with finding station pets and getting them dressed up properly.

Finally, I think giving the animals little outfits sounds really cute.

## Technical details
This should be entirely a yml/rsi change--just adding new sprites and giving pets a new equipment component. :)

**Changelog**
:cl:
- tweak: Pets now have an inventory slot for appropriately-tagged outer clothing.
- tweak: Pets now have an inventory slot for appropriate-tagged hats.