### PR TITLE
tweak: reduce fulton cloth cost

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/salvage.yml
+++ b/Resources/Prototypes/Recipes/Lathes/salvage.yml
@@ -26,7 +26,7 @@
   completetime: 1
   materials:
     Steel: 200
-    Cloth: 500
+    Cloth: 100 # starcup: 500 -> 100, a full stack of ten fultons should not cost 50 Cloth.
 
 - type: latheRecipe
   id: FultonBeacon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fulton cloth cost has been reduced from 5 -> 1 per fulton.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fultons need to be crafted one at a time, which means a crafting cost of 2 Steel + 5 Cloth is actually 20 Steel and 50 Cloth for a full stack of 10 fultons. This essentially requires mass ordering cloth from Cargo, as the only methods of 

## Technical details
<!-- Summary of code changes for easier review. -->
In lathes, inserting a single piece of material (say, a sheet of steel) adds 100 of that material to the lathe, and recipes typically cost increments of 100 units of materials to compensate. This is to allow for recipes to call for a fraction of a single piece of material, such as with raw ores and ore processors. This is why the code appears to reduce the material cost from 500 Cloth -> 100 Cloth.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: reduced the amount of cloth required to craft fultons from 5 -> 1