### PR TITLE
add: adds fultons + beacons as a T1 industrial research

### DIFF
--- a/Resources/Locale/en-US/_starcup/research/technologies.ftl
+++ b/Resources/Locale/en-US/_starcup/research/technologies.ftl
@@ -1,0 +1,1 @@
+research-technology-aerial-extraction = Aerial Extraction

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -15,6 +15,7 @@
 ## Dynamic
 
 - type: latheRecipePack
+  parent: Miningstarcup # starcup
   id: Mining
   recipes:
   - MiningDrill

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -59,8 +59,8 @@
   - PowerDrill
   - WelderExperimental
   - JawsOfLife
-  - Fulton
-  - FultonBeacon
+#  - Fulton # starcup: moved to the new Tier 1 Aerial Extraction research
+#  - FultonBeacon # starcup: moved to the new Tier 1 Aerial Extraction research
 
 - type: latheRecipePack
   id: AtmosTools

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -165,8 +165,8 @@
     - PowerDrill
     - JawsOfLife
     - BorgModuleAdvancedTool
-    - Fulton
-    - FultonBeacon
+#    - Fulton # starcup: moved to the new Tier 1 Aerial Extraction research
+#    - FultonBeacon # starcup: moved to the new Tier 1 Aerial Extraction research
 
 - type: technology
   id: MassExcavation

--- a/Resources/Prototypes/_starcup/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/_starcup/Recipes/Lathes/Packs/cargo.yml
@@ -1,0 +1,7 @@
+## Dynamic
+
+- type: latheRecipePack
+  id: Miningstarcup
+  recipes:
+  - Fulton
+  - FultonBeacon

--- a/Resources/Prototypes/_starcup/Research/industrial.yml
+++ b/Resources/Prototypes/_starcup/Research/industrial.yml
@@ -1,0 +1,14 @@
+# Tier 1
+
+- type: technology
+  id: AerialExtraction
+  name: research-technology-aerial-extraction
+  icon:
+    sprite: Objects/Tools/fulton.rsi
+    state: extraction_pack
+  discipline: Industrial
+  tier: 1
+  cost: 5000
+  recipeUnlocks:
+    - Fulton
+    - FultonBeacon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Removes fultons and fulton beacons from the Tier 2 Industrial tree research tech Advanced Tools
- Adds a new Tier 1 Industrial tree research tech, Aerial Extraction, which costs 5000 research points and unlocks fultons and fulton beacons.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, salvage has a hard time getting access to fultons and fulton beacons. They either need to find them as loot during the course of their work - entirely reliant on RNG - or they need to wait for Science to finish researching Advanced Tools, and as a Tier 2 research technology that can take some time.

This change seeks to make fultons and fulton beacons accessible earlier in the shift by making them a unique Tier 1 Industrial tree research tech, cutting the time it takes for Science to get access to fulton technology by what is hopefully a significant margin.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/bb7ec0db-53c3-4215-9a73-d5d8fca9c1cb)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Aerial Extraction, a new T1 industrial research tech that unlocks fultons and fulton beacons
- remove: the T2 industrial research tech Advanced Tools no longer unlocks fultons and fulton beacons