### PR TITLE
feat: directional curtains

### DIFF
--- a/Content.Client/_starcup/OrientationHint/OrientationHintSystem.cs
+++ b/Content.Client/_starcup/OrientationHint/OrientationHintSystem.cs
@@ -1,0 +1,22 @@
+using Content.Shared._starcup.OrientationHint;
+using Content.Shared.Examine;
+using Robust.Shared.Map;
+
+namespace Content.Client._starcup.OrientationHint;
+
+public sealed class OrientationHintSystem : EntitySystem
+{
+    [Dependency] private readonly EntityManager _entityManager = null!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<OrientationHintComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<OrientationHintComponent> ent, ref ExaminedEvent args)
+    {
+        _entityManager.SpawnEntity(ent.Comp.ExamineArrow, new EntityCoordinates(ent, 0, 0));
+    }
+}

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -739,7 +739,7 @@ namespace Content.Shared.Interaction
             var inRange = true;
             MapCoordinates originPos = default;
             var targetPos = _transform.ToMapCoordinates(otherCoordinates);
-            Angle targetRot = default;
+            Angle targetRot = other.Comp?.LocalRotation ?? default;  // starcup: previously `default`, interfered with curtains
 
             // So essentially:
             // 1. If fixtures available check nearest point. We take in coordinates / angles because we might want to use a lag compensated position

--- a/Content.Shared/_starcup/OrientationHint/OrientationHintComponent.cs
+++ b/Content.Shared/_starcup/OrientationHint/OrientationHintComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._starcup.OrientationHint;
+
+[RegisterComponent, AutoGenerateComponentState]
+public sealed partial class OrientationHintComponent : Component
+{
+    [AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public EntProtoId ExamineArrow = "TurnstileArrow";
+
+    /// <summary>
+    ///     The direction in which the examine arrow is facing, relative to the entity's rotation. Defaults to south.
+    /// </summary>
+    [AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public Angle Direction = Angle.Zero;
+}

--- a/Resources/Prototypes/_starcup/Entities/Structures/curtains.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/curtains.yml
@@ -1,0 +1,110 @@
+- type: entity
+  id: BaseCurtainsDirectional
+  parent: BaseCurtains
+  abstract: true
+  components:
+  - type: OrientationHint
+  - type: WallMount
+    arc: 90
+  - type: Clickable
+  - type: InteractionOutline
+
+- type: entity
+  id: HospitalCurtainsDirectional
+  parent: [ BaseCurtainsDirectional, HospitalCurtains ]
+  suffix: Hospital, Directional
+
+- type: entity
+  id: HospitalCurtainsOpenDirectional
+  parent: [ BaseCurtainsDirectional, HospitalCurtainsOpen ]
+  suffix: Hospital, Open, Directional
+
+- type: entity
+  id: CurtainsBlackDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsBlack ]
+  suffix: Fancy black, Directional
+
+- type: entity
+  id: CurtainsBlackOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsBlackOpen ]
+  suffix: Fancy black, Open, Directional
+
+- type: entity
+  id: CurtainsBlueDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsBlue ]
+  suffix: Fancy blue, Directional
+
+- type: entity
+  id: CurtainsBlueOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsBlueOpen ]
+  suffix: Fancy blue, Open, Directional
+
+- type: entity
+  id: CurtainsCyanDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsCyan ]
+  suffix: Fancy cyan, Directional
+
+- type: entity
+  id: CurtainsCyanOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsCyanOpen ]
+  suffix: Fancy cyan, Open, Directional
+
+- type: entity
+  id: CurtainsGreenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsGreen ]
+  suffix: Fancy green, Directional
+
+- type: entity
+  id: CurtainsGreenOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsGreenOpen ]
+  suffix: Fancy green, Open, Directional
+
+- type: entity
+  id: CurtainsOrangeDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsOrange ]
+  suffix: Fancy orange, Directional
+
+- type: entity
+  id: CurtainsOrangeOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsOrangeOpen ]
+  suffix: Fancy orange, Open, Directional
+
+- type: entity
+  id: CurtainsPinkDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsPink ]
+  suffix: Fancy pink, Directional
+
+- type: entity
+  id: CurtainsPinkOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsPinkOpen ]
+  suffix: Fancy pink, Open, Directional
+
+- type: entity
+  id: CurtainsPurpleDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsPurple ]
+  suffix: Fancy purple, Directional
+
+- type: entity
+  id: CurtainsPurpleOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsPurpleOpen ]
+  suffix: Fancy purple, Open, Directional
+
+- type: entity
+  id: CurtainsRedDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsRed ]
+  suffix: Fancy red, Directional
+
+- type: entity
+  id: CurtainsRedOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsRedOpen ]
+  suffix: Fancy red, Open, Directional
+
+- type: entity
+  id: CurtainsWhiteDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsWhite ]
+  suffix: Fancy white, Directional
+
+- type: entity
+  id: CurtainsWhiteOpenDirectional
+  parent: [ BaseCurtainsDirectional, CurtainsWhiteOpen ]
+  suffix: Fancy white, Open, Directional


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
adds directional window curtains, which can only be opened from one side

also adds the OrientationHint component and system, which generalizes the examine-to-show-direction functionality of e.g. teg circulators and turnstiles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
a curtain that can be opened from outside of the station as easily as it can be closed from inside it is a complete value cancellation

allows medical to have curtains on the window instead of taking up a full tile of space

## Technical details
<!-- Summary of code changes for easier review. -->
curtains already have a WallMount component but are configured for 360 degrees. this change adds new entity prototypes for each existing curtain that drops this angle to 90 degrees, effectively making them direction-dependent for interactions.

this pull request also adds a new component/system pair for generalizing client-side directionality hints for entities. examining these directional curtains will display an arrow indicating on which side of the curtain they may be interacted from.

hint: spawning an arrow (a literal arrow, like a projectile) and rotating it in the cardinal directions will also demonstrate directionality (from user to curtain.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="393" alt="Content Client_wRfqtQ6Rga" src="https://github.com/user-attachments/assets/9932a1a9-931b-49f2-9b3e-6cfd7f3c56ea" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: added new variants of curtains that may only be opened or closed from one side.