### PR TITLE
fix: no longer rotate held items unless hovering over a storage window

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -181,11 +181,6 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
         _input.FirstChanceOnKeyEvent += OnMiddleMouse;
     }
 
-    public void OnSystemUnloaded(StorageSystem system)
-    {
-        _input.FirstChanceOnKeyEvent -= OnMiddleMouse;
-    }
-
     /// One might ask, Hey Emo, why are you parsing raw keyboard input just to rotate a rectangle?
     /// The answer is, that input bindings regarding mouse inputs are always intercepted by the UI,
     /// thus, if i want to be able to rotate my damn piece anywhere on the screen,
@@ -225,13 +220,31 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
         if (!IsDragging && EntityManager.System<HandsSystem>().GetActiveHandEntity() == null)
             return;
 
+        // begin starcup: disable original logic for rotation fix
         //clamp it to a cardinal.
+        // DraggingRotation = (DraggingRotation + Math.PI / 2f).GetCardinalDir().ToAngle();
+        // if (DraggingGhost != null)
+        //     DraggingGhost.Location.Rotation = DraggingRotation;
+
+        // if (IsDragging || UIManager.CurrentlyHovered is StorageWindow)
+        //     keyEvent.Handle();
+        // end starcup
+
+        // begin starcup: only rotate items if we're hovering over a storage window
+        if (DraggingGhost is null && UIManager.CurrentlyHovered is not StorageWindow)
+            return;
+
         DraggingRotation = (DraggingRotation + Math.PI / 2f).GetCardinalDir().ToAngle();
-        if (DraggingGhost != null)
+        if (DraggingGhost is not null)
             DraggingGhost.Location.Rotation = DraggingRotation;
 
-        if (IsDragging || UIManager.CurrentlyHovered is StorageWindow)
-            keyEvent.Handle();
+        keyEvent.Handle();
+        // end starcup
+    }
+
+    public void OnSystemUnloaded(StorageSystem system)
+    {
+        _input.FirstChanceOnKeyEvent -= OnMiddleMouse;
     }
 
     private void OnPiecePressed(GUIBoundKeyEventArgs args, StorageWindow window, ItemGridPiece control)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You know how sometimes you pick up an item and go to use it, but no matter how hard you try to avoid it, it always goes back to your inventory *rotated?*

Yeah, this makes that not happen anymore.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Friction level: 10
Effort level: 1

You will never have to spam right click every single time you move something back into your storage ever again.

## Technical details
<!-- Summary of code changes for easier review. -->
The original bit of relevant code was something like this (with my explanatory comments added):
```cs
        // <-- You have something in your hand and you right-clicked (or whatever your rotate key bind is)
        DraggingRotation = (DraggingRotation + Math.PI / 2f).GetCardinalDir().ToAngle();  // <-- Rotate placement angle by 90 degrees
        if (DraggingGhost != null)
            DraggingGhost.Location.Rotation = DraggingRotation;  // <-- If you were dragging the item in your storage, also rotate the 'ghost' of the item visually.

        if (IsDragging || UIManager.CurrentlyHovered is StorageWindow)  // <-- Don't click-through to any UI component beneath this
            keyEvent.Handle();
```

But now we perform this check before doing any of that:
```cs
    if (DraggingGhost is null && UIManager.CurrentlyHovered is not StorageWindow)
        return;
```

... which guarantees that there are now two conditions to rotate the storage placement of a held item:
- you are dragging it OR
- you are hovering over a storage window

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: You will never again accidentally rotate a held item.
