### PR TITLE
feat: add wall ambient occlusion [early merge]

### DIFF
--- a/Content.Client/Light/AmbientOcclusionOverlay.cs
+++ b/Content.Client/Light/AmbientOcclusionOverlay.cs
@@ -1,0 +1,74 @@
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Light;
+
+public sealed class AmbientOcclusionOverlay : Overlay
+{
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
+
+    private IRenderTexture? _aoTarget;
+
+    public AmbientOcclusionOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        ZIndex = AfterLightTargetOverlay.ContentZIndex + 1;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var viewport = args.Viewport;
+        var mapId = args.MapId;
+        var worldBounds = args.WorldBounds;
+        var worldHandle = args.WorldHandle;
+        var color = Color.FromHex("#04080FAA");
+        //var color = Color.Red;
+        var target = viewport.RenderTarget;
+        var lightScale = target.Size / (Vector2) viewport.Size;
+        var scale = viewport.RenderScale / (Vector2.One / lightScale);
+
+        if (_aoTarget?.Texture.Size != target.Size)
+        {
+            _aoTarget?.Dispose();
+            _aoTarget = _clyde.CreateRenderTarget(target.Size, new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "ambient-occlusion-target");
+        }
+
+        args.WorldHandle.RenderInRenderTarget(_aoTarget,
+            () =>
+            {
+                var invMatrix = _aoTarget.GetWorldToLocalMatrix(viewport.Eye!, scale);
+
+                var query = _entManager.System<OccluderSystem>();
+                var xformSystem = _entManager.System<SharedTransformSystem>();
+
+                foreach (var entry in query.QueryAabb(mapId, worldBounds))
+                {
+                    DebugTools.Assert(entry.Component.Enabled);
+                    var matrix = xformSystem.GetWorldMatrix(entry.Transform);
+                    var localMatrix = Matrix3x2.Multiply(matrix, invMatrix);
+
+                    worldHandle.SetTransform(localMatrix);
+                    // 4 pixels
+                    worldHandle.DrawRect(Box2.UnitCentered.Enlarged(4f / EyeManager.PixelsPerMeter), Color.White);
+                }
+            }, Color.Transparent);
+
+        _clyde.BlurRenderTarget(viewport, _aoTarget, _aoTarget, viewport.Eye!, 14f);
+
+        args.WorldHandle.RenderInRenderTarget(target,
+            () =>
+            {
+                var localMatrix = target.GetWorldToLocalMatrix(viewport.Eye!, viewport.RenderScale);
+                worldHandle.SetTransform(localMatrix);
+
+                worldHandle.DrawTextureRect(_aoTarget.Texture, worldBounds, color);
+            }, null);
+
+        args.WorldHandle.SetTransform(Matrix3x2.Identity);
+    }
+}

--- a/Content.Client/Light/AmbientOcclusionOverlay.cs
+++ b/Content.Client/Light/AmbientOcclusionOverlay.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Client.Light;
 
+// starcup: #38276 early merge
 public sealed class AmbientOcclusionOverlay : Overlay
 {
     [Dependency] private readonly IClyde _clyde = default!;

--- a/Content.Client/Light/EntitySystems/PlanetLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/PlanetLightSystem.cs
@@ -1,16 +1,47 @@
+using Content.Shared.CCVar;
 using Robust.Client.Graphics;
+using Robust.Shared.Configuration;
 
 namespace Content.Client.Light.EntitySystems;
 
 public sealed class PlanetLightSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfgManager = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
+
+    public bool AmbientOcclusion
+    {
+        get => _ambientOcclusion;
+        set
+        {
+            if (_ambientOcclusion == value)
+                return;
+
+            _ambientOcclusion = value;
+
+            if (value)
+            {
+                _overlayMan.AddOverlay(new AmbientOcclusionOverlay());
+            }
+            else
+            {
+                _overlayMan.RemoveOverlay<AmbientOcclusionOverlay>();
+            }
+        }
+    }
+
+    private bool _ambientOcclusion;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<GetClearColorEvent>(OnClearColor);
+
+        _cfgManager.OnValueChanged(CCVars.AmbientOcclusion, val =>
+        {
+            AmbientOcclusion = val;
+        }, true);
 
         _overlayMan.AddOverlay(new BeforeLightTargetOverlay());
         _overlayMan.AddOverlay(new RoofOverlay(EntityManager));

--- a/Content.Client/Light/EntitySystems/PlanetLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/PlanetLightSystem.cs
@@ -1,14 +1,15 @@
-using Content.Shared.CCVar;
+using Content.Shared.CCVar;  // starcup: #38276 early merge
 using Robust.Client.Graphics;
-using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;  // starcup: #38276 early merge
 
 namespace Content.Client.Light.EntitySystems;
 
 public sealed class PlanetLightSystem : EntitySystem
 {
-    [Dependency] private readonly IConfigurationManager _cfgManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfgManager = default!;  // starcup: #38276 early merge
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
 
+    // begin starcup: #38276 early merge
     public bool AmbientOcclusion
     {
         get => _ambientOcclusion;
@@ -31,6 +32,7 @@ public sealed class PlanetLightSystem : EntitySystem
     }
 
     private bool _ambientOcclusion;
+    // end starcup
 
     public override void Initialize()
     {
@@ -38,10 +40,12 @@ public sealed class PlanetLightSystem : EntitySystem
 
         SubscribeLocalEvent<GetClearColorEvent>(OnClearColor);
 
+        // begin starcup: #38276 early merge
         _cfgManager.OnValueChanged(CCVars.AmbientOcclusion, val =>
         {
             AmbientOcclusion = val;
         }, true);
+        // end starcup
 
         _overlayMan.AddOverlay(new BeforeLightTargetOverlay());
         _overlayMan.AddOverlay(new RoofOverlay(EntityManager));

--- a/Content.Client/Light/RoofOverlay.cs
+++ b/Content.Client/Light/RoofOverlay.cs
@@ -62,14 +62,14 @@ public sealed class RoofOverlay : Overlay
         worldHandle.RenderInRenderTarget(target,
             () =>
             {
+                var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
+
                 for (var i = 0; i < _grids.Count; i++)
                 {
                     var grid = _grids[i];
 
                     if (!_entManager.TryGetComponent(grid.Owner, out ImplicitRoofComponent? roof))
                         continue;
-
-                    var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
 
                     var gridMatrix = _xformSystem.GetWorldMatrix(grid.Owner);
                     var matty = Matrix3x2.Multiply(gridMatrix, invMatrix);
@@ -94,12 +94,12 @@ public sealed class RoofOverlay : Overlay
         worldHandle.RenderInRenderTarget(target,
             () =>
             {
+                var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
+
                 foreach (var grid in _grids)
                 {
                     if (!_entManager.TryGetComponent(grid.Owner, out RoofComponent? roof))
                         continue;
-
-                    var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
 
                     var gridMatrix = _xformSystem.GetWorldMatrix(grid.Owner);
                     var matty = Matrix3x2.Multiply(gridMatrix, invMatrix);

--- a/Content.Client/Light/RoofOverlay.cs
+++ b/Content.Client/Light/RoofOverlay.cs
@@ -62,7 +62,7 @@ public sealed class RoofOverlay : Overlay
         worldHandle.RenderInRenderTarget(target,
             () =>
             {
-                var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
+                var invMatrix = target.GetWorldToLocalMatrix(eye, scale);  // starcup: #38276 early merge
 
                 for (var i = 0; i < _grids.Count; i++)
                 {
@@ -70,6 +70,8 @@ public sealed class RoofOverlay : Overlay
 
                     if (!_entManager.TryGetComponent(grid.Owner, out ImplicitRoofComponent? roof))
                         continue;
+
+                    // var invMatrix = target.GetWorldToLocalMatrix(eye, scale);  // starcup: #38276 early merge
 
                     var gridMatrix = _xformSystem.GetWorldMatrix(grid.Owner);
                     var matty = Matrix3x2.Multiply(gridMatrix, invMatrix);
@@ -94,12 +96,14 @@ public sealed class RoofOverlay : Overlay
         worldHandle.RenderInRenderTarget(target,
             () =>
             {
-                var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
+                var invMatrix = target.GetWorldToLocalMatrix(eye, scale);  // starcup: #38276 early merge
 
                 foreach (var grid in _grids)
                 {
                     if (!_entManager.TryGetComponent(grid.Owner, out RoofComponent? roof))
                         continue;
+
+                    // var invMatrix = target.GetWorldToLocalMatrix(eye, scale);  // starcup: #38276 early merge
 
                     var gridMatrix = _xformSystem.GetWorldMatrix(grid.Owner);
                     var matty = Matrix3x2.Multiply(gridMatrix, invMatrix);

--- a/Content.Shared/CCVar/CCVars.Lighting.cs
+++ b/Content.Shared/CCVar/CCVars.Lighting.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    public static readonly CVarDef<bool> AmbientOcclusion =
+        CVarDef.Create("light.ambient_occlusion", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/CCVar/CCVars.Lighting.cs
+++ b/Content.Shared/CCVar/CCVars.Lighting.cs
@@ -2,6 +2,7 @@ using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
+// starcup: #38276 early merge
 public sealed partial class CCVars
 {
     public static readonly CVarDef<bool> AmbientOcclusion =


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Early merge of `https://github.com/space-wizards/space-station-14/pull/38276`

> Most 13 servers have some form of AO.
> 
> Want to add some more CVARs for tweaking it. At the moment it draws to the entity render target rather than lighting as well, plus it also shows in space which may not be ideal and may need stencilling?
> 
> Also want to add it to graphics too.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Without:
<img width="961" alt="Content Client_9ziOy1CCkn" src="https://github.com/user-attachments/assets/e22349e2-8d2c-44bb-8316-b62d6c5ee233" />
With:
<img width="962" alt="Content Client_Ef8rFnlu3h" src="https://github.com/user-attachments/assets/c0cc16c5-1399-46dd-ba59-5c6b5ddd5799" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Included an early merge of wizden's partial ambient occlusion lighting.