### PR TITLE
tweak: customizable clown masks

### DIFF
--- a/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
@@ -26,6 +26,8 @@ loadout-group-chaplain-id-starcup = Chaplain PDA
 
 loadout-group-chef-shoes = Chef shoes
 
+loadout-group-clown-mask = Clown mask
+
 loadout-group-janitor-shoes = Janitor shoes
 loadout-group-janitor-light = Janitor flashlight
 

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -190,6 +190,7 @@
   groups:
   - GroupTankHarness
   - ClownHead
+  - ClownMask # starcup
   - Scarfs # DeltaV
   - ClownJumpsuit
   - ClownBackpack

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -28,7 +28,7 @@
 - type: startingGear
   id: ClownGear
   equipment:
-    mask: ClothingMaskClown
+#    mask: ClothingMaskClown # starcup: replaced with loadout
     pocket1: BikeHorn
     pocket2: ClownRecorder
 #    id: ClownPDA # DeltaV: different PDAs in loadouts

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/clown.yml
@@ -1,3 +1,49 @@
+# Mask
+- type: loadout
+  id: ClownMask
+  equipment:
+    mask: ClothingMaskClown
+
+- type: loadout
+  id: BlushingClownMask
+  equipment:
+    mask: ClothingMaskBlushingClown
+
+- type: loadout
+  id: RatMask
+  equipment:
+    mask: ClothingMaskRat
+
+- type: loadout
+  id: FoxMask
+  equipment:
+    mask: ClothingMaskFox
+
+- type: loadout
+  id: BeeMask
+  equipment:
+    mask: ClothingMaskBee
+
+- type: loadout
+  id: BearMask
+  equipment:
+    mask: ClothingMaskBear
+
+- type: loadout
+  id: RavenMask
+  equipment:
+    mask: ClothingMaskRaven
+
+- type: loadout
+  id: JackalMask
+  equipment:
+    mask: ClothingMaskJackal
+
+- type: loadout
+  id: BatMask
+  equipment:
+    mask: ClothingMaskBat
+
 # Shoes
 - type: loadout
   id: ClownWinterBoots

--- a/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
@@ -112,6 +112,22 @@
   - BlackShoes
   - ChefWinterBoots
 
+## Clown
+- type: loadoutGroup
+  id: ClownMask
+  name: loadout-group-clown-mask
+  minLimit: 0
+  loadouts:
+  - ClownMask
+  - BlushingClownMask
+  - RatMask
+  - FoxMask
+  - BeeMask
+  - BearMask
+  - RavenMask
+  - JackalMask
+  - BatMask
+
 ## Janitor
 - type: loadoutGroup
   id: JanitorShoes


### PR DESCRIPTION
## About the PR
this introduces a new mask loadout group for clowns, introducing a variety of alternatives (mostly the various animal masks) to the standard clown mask—or the option to not use a mask at all!

## Why / Balance
although there are a few alternate costumes available for the clown, you're always stuck wearing the same mask, which can be rather unflattering for some getups and may not be condusive to the kind of clownery people want to get up to! this not only changes that, but encourages this variety by supplying a multitude of alternatives

**Changelog**
:cl:
- tweak: clowns can now select from a variety of different masks in their loadout!