### PR TITLE
tweak: removed priority mail

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Structures/Machines/mailTeleporter.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Structures/Machines/mailTeleporter.yml
@@ -6,6 +6,7 @@
   components:
   - type: MailTeleporter
     radioNotification: true
+    priorityChance: 0  # starcup: no priority mail
   - type: InteractionOutline
   - type: Physics
     bodyType: Static


### PR DESCRIPTION
## About the PR
Removed chance for the Mail Teleporter to generate priority mail, meaning mail that penalizes Couriers for delivering it late will no longer naturally spawn.

The Priority label can still be spawned manually (mailto [playerid] [containerid] false true), and it may be useful now in clarifying when mail is actually important, such as the ACO receiving their new ID.


## Why / Balance
Priority mail is generally a source of needless stress, and it disincentivizes the crew from leaving the mailbox on, which limits curators' chances to send specialized mail deliveries.

Its intention was clearly to offer Couriers some extra "challenge", but forcing a breakneck pace only limits Couriers' opportunities to roleplay and interact in a "non-viable" manner. Being penalized because the intended recipient has gone planetside is not a fun or compelling challenge for anyone.

**Changelog**
:cl:
- tweak: added a trait so normal Mail Teleporters won't spawn priority mail randomly.