### PR TITLE
tweak: give harpies access to rodentia bat markings

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Customization/Markings/rodentia.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Customization/Markings/rodentia.yml
@@ -34,7 +34,7 @@
   id: RodentiaHeadTopEarBat
   markingCategory: HeadTop
   bodyPart: HeadTop
-  speciesRestriction: [Rodentia]
+  speciesRestriction: [Rodentia, Harpy] # starcup - added Harpies
   sprites:
     - sprite: _DeltaV/Mobs/Customization/Rodentia/ear_markings.rsi
       state: bat
@@ -43,7 +43,7 @@
   id: RodentiaHeadTopEarBatLarge
   markingCategory: HeadTop
   bodyPart: HeadTop
-  speciesRestriction: [Rodentia]
+  speciesRestriction: [Rodentia, Harpy] # starcup - added Harpies
   sprites:
     - sprite: _DeltaV/Mobs/Customization/Rodentia/ear_markings.rsi
       state: bat_large
@@ -136,7 +136,7 @@
   id: RodentiaSnoutBat
   markingCategory: Snout
   bodyPart: Snout
-  speciesRestriction: [Rodentia]
+  speciesRestriction: [Rodentia, Harpy] # starcup - added Harpies
   sprites:
     - sprite: _DeltaV/Mobs/Customization/Rodentia/snout_markings.rsi
       state: bat
@@ -147,7 +147,7 @@
   id: RodentiaSnoutBatCounter
   markingCategory: Snout
   bodyPart: Snout
-  speciesRestriction: [Rodentia]
+  speciesRestriction: [Rodentia, Harpy] # starcup - added Harpies
   sprites:
     - sprite: _DeltaV/Mobs/Customization/Rodentia/snout_markings.rsi
       state: bat
@@ -363,7 +363,7 @@
   id: RodentiaTailShort
   markingCategory: Tail
   bodyPart: Tail
-  speciesRestriction: [Rodentia]
+  speciesRestriction: [Rodentia, Harpy] # starcup - added Harpies
   sprites:
     - sprite: _DeltaV/Mobs/Customization/Rodentia/tail_markings.rsi
       state: short


### PR DESCRIPTION
## About the PR
Gave harpies access to rodentias' bat ear and bat nose markings, plus the short tail.

## Why / Balance
Harpies have bat wings! It feels nice to give them the option of bat facial features. They already get the option of feathered ear tufts, after all, so there's precedent for harpies having _birdy_ facial features.

## Technical details
Just added Harpies to a few prototypes in the Rodentia file.

## Media
![image](https://github.com/user-attachments/assets/7adb82d1-594a-4d37-915b-aba42741c89a)
![image](https://github.com/user-attachments/assets/f07c307c-316e-40a8-aca7-e9327b002ff4)
![image](https://github.com/user-attachments/assets/9121d065-bcb4-459d-b982-c97dad870565)

**Changelog**
:cl:
- tweak: Gave Harpies access to Rodentia's bat markings