### PR TITLE
Sec and Med vend QoL Ops: Add new sec and EMT gear to SecTech, e-pens to Med vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -6,6 +6,7 @@
     Ointment: 5
     Bloodpack: 5
     ChemistryBottleEpinephrine: 3
+    EmergencyMedipen: 4 # Starcup - Added e-pens to the NanoMedPlus. Intended for emergency doctor use, or spare paramedic supplies.
     Syringe: 5
     BoxBottle: 3
     ClothingEyesHudMedical: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -20,6 +20,9 @@
     RiotLaserShield: 2
     RiotBulletShield: 2
     RadioHandheldSecurity: 5
+    Bola: 4 # Starcup - Added bolas to the SecTech
+    ClothingHeadHelmetBasic: 3 # Starcup - Added helmets to the SecTech
+    EmergencyMedipen: 4 # Starcup- Added e-pens to SecTech. Meant to encourage Security to be first responders
   # security officers need to follow a diet regimen!
   contrabandInventory:
     WeaponMeleeNeedle: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -22,10 +22,12 @@
     RadioHandheldSecurity: 5
     Bola: 4 # Starcup - Added bolas to the SecTech
     ClothingHeadHelmetBasic: 3 # Starcup - Added helmets to the SecTech
-    EmergencyMedipen: 4 # Starcup- Added e-pens to SecTech. Meant to encourage Security to be first responders
+    EmergencyMedipen: 4 # Starcup - Added e-pens to SecTech. Meant to encourage Security to be first responders
+    ClothingBeltMedicalEMT: 2 # Starcup - Added EMT belts to SecTech. Meant to encourage Security to be first responders and cooperate with medical
   # security officers need to follow a diet regimen!
   contrabandInventory:
     WeaponMeleeNeedle: 2
     FoodDonutHomer: 12
     FoodBoxDonut: 2
+    ClothingBeltMedicalEMTFilled: 1 # Starcup - Added filled EMT belts to SecTech. Filled is in contra inv because of medical goodies.
     #box evidence

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
@@ -5,6 +5,7 @@
     Ointment: 3
     Bloodpack: 3
     ChemistryBottleEpinephrine: 3
+    EmergencyMedipen: 2 # Starcup - Added e-pens to the NanoMed. Intended for emergency doctor use, or spare paramedic supplies.
     Syringe: 3
   contrabandInventory:
     PowerCellSmall: 2


### PR DESCRIPTION

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
Security should be encouraged to be first responders. They care about the crew safety first. Giving them things like bolas, easier to access helmets, and e-pens should incentivize them to be safer and keep crit crew stable. NanoMeds sporting e-pens is mainly QoL for paramedics or general medbay emergencies.

**SecTech has gained:**
- Bolas
- Helmet
- Emergency medipens
- Unfilled EMT belt. Filled EMT belt if you hack it

**Both versions of NanoMed gained:**
- Emergency medipens
## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
All YML in the respective vending machines.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->
Image of a hyper realistic vending machine here.
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added bolas, EMT belts (filled belt if hacked), emergency medipens, and helmets to the SecTech! NanoMeds now also carry a few emergency medipens.