### PR TITLE
fix: add missing comment to development.toml

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -39,6 +39,7 @@ preload_grids = false
 see_own_notes = true
 
 [ic]
+# starcup: disable random characters
 random_characters = false
 random_species_weights = ""
 ssd_sleep_time = 3600


### PR DESCRIPTION
whoops! that's not in the starcup namespace