### PR TITLE
fix: allow delaying round start by negative time

### DIFF
--- a/Content.Server/GameTicking/Commands/DelayStartCommand.cs
+++ b/Content.Server/GameTicking/Commands/DelayStartCommand.cs
@@ -35,7 +35,7 @@ namespace Content.Server.GameTicking.Commands
                 return;
             }
 
-            if (!uint.TryParse(args[0], out var seconds) || seconds == 0)
+            if (!int.TryParse(args[0], out var seconds) || seconds == 0)
             {
                 shell.WriteLine($"{args[0]} isn't a valid amount of seconds.");
                 return;


### PR DESCRIPTION
Now there's a way to deal with the delayed start round timer being too long by delaying it with negative seconds.

## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
single bit change

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The `delayroundstart` command can now take a negative number of seconds.