### PR TITLE
tweak: gave more species undergarments/makeup

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -1,11 +1,11 @@
 # These options are kept very sparse to not put emphasis on nudity, and to provide a base for players to feel comfortable with.
-# It's unlikely more will be added to upstream for cosmetic reasons. 
+# It's unlikely more will be added to upstream for cosmetic reasons.
 
 - type: marking
   id: UndergarmentBottomBoxers
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null
@@ -18,7 +18,7 @@
   id: UndergarmentBottomBriefs
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null
@@ -31,7 +31,7 @@
   id: UndergarmentBottomSatin
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null
@@ -44,7 +44,7 @@
   id: UndergarmentTopBra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null
@@ -57,7 +57,7 @@
   id: UndergarmentTopSportsbra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null
@@ -70,7 +70,7 @@
   id: UndergarmentTopBinder
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null
@@ -83,7 +83,7 @@
   id: UndergarmentTopTanktop
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Felinid, IPC, Oni, Rodentia, Vulpkanin] # starcup - added Felinid, IPC, Oni, Rodentia, Vulp
   coloring:
     default:
       type: null

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Customization/Markings/makeup.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Customization/Markings/makeup.yml
@@ -2,7 +2,7 @@
   id: MakeupLips
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Dwarf, Human, SlimePerson, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
+  speciesRestriction: [Dwarf, Human, SlimePerson, Felinid, Oni, Harpy, Rodentia] # Delta V - Felinid, Oni, Harpy # starcup - Rodentia
   coloring:
     default:
       type:
@@ -16,7 +16,7 @@
   id: MakeupBlush
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Dwarf, Human, Reptilian, SlimePerson, Felinid, Oni, Vulpkanin, Harpy] # Delta V - Felinid, Oni, Vulpkanin, Harpy
+  speciesRestriction: [Dwarf, Human, Reptilian, SlimePerson, Felinid, Oni, Vulpkanin, Rodentia] # Delta V - Felinid, Oni, Vulpkanin # starcup - Rodentia
   coloring:
     default:
       type:
@@ -30,7 +30,7 @@
   id: MakeupNailPolishRight
   bodyPart: RHand
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin, Rodentia] # Delta V - Felinid, Oni, Vulpkanin # starcup - Rodentia
   coloring:
     default:
       type:
@@ -44,7 +44,7 @@
   id: MakeupNailPolishLeft
   bodyPart: LHand
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin, Rodentia] # Delta V - Felinid, Oni, Vulpkanin # starcup - Rodentia
   coloring:
     default:
       type:

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Customization/Markings/makeup.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Customization/Markings/makeup.yml
@@ -16,7 +16,7 @@
   id: MakeupBlush
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Dwarf, Human, Reptilian, SlimePerson, Felinid, Oni, Vulpkanin, Rodentia] # Delta V - Felinid, Oni, Vulpkanin # starcup - Rodentia
+  speciesRestriction: [Dwarf, Human, Reptilian, SlimePerson, Felinid, Oni, Vulpkanin, Rodentia, Harpy] # Delta V - Felinid, Oni, Vulpkanin # starcup - Rodentia, Harpy
   coloring:
     default:
       type:

--- a/Resources/Prototypes/_DeltaV/Species/Oni.yml
+++ b/Resources/Prototypes/_DeltaV/Species/Oni.yml
@@ -33,6 +33,14 @@
     Snout:
       points: 2
       required: false
+    # begin starcup
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
+    # end starcup
     Chest:
       points: 1
       required: false

--- a/Resources/Prototypes/_DeltaV/Species/felinid.yml
+++ b/Resources/Prototypes/_DeltaV/Species/felinid.yml
@@ -27,6 +27,14 @@
       points: 1
       required: true
       defaultMarkings: [ FelinidEarsBasic ]
+# begin starcup
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
+# end starcup
     Chest:
       points: 4 # Frontier 1<4
       required: false

--- a/Resources/Prototypes/_DeltaV/Species/harpy.yml
+++ b/Resources/Prototypes/_DeltaV/Species/harpy.yml
@@ -48,6 +48,11 @@
       points: 1
       required: true
       defaultMarkings: [ HarpyEarsDefault ]
+    # begin starcup (no undershirts, wings get in the way and I don't know how to layer them differently)
+    UndergarmentBottom:
+      points: 1
+      required: false
+    # end starcup
     Chest:
       points: 1
       required: true

--- a/Resources/Prototypes/_DeltaV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DeltaV/Species/rodentia.yml
@@ -24,6 +24,8 @@
     Hair: MobHumanoidAnyMarking
     FacialHair: MobHumanoidAnyMarking
     Snout: MobHumanoidAnyMarking
+    UndergarmentTop: MobHumanoidAnyMarking # starcup
+    UndergarmentBottom: MobHumanoidAnyMarking # starcup
     Chest: MobRodentiaTorso
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
@@ -67,6 +69,14 @@
     HeadSide:
       points: 1
       required: false
+    # begin starcup
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
+    # end starcup
     Chest:
       points: 2
       required: false

--- a/Resources/Prototypes/_DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DeltaV/Species/vulpkanin.yml
@@ -20,6 +20,8 @@
     FacialHair: MobHumanoidAnyMarking
     Snout: MobHumanoidAnyMarking
     Chest: MobVulpkaninTorso
+    UndergarmentTop: MobHumanoidAnyMarking # starcup
+    UndergarmentBottom: MobHumanoidAnyMarking # starcup
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking
@@ -58,6 +60,14 @@
     Snout:
       points: 1
       required: false
+    # begin starcup
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
+    # end starcup
     HeadTop:
       points: 1
       required: true

--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -36,6 +36,8 @@
     HeadSide: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking
     Hair: MobHumanoidMarkingMatchSkin
+    UndergarmentTop: MobHumanoidAnyMarking # starcup
+    UndergarmentBottom: MobHumanoidAnyMarking # starcup
     Chest: MobIPCTorso
     LArm: MobIPCLArm
     RArm: MobIPCRArm
@@ -59,6 +61,14 @@
       points: 1
       required: true
       defaultMarkings: [ MobIPCHeadDefault ]
+    # begin starcup
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
+      # end starcup
     Chest:
       points: 1
       required: true


### PR DESCRIPTION
Up until now, only the core species have had access to the Upstream underwear markings. This has been fixed. Now, everyone but harpies will be able to wear undershirts and sports bras!

Additionally, added Rodentia to the whitelist for makeup markings! That's to say, blush, lips, and nail polish. Harpies get blush, too. <3

## Why / Balance
The omissions were not deliberate to begin with, just a mishap of timings and many downstreams having their own alternative underwear systems.

Sadly, harpies will not be able to wear underclothing (or headcoverings, incidentally) until someone figures out the layering issues for it with the wings.

I was tempted to give MKCs blush, but I held off for now. For now.

**Changelog**
:cl:
- tweak: Added Felinids, Vulpekin, Rodentia, and MKCs to the undergarments whitelists.
- tweak: Gave Rodentia and Harpies access to blush, lipstick, and nail polish markings.