### PR TITLE
tweak: increase power outage event reoccurence delay

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -370,7 +370,7 @@
         volume: -4
     duration: 60
     maxDuration: 120
-    reoccurrenceDelay: 5 # starcup: added to prevent constant power outages on lowpop survival
+    reoccurrenceDelay: 9 # starcup: added to prevent constant power outages on lowpop survival
   - type: PowerGridCheckRule
 
 - type: entity


### PR DESCRIPTION
Increases the minimum time between Power Outage events from 5 -> 9 mins

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
The PowerGridCheck event lasts for 1-2 minutes and completely disrupts progress on a variety of jobs during that period, and testing the delay we originally added in conjunction with Survival's reduced time between events has shown that a 5-minute delay is not long enough to prevent frustration from building amongst the crew. This is admittedly a bandaid fix for now - what we really need is a wider variety of low-population station events for the scheduler to choose from, otherwise it may simply spawn more anomalies / artifacts instead.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: the PowerGridCheck event now has a 9-minute delay before it can run again