### PR TITLE
tweak: let animals and xenos drag stuff

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -161,6 +161,8 @@
       behaviors:
       - !type:GibBehavior
         recursive: false
+  - type: Puller # starcup
+    needsHands: false # starcup - bees are very hardworking! will have no effect unless made a ghostrole
 
 - type: entity
   name: bee
@@ -1725,7 +1727,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.2
-        density: 100
+        density: 30 # starcup - to balance their dragging speed. we might regret this.
         mask:
         - SmallMobMask
         layer:
@@ -1848,6 +1850,8 @@
       behaviors:
       - !type:GibBehavior
         recursive: false
+  - type: Puller # starcup
+    needsHands: false # starcup - let the rat drag the pizza slice (improves ghostrole gameplay and makes sense)
 
 - type: entity
   parent: MobMouse
@@ -2494,6 +2498,8 @@
     raffle:
       settings: short
   - type: GhostTakeoverAvailable
+  - type: Puller # starcup
+    needsHands: false # starcup - allows for creepy spider dragging away bodies stuff, which plays well with the poison
 
 - type: entity
   name: tarantula
@@ -2723,6 +2729,8 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: Puller # starcup
+    needsHands: false # starcup - "THEY CAN GRASP!!!"
 
 - type: entity
   name: fox
@@ -2801,6 +2809,8 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: Puller
+    needsHands: false # starcup - ability to carry emeralds important for niche Minecraft challenge modes
 
 - type: entity
   abstract: true
@@ -2844,6 +2854,8 @@
       gender: epicene
   - type: MobPrice
     price: 200
+  - type: Puller
+    needsHands: false # starcup - gives ghostrole corgis something to do. go fetch!
 
 - type: entity
   parent: MobCorgiBase
@@ -3028,6 +3040,8 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 4
+  - type: Puller
+    needsHands: false # starcup - gives ghostrole cats more to do, lets them drag mice around to leave on their keepers' beds
 
 - type: entity
   name: calico cat

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -267,6 +267,8 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalNamedCat
+  - type: Puller
+    needsHands: false # starcup - basically a cat
 
 - type: entity
   name: McGriff
@@ -329,6 +331,8 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalMcGriff
+  - type: Puller
+    needsHands: false # starcup - go fetch!
 
 - type: entity
   name: Paperwork
@@ -363,6 +367,8 @@
     attributes:
       proper: true
       gender: male
+  - type: Puller
+    needsHands: false # starcup - Paperwork likes helping retrieve random books and papers for his librarian caretaker
 
 - type: entity
   name: Walter
@@ -425,6 +431,8 @@
   - type: Speech
     speechVerb: Canine
     speechSounds: Dog
+  - type: Puller
+    needsHands: false # starcup - go fetch!
 
 - type: entity
   name: Morty

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -88,6 +88,8 @@
       Dead:
         Base: dead
   - type: Puller
+    needsHands: false # starcup - allows for creepy ghostrole "dragging away the body" behavior
+# ideally we would only give dragging to select xenos, like burrowers/runners/praetorians, but currently burrowers are the parent, so.
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
Rats can now steal pizzas! Spiders and xenos can now drag bodies away into maints!

The Puller component has been added to mice, all xenos (because of how the burrower prototype is also the xeno parent prototype), spiders, felines, bees, canines, raccoons, and Paperwork. Kangaroos and monkeys could already drag things. Hands are not required for dragging.

Excluded from this: Slimes, other animals (including possums, ferrets, hamsters, pigs, crabs, moth/snail/roach variants, bats, and normal sloths).

Mouse density has been reduced from 100 to 30, to reduce their speed when dragging heavy objects.

## Why / Balance
This change is to enable three intended kinds of play for ghostroles:
- Mice can comically drag food away instead of immediately gobbling it up.
- Monsters can drag away the bodies of crit or unconscious crew for nice horror vibes.
- Some ghostrole pets and animals will be able to help out/goof around a bit more, hopefully without it being too excessive.

Gameplay as a mouse is somewhat limited, and while the same problem exists for all vent pests, mice are especially prevalent and have a known IRL history of dragging food around. It's a nice way to misbehave as a mouse in a manageable way.

Mouse density was decreased to reduce their pulling speed. Because mousetrap damage is based on target mass, this means mousetraps will gib them instantly atm. I need to give mousetraps a capped damage amount before this is viable.

**Changelog**
:cl:
- tweak: added Puller component to numerous mobs
- tweak: reduced mouse density