### PR TITLE
tweak: adjust secret preset weights

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,9 +1,9 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.20
-    Traitor: 0.55
+    Nukeops: 0.25 # starcup: 0.20 -> 0.25
+    Traitor: 0.65 # starcup: 0.55 -> 0.65
     Zombie: 0.05
-    Survival: 0.10
+    Survival: 0.00 # starcup: 0.10 -> 0.00, until we add more events we don't want this randomly rolling
     Revolutionary: 0.05
-    Wizard: 0.05 # Why not, should probably be lower
+    Wizard: 0.00 # starcup: 0.05 -> 0.00, Wizard needs serious rebalancing before we will allow it


### PR DESCRIPTION
Removes the chance of rolling Survival and Wizard, and increases the chance of rolling Nukeops and Traitor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
For context, I am going to explain how Secret works.

### Secret
When you run the Secret preset (either via admin commands or by vote in the lobby) the game rolls on a table to determine which gamemode will occur, with the following options and chances:
- Traitors: 55%
- Nukeops: 20%
- Survival: 10%
- Revolutionary: 5%
- Wizard: 5%
- Zombie: 5%

Secret is not a true "pick a random gamemode" preset, but rather, a "pick a random antagonist / station threat to deal with" preset. Until fairly recently I was under the impression that it had a chance to roll Extended and Greenshift, but that is not the case, so I figured I'd put out a little PSA here in case anyone else was unaware.

**Survival**
At present, Survival is in a bit of a rough spot. The pace of events isn't too far off from what we expected and desired for what is intended to be an occasional intense shift, but we're running into a problem with player counts - the event pool upstream is severely limited below 15-20 players, which are key cutoff points for many staple events of Survival, such as hostile vent critters, loneops, revenants, and more. We've done what we can to increase the event pool for lower-population shifts, but testing has shown that it just isn't enough at the moment, and science gets overworked while power outages severely hamper the station's functions frequently. We want Survival to be playable at lowpops, but we will need to create and/or port more events appropriate for those player counts before it will be ready. Until then, I recommend disabling its chance to roll under the Secret preset.

**Wizard**
While the concept of a traveling wizard causing issues on the station by employing a variety of disruptive spells and enchanted equipment is really cool, I am fundamentally opposed to any player having access to spells that can instantly gib you with zero counterplay, and their potential for stationwide destruction with immovable rods is just too high. This antag needs to be cooked before it can be introduced to the server, and while I removed the event chance a while back I didn't notice the preset could roll in Secret. As such, it is being removed now.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: removed the chance for Secret to roll Survival and Wizard
- tweak: increased the chance for Secret to roll Nukeops and Traitors