### PR TITLE
fix: remove priority mail chance from mail prototypes

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Mail/mail.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Mail/mail.yml
@@ -292,7 +292,8 @@
   components:
   - type: Mail
     isFragile: true
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     contents:
       # 14.8 total weight, ~6.8% base chance
     - id: FoodCakeApple
@@ -397,7 +398,8 @@
   components:
   - type: Mail
     isFragile: true
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     contents:
     - id: FoodCheese
       orGroup: Cheese
@@ -481,7 +483,8 @@
   suffix: cookies, random
   components:
   - type: Mail
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     contents:
       # Cookie 1
     - id: FoodBakedCookie
@@ -577,7 +580,8 @@
   suffix: muffins, random
   components:
   - type: Mail
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     contents:
       # Muffin 1
     - id: FoodBakedMuffinBerry
@@ -1012,7 +1016,8 @@
   suffix: unusual food
   components:
   - type: Mail
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     isFragile: true
     contents:
     - id: FoodMealNachos
@@ -1077,7 +1082,8 @@
   suffix: baked goods
   components:
   - type: Mail
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     isFragile: true
     contents:
     - id: FoodBakedBunHoney
@@ -1223,7 +1229,8 @@
   suffix: unusual produce
   components:
   - type: Mail
-    isPriority: true
+    #isPriority: true # starcup
+    isPriority: false # starcup - remove random priority mail
     isFragile: true
     contents:
     - id: FoodLaughinPeaPod

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Mail/mail.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Mail/mail.yml
@@ -292,8 +292,7 @@
   components:
   - type: Mail
     isFragile: true
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup true -> false
     contents:
       # 14.8 total weight, ~6.8% base chance
     - id: FoodCakeApple
@@ -398,8 +397,7 @@
   components:
   - type: Mail
     isFragile: true
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup: true -> false
     contents:
     - id: FoodCheese
       orGroup: Cheese
@@ -483,8 +481,7 @@
   suffix: cookies, random
   components:
   - type: Mail
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup true -> false
     contents:
       # Cookie 1
     - id: FoodBakedCookie
@@ -580,8 +577,7 @@
   suffix: muffins, random
   components:
   - type: Mail
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup true -> false
     contents:
       # Muffin 1
     - id: FoodBakedMuffinBerry
@@ -1016,8 +1012,7 @@
   suffix: unusual food
   components:
   - type: Mail
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup true -> false
     isFragile: true
     contents:
     - id: FoodMealNachos
@@ -1082,8 +1077,7 @@
   suffix: baked goods
   components:
   - type: Mail
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup true -> false
     isFragile: true
     contents:
     - id: FoodBakedBunHoney
@@ -1229,8 +1223,7 @@
   suffix: unusual produce
   components:
   - type: Mail
-    #isPriority: true # starcup
-    isPriority: false # starcup - remove random priority mail
+    isPriority: false # starcup true -> false
     isFragile: true
     contents:
     - id: FoodLaughinPeaPod

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Mail/mail.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Mail/mail.yml
@@ -292,7 +292,7 @@
   components:
   - type: Mail
     isFragile: true
-    isPriority: false # starcup true -> false
+    isPriority: false # starcup: true -> false
     contents:
       # 14.8 total weight, ~6.8% base chance
     - id: FoodCakeApple
@@ -481,7 +481,7 @@
   suffix: cookies, random
   components:
   - type: Mail
-    isPriority: false # starcup true -> false
+    isPriority: false # starcup: true -> false
     contents:
       # Cookie 1
     - id: FoodBakedCookie
@@ -577,7 +577,7 @@
   suffix: muffins, random
   components:
   - type: Mail
-    isPriority: false # starcup true -> false
+    isPriority: false # starcup: true -> false
     contents:
       # Muffin 1
     - id: FoodBakedMuffinBerry
@@ -1012,7 +1012,7 @@
   suffix: unusual food
   components:
   - type: Mail
-    isPriority: false # starcup true -> false
+    isPriority: false # starcup: true -> false
     isFragile: true
     contents:
     - id: FoodMealNachos
@@ -1077,7 +1077,7 @@
   suffix: baked goods
   components:
   - type: Mail
-    isPriority: false # starcup true -> false
+    isPriority: false # starcup: true -> false
     isFragile: true
     contents:
     - id: FoodBakedBunHoney
@@ -1223,7 +1223,7 @@
   suffix: unusual produce
   components:
   - type: Mail
-    isPriority: false # starcup true -> false
+    isPriority: false # starcup: true -> false
     isFragile: true
     contents:
     - id: FoodLaughinPeaPod


### PR DESCRIPTION
Just a quick bug fix for https://github.com/teamstarcup/starcup/pull/142 so it actually blocks all priority mail and no parcel prototypes override that.

**Changelog**
:cl:
- fix: removed priority mail chance from prototypes
