### PR TITLE
tweak: cold-weather hats now keep you warm

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -41,7 +41,7 @@
   - type: Tag
     tags:
     - ClothMade
-    - Recyclable    
+    - Recyclable
     - WhitelistChameleon
 
 - type: entity
@@ -477,8 +477,10 @@
     - state: icon-nobeard
       map: [ "foldedLayer" ]
       visible: true
-  
-    
+  - type: TemperatureProtection # starcup - cold-weather hats should work
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
+
 
 - type: entity
   parent: ClothingHeadBase
@@ -589,6 +591,9 @@
     - state: icon-up
       map: ["foldedLayer"]
       visible: false
+  - type: TemperatureProtection # starcup - cold-weather hats should work
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingHeadBase
@@ -627,6 +632,9 @@
         color: "#a60b0b"
       - state: pompom-equipped-HELMET
         color: "#a60b0b"
+  - type: TemperatureProtection # starcup - cold-weather hats should work
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingHeadHatWizardBase


### PR DESCRIPTION
SyndComm has recently issued improved prototypes for cold-weather headgear. The beanie, the Santa hat, and the beloved ushanka will now properly keep that loyal head of yours warm!

I notably excluded Syndie pajama hats. They're pajamas. C'mon.

## Why / Balance
It's silly to force folks to have their hood up when fashionable alternatives exist, and players often assume these hats keep you warm anyways. Because the description text _heavily implies they do._

Plus, this means we can put cute functional hats on animals when the sprites are done.

## Technical details
Just added this to a few hats in the yml to make them equivalent to having your hood up:
  - type: TemperatureProtection
    heatingCoefficient: 1.05
    coolingCoefficient: 0.7

**Changelog**
:cl:
- tweak: ushanka, santa hat, and beanie all now provide equivalent temp protection to a hood
-->
