### PR TITLE
feat: senior bartender roletimer and pda

### DIFF
--- a/Resources/Locale/en-US/_starcup/job/job-names.ftl
+++ b/Resources/Locale/en-US/_starcup/job/job-names.ftl
@@ -3,6 +3,7 @@
 # Bartender
 job-alt-title-barista = Barista
 job-alt-title-speakeasyer = Speakeasyer
+job-alt-title-seniorbartender = Senior Bartender
 
 # Chaplain
 job-alt-title-atheist-shepherd = Atheist Shepherd

--- a/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DeltaV/Loadouts/loadout_groups.yml
@@ -471,6 +471,7 @@
   - MixologistPDA
   - BaristaPDA # starcup
   - SpeakeasyerPDA # starcup
+  - SeniorBartenderPDA # starcup
 
 - type: loadoutGroup
   id: ChefPDADelta

--- a/Resources/Prototypes/_starcup/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Devices/pda.yml
@@ -17,6 +17,15 @@
   - type: Pda
     id: SpeakeasyerIDCard
 
+- type: entity
+  parent: BartenderPDA
+  id: SeniorBartenderPDA
+  name: senior bartender PDA
+  description: Much like what they serve, bartenders also get better with age.
+  components:
+  - type: Pda
+    id: SeniorBartenderIDCard
+
 # Chaplain
 - type: entity
   parent: ChaplainPDA

--- a/Resources/Prototypes/_starcup/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Misc/identification_cards.yml
@@ -15,6 +15,14 @@
   - type: IdCard
     jobTitle: job-alt-title-speakeasyer
 
+- type: entity
+  parent: BartenderIDCard
+  id: SeniorBartenderIDCard
+  name: senior bartender ID card
+  components:
+  - type: IdCard
+    jobTitle: job-alt-title-seniorbartender
+
 # Chaplain
 - type: entity
   parent: ChaplainIDCard

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/bartender.yml
@@ -1,3 +1,13 @@
+# Senior times
+- type: loadoutEffectGroup
+  id: SeniorBartender
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBartender
+      time: 187200 #52 hrs (1 hour per week for 1 year)
+
 # ID
 - type: loadout
   id: BaristaPDA
@@ -8,3 +18,11 @@
   id: SpeakeasyerPDA
   equipment:
     id: SpeakeasyerPDA
+
+- type: loadout
+  id: SeniorBartenderPDA
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorBartender
+  equipment:
+    id: SeniorBartenderPDA


### PR DESCRIPTION
## Why / Balance
prompted by #164, adding a senior bartender alt job title and corresponding pda. teeeechnically ported from impstation, but their implementation of the job is different enough from ours that I thought it appropriate to go in our namespace.

## Technical details
just adds a senior bartender roletimer (52 hours as bartender), pda, job title, and associated loadouts

**Changelog**
:cl:
- add: especially venerable bartenders now have a senior job title available in their loadout