### PR TITLE
tweak: the big description text rewrite

### DIFF
--- a/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeComponent.cs
+++ b/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeComponent.cs
@@ -71,8 +71,8 @@ public sealed partial class SpaceVillainArcadeComponent : SharedSpaceVillainArca
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("possibleFirstEnemyNames")]
     public List<string> PossibleFirstEnemyNames = new(){
-        "the Automatic", "Farmer", "Lord", "Professor", "the Cuban", "the Evil", "the Dread King",
-        "the Space", "Lord", "the Great", "Duke", "General"
+        "the Automatic", "Farmer", "Lord", "Professor", "the Evil", "the Dread King",
+        "the Space", "Lord", "the Great", "Duke", "General" /// starcup: remove "the Cuban"
     };
 
     /// <summary>
@@ -83,7 +83,7 @@ public sealed partial class SpaceVillainArcadeComponent : SharedSpaceVillainArca
     public List<string> PossibleLastEnemyNames = new()
     {
         "Melonoid", "Murdertron", "Sorcerer", "Ruin", "Jeff", "Ectoplasm", "Crushulon", "Uhangoid",
-        "Vhakoid", "Peteoid", "slime", "Griefer", "ERPer", "Lizard Man", "Unicorn"
+        "Vhakoid", "Peteoid", "slime", "Griefer", "Lizard Man", "Unicorn" /// starcup: remove "ERPer"
     };
 
     /// <summary>

--- a/Resources/Locale/en-US/_starcup/advertisements/vending/cigs.ftl
+++ b/Resources/Locale/en-US/_starcup/advertisements/vending/cigs.ftl
@@ -1,0 +1,7 @@
+advertisement-cigs-starcup-1 = It's safer in space than it is on the ground!
+advertisement-cigs-starcup-2 = Tastes good, like a cigarette should!
+advertisement-cigs-starcup-3 = Real flavor, real quality!
+advertisement-cigs-starcup-4 = Interdyne physicians say our brands are the healthiest on the market!
+advertisement-cigs-starcup-5 = Proud partner of countless Syndicate stations!
+advertisement-cigs-starcup-6 = Consider us a perk of the job!
+thankyou-cigs-starcup-1 = See you next time!

--- a/Resources/Locale/en-US/_starcup/advertisements/vending/scidrobe.ftl
+++ b/Resources/Locale/en-US/_starcup/advertisements/vending/scidrobe.ftl
@@ -1,0 +1,3 @@
+advertisement-scidrobe-starcup-1 = Nothing says "I know what I'm doing with this dangerous alien artifact" like a spiffy lab coat!
+advertisement-scidrobe-starcup-2 = Goes great with ominous floating anomaly cores!
+advertisement-scidrobe-starcup-3 = For making a good impression on command if something goes horribly wrong!

--- a/Resources/Locale/en-US/_starcup/advertisements/vending/sectech.ftl
+++ b/Resources/Locale/en-US/_starcup/advertisements/vending/sectech.ftl
@@ -1,0 +1,6 @@
+advertisement-sectech-starcup-1 = Remember, if SyndComm tells you to shoot the captain, you can. And must.
+advertisement-sectech-starcup-2 = Just because the China Lake has a syndie label doesn't make it okay for the cadet to have it.
+advertisement-sectech-starcup-3 = Think of yourself as a service employee. With a stun baton.
+advertisement-sectech-starcup-4 = Remember the Tunnel Uprisings of Year 54 ANC. Remember that you lost.
+thankyou-sectech-starcup-1 = Good luck, and stay sharp!
+thankyou-sectech-starcup-2 = Remember, you can't arrest the felinid janitor for saying 'nyaa'. Not in Syndicate systems.

--- a/Resources/Locale/en-US/_starcup/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/_starcup/cargo/bounties.ftl
@@ -1,0 +1,5 @@
+bounty-description-cuban-carp-starcup = SyndComm has been studying the viability of space carp as a substitute for certain meat products. Ship a Cuban carp so they can perform rigorous taste testing.
+bounty-description-lung-starcup = When an employee raised concerns about having hacked up a lung, it took the doctors a bit too long to realize they were being literal. They'll need a replacement.
+bounty-description-banana-starcup = Hi station! They took away my bike horns when I tried honking ten of them at the same time! I need a new routine now! Bananas please?
+bounty-description-hi-viz-vest-starcup = A corgi got into Engineering and ate the AME controller. Please don't ask how. We've had enough incidents with people running into each other in the maintenance tunnels that we've decided to distribute hi-viz vests to the crew.
+bounty-description-microwave-machine-board-starcup = The chef's microwaves still aren't turning back on after a recent power outage. We need help getting replacements before she starts eyeing oven catalogs.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/biological.ftl
@@ -1,0 +1,1 @@
+reagent-desc-blood-starcup = This probably shouldn't be outside of somebody.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/consumable/drink/alcohol.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/consumable/drink/alcohol.ftl
@@ -1,0 +1,7 @@
+reagent-desc-clownblood-starcup = A mixture invented by a famed clown who wanted a yummier choice for fake blood.
+
+reagent-desc-circusjuice-starcup = One day, a clown managed to sneak their way into an Interdyne chemical lab. This was the result.
+
+reagent-desc-three-mile-island-starcup = Named for the minimum safe distance from your location once you've had enough of it.
+
+reagent-desc-kvas-starcup = A sweet-and-sour grain alcohol, mellow enough to replace cola in some cultures.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/consumable/drink/alcohol.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/consumable/drink/alcohol.ftl
@@ -4,4 +4,4 @@ reagent-desc-circusjuice-starcup = One day, a clown managed to sneak their way i
 
 reagent-desc-three-mile-island-starcup = Named for the minimum safe distance from your location once you've had enough of it.
 
-reagent-desc-kvas-starcup = A sweet-and-sour grain alcohol, mellow enough to replace cola in some cultures.
+reagent-desc-kvass-starcup = A sweet-and-sour grain alcohol, mellow enough to replace cola in some cultures.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/consumable/food/condiments.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/consumable/food/condiments.ftl
@@ -1,0 +1,1 @@
+reagent-desc-ketchunaise-starcup = The nature of sapient life is just that every so often someone makes a new name for a combined ketchup and mayonnaise sauce.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/fun.ftl
@@ -1,0 +1,1 @@
+reagent-desc-carpetium-starcup = A mystical chemical that covers everything it touches in carpet. Somehow filters out carpotoxin from the blood stream.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/narcotics.ftl
@@ -1,0 +1,1 @@
+reagent-desc-nicotine = An herbally sourced stimulant that acts as the main component of cigarettes.

--- a/Resources/Locale/en-US/advertisements/vending/chefdrobe.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/chefdrobe.ftl
@@ -1,4 +1,8 @@
-﻿advertisement-chefdrobe-1 = Our clothes are guaranteed to protect you from food splatters!
-advertisement-chefdrobe-2 = Perfectly white, so everyone knows about the murder in the kitchen!
+﻿# starcup: replaced line 2 for tone
+# advertisement-chefdrobe-2 = Perfectly white, so everyone knows about the murder in the kitchen!
+
+# starcup: added line 2
+advertisement-chefdrobe-1 = Our clothes are guaranteed to protect you from food splatters!
+advertisement-chefdrobe-2 = A pristine white, so everyone will know what you did behind the freezer doors.
 advertisement-chefdrobe-3 = Easy to clean, easy to see!
 advertisement-chefdrobe-4 = Cook like a pro, look like a maestro!

--- a/Resources/Locale/en-US/advertisements/vending/chemdrobe.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/chemdrobe.ftl
@@ -1,4 +1,8 @@
+# starcup: removed line 3 for tone
+# advertisement-chemdrobe-3 = I'm pretty sure these will protect you against acid spills!
+
+# starcup: added line 3
 advertisement-chemdrobe-1 = Our clothes are 0.5% more resistant to acid spills! Get yours now!
 advertisement-chemdrobe-2 = Professional laboratory clothing, designed by NanoTrasen!
-advertisement-chemdrobe-3 = I'm pretty sure these will protect you against acid spills!
+advertisement-chemdrobe-3 = Made from the fittest fibers Interdyne labs can synthesize!
 advertisement-chemdrobe-4 = The best fashion formula!

--- a/Resources/Locale/en-US/advertisements/vending/detdrobe.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/detdrobe.ftl
@@ -1,3 +1,9 @@
-advertisement-detdrobe-1 = Apply your brilliant deductive methods in style!
-advertisement-detdrobe-2 = Come here and dress up like Sherlock Holmes!
+# starcup: removed lines 2, 3 for tone
+# advertisement-detdrobe-2 = Come here and dress up like Sherlock Holmes!
 advertisement-detdrobe-3 = Our outfits are very conservative!
+
+# starcup: added lines 2, 3
+
+advertisement-detdrobe-1 = Apply your brilliant deductive methods in style!
+advertisement-detdrobe-2 = Having problems sleuthing out criminals? Try a more hard-boiled look.
+advertisement-detdrobe-3 = Outfits to help you get down to brass tacks.

--- a/Resources/Locale/en-US/advertisements/vending/donut.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/donut.ftl
@@ -1,4 +1,9 @@
-﻿advertisement-donut-1 = Each of us is a little cop!
+﻿# starcup: removed ad line 1 and thanks line 3 for tone
+# advertisement-donut-1 = Each of us is a little cop!
+# thankyou-donut-3 = Have a nice day, officer!
+
+# starcup: added ad line 1 and thanks line 3
+advertisement-donut-1 = Get dunked on by sugary goodness!
 advertisement-donut-2 = Hope you're hungry!
 advertisement-donut-3 = Over 1 million donuts sold!
 advertisement-donut-4 = We pride ourselves in the consistency of our products!
@@ -6,5 +11,5 @@ advertisement-donut-5 = Sweet, sugary and delicious!
 advertisement-donut-6 = Donut worry, be happy!
 thankyou-donut-1 = Enjoy your donut!
 thankyou-donut-2 = Another donut sold!
-thankyou-donut-3 = Have a nice day, officer!
+thankyou-donut-3 = Hope you circle back around soon, constable!
 thankyou-donut-4 = I hope you get addicted!

--- a/Resources/Locale/en-US/advertisements/vending/happyhonk.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/happyhonk.ftl
@@ -1,9 +1,15 @@
-﻿advertisement-happyhonk-1 = Honk! Honk! Why not order a Happy Honk Meal today?
+﻿# starcup: removed ad lines 5, 6 and thanks line 4 for tone
+# advertisement-happyhonk-5 = What's black and white and red all over? The mime and she died from blunt head trauma.
+# advertisement-happyhonk-6 = How many security officers does it take to arrest you? Three, one to beat you to death, one to cuff you and one to dump your body in maintenance.
+# thankyou-happyhonk-4 = Go slip people! Honk!
+
+# starcup: added ad lines 5, 6 and thanks line 4
+advertisement-happyhonk-1 = Honk! Honk! Why not order a Happy Honk Meal today?
 advertisement-happyhonk-2 = Clowns deserve a hug, if you see one be sure to show your appreciation.
 advertisement-happyhonk-3 = If you find the Golden Honker then pray to the gods, you are one lucky person.
 advertisement-happyhonk-4 = Happy Honk: it's a meal, it's a deal, it's got a plastic toy that will make you squeal.
-advertisement-happyhonk-5 = What's black and white and red all over? The mime and she died from blunt head trauma.
-advertisement-happyhonk-6 = How many security officers does it take to arrest you? Three, one to beat you to death, one to cuff you and one to dump your body in maintenance.
+advertisement-happyhonk-5 = Take one home, or two, or three; a marvelous fun is about to break free!
+advertisement-happyhonk-6 = How many security officers does it take to tell a joke? Three! One to consult SOP, one to check the company policy, and one to mess up telling it!
 advertisement-happyhonk-7 = Happy Honk is not responsible for the quality of the food placed within our Happy Honk meal boxes.
 advertisement-happyhonk-8 = Why not ask for our limited edition Mime Happy Honk Meal?
 advertisement-happyhonk-9 = Happy Honk is a trademark of Honk! co. and is far superior to Robust Nukie Food corp.
@@ -11,4 +17,4 @@ advertisement-happyhonk-10 = Our Happy Honk meals are sure to offer a great surp
 thankyou-happyhonk-1 = Honk!
 thankyou-happyhonk-2 = Honk honk!
 thankyou-happyhonk-3 = Go share the fun! Honk!
-thankyou-happyhonk-4 = Go slip people! Honk!
+thankyou-happyhonk-4 = Go make merry! Honk!

--- a/Resources/Locale/en-US/advertisements/vending/lawdrobe.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/lawdrobe.ftl
@@ -1,14 +1,23 @@
+# starcup: removed ad lines 2, 4, 7, 8, and thanks lines 3, 4 for tone
+#advertisement-lawdrobe-2 = Go pester security until they abide by your own rules!
+#advertisement-lawdrobe-4 = A dougnut a day keeps security away!
+#advertisement-lawdrobe-7 = Injecting space drugs leaves no evidence!
+#advertisement-lawdrobe-8 = You or a loved one hurt by Nanotrasen? Too bad!
+#thankyou-lawdrobe-3 = Win or lose, you get paid either way!
+#thankyou-lawdrobe-4 = Remember: It's only illegal if you get caught!
+
+# starcup: added ad lines 2, 4, 7, 8, and thanks lines 3, 4
 advertisement-lawdrobe-1 = OBJECTION! Get the rule of law for yourself!
-advertisement-lawdrobe-2 = Go pester security until they abide by your own rules!
+advertisement-lawdrobe-2 = Be the face every security officer knows to fear!
 advertisement-lawdrobe-3 = A new case just came in? Go get them out of jail!
-advertisement-lawdrobe-4 = A dougnut a day keeps security away!
+advertisement-lawdrobe-4 = Suits so sharp, they should require a license to carry!
 advertisement-lawdrobe-5 = No one is above the law!
 advertisement-lawdrobe-6 = No officer, I do not consent to a search!
-advertisement-lawdrobe-7 = Injecting space drugs leaves no evidence!
-advertisement-lawdrobe-8 = You or a loved one hurt by Nanotrasen? Too bad!
+advertisement-lawdrobe-7 = The longest recorded trial in Syndicate space is still ongoing after 3.46 years. Pick a comfortable suit!
+advertisement-lawdrobe-8 = There, right there! Look at that sorry state you're in! Fix it here!
 advertisement-lawdrobe-9 = Case closed! Defendant has too much drip!
 thankyou-lawdrobe-1 = You can win any case in that outfit!
 thankyou-lawdrobe-2 = Get one for your client as well!
-thankyou-lawdrobe-3 = Win or lose, you get paid either way!
-thankyou-lawdrobe-4 = Remember: It's only illegal if you get caught!
+thankyou-lawdrobe-3 = Go and face your trials and tribulations!
+thankyou-lawdrobe-4 = Remember: Justice is for all!
 thankyou-lawdrobe-5 = OBJECTION! That outfit is too cool for court!

--- a/Resources/Locale/en-US/advertisements/vending/nanomed.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/nanomed.ftl
@@ -1,4 +1,8 @@
-﻿advertisement-nanomed-1 = Go save some lives!
+﻿# starcup: removed line 9 for tone
+# advertisement-nanomed-9 = Go overdose people!
+
+# starcup: added line 9
+advertisement-nanomed-1 = Go save some lives!
 advertisement-nanomed-2 = The best stuff for your medbay.
 advertisement-nanomed-3 = Only the finest tools.
 advertisement-nanomed-4 = Natural chemicals!
@@ -6,4 +10,4 @@ advertisement-nanomed-5 = This stuff saves lives.
 advertisement-nanomed-6 = Don't you want some?
 advertisement-nanomed-7 = Ping!
 advertisement-nanomed-8 = Make sure not to overdose people!
-advertisement-nanomed-9 = Go overdose people!
+advertisement-nanomed-9 = Interesting symptoms. Have you considered progesterone?

--- a/Resources/Locale/en-US/advertisements/vending/robodrobe.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/robodrobe.ftl
@@ -1,4 +1,8 @@
+# starcup: removed line 3 for tone
+# advertisement-robodrobe-3 = Steal someone from maintenance and turn them into a robot!
+
+# starcup: added line 3
 advertisement-robodrobe-1 = You turn me TRUE, use defines!
 advertisement-robodrobe-2 = 0110001101101100011011110111010001101000011001010111001101101000011001010111001001100101
-advertisement-robodrobe-3 = Steal someone from maintenance and turn them into a robot!
+advertisement-robodrobe-3 = Salutations, Syndicate roboticists!
 advertisement-robodrobe-4 = Robotics is fun!

--- a/Resources/Locale/en-US/advertisements/vending/secdrobe.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/secdrobe.ftl
@@ -1,5 +1,10 @@
-advertisement-secdrobe-1 = Beat perps in style!
-advertisement-secdrobe-2 = It's red so you can't see the blood!
+# starcup: removed lines 1, 2 for tone
+# advertisement-secdrobe-1 = Beat perps in style!
+# advertisement-secdrobe-2 = It's red so you can't see the blood!
+
+# starcup: added lines 1, 2
+advertisement-secdrobe-1 = Maid outfits aren't contraband in Syndicate systems! But most won't protect you from bullets.
+advertisement-secdrobe-2 = Officers, remember to wear your protective shades at all times to avoid mental subversion! Cadets, good luck!
 advertisement-secdrobe-3 = You have the right to be fashionable!
 advertisement-secdrobe-4 = Now you can be the fashion police you always wanted to be!
 advertisement-secdrobe-5 = The best shade of red, TOTALLY not, like, the same shade as what Syndicates use!

--- a/Resources/Locale/en-US/job/job-description.ftl
+++ b/Resources/Locale/en-US/job/job-description.ftl
@@ -1,3 +1,7 @@
+# starcup: removed cargo tech job description for tone
+# job-description-cargotech = Deal with requisitions and deliveries, pilot the cargo shuttle to the trade station and back, and work with others to make ludicrous amounts of cash and then waste it all gambling.
+
+# starcup: added cargo tech job description
 job-description-technical-assistant = Learn the basics of managing the station's power, as well as repairing the station's hull.
 job-description-atmostech = Optimize the station's atmospherics setup, and synthesize rare gases to use or sell.
 job-description-bartender = Manage the bar and keep it lively, give out drinks, and listen to the crew's stories.
@@ -7,7 +11,7 @@ job-description-boxer = Fight your way to the top! Challenge the head of personn
 job-description-brigmedic = Fight in the rear of the security service, for the lives of your comrades! You are the first and last hope of your squad. Hippocrates bless you.
 job-description-cadet = Learn the basics of arresting criminals and managing the brig. Listen to your supervisors and feel free to ask them for any help.
 job-description-captain = Keep the station running, delegate work to the other heads of staff, and exert your will.
-job-description-cargotech = Deal with requisitions and deliveries, pilot the cargo shuttle to the trade station and back, and work with others to make ludicrous amounts of cash and then waste it all gambling.
+job-description-cargotech = Deal with requisitions and deliveries, supply other departments with materials, and pilot the cargo shuttle to the trade station and back.
 job-description-ce = Manage the engineering department to ensure power, atmospherics, and the hull are in perfect shape.
 job-description-centcomoff = Act as an ambassador to the newest state-of-the-art space station in Nanotrasen's fleet.
 job-description-chaplain = Preach the good word of your deity and religion, and conduct spiritual healing and miracles with your bible.

--- a/Resources/Locale/en-US/reagents/meta/gases.ftl
+++ b/Resources/Locale/en-US/reagents/meta/gases.ftl
@@ -1,8 +1,10 @@
 reagent-name-oxygen = oxygen
 reagent-desc-oxygen = An oxidizing, colorless gas.
 
+# starcup: rewrote plasma description for tone
+# reagent-desc-plasma = Funky, space-magic pixie dust. You probably shouldn't eat this, but we both know you will anyways.
 reagent-name-plasma = plasma
-reagent-desc-plasma = Funky, space-magic pixie dust. You probably shouldn't eat this, but we both know you will anyways.
+reagent-desc-plasma = This highly flammable gas is the fuel source that propelled NanoTrasen to the corporate dominance it lords over you now. It, like them, is to be dealt with very carefully.
 
 reagent-name-tritium = tritium
 reagent-desc-tritium = Radioactive space-magic pixie dust.

--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -9330,15 +9330,6 @@ entities:
     - type: Transform
       pos: 9.5,15.5
       parent: 588
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 1800
-#    components:
-#    - type: Transform
-#      rot: -1.5707963267948966 rad
-#      pos: 8.5,9.5
-#      parent: 588
 - proto: PosterLegitNanotrasenLogo
   entities:
   - uid: 1802
@@ -9369,15 +9360,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 588
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 1804
-#    components:
-#    - type: Transform
-#      rot: -1.5707963267948966 rad
-#      pos: 1.5,19.5
-#      parent: 588
 - proto: PottedPlantRandom
   entities:
   - uid: 1286

--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -9330,14 +9330,15 @@ entities:
     - type: Transform
       pos: 9.5,15.5
       parent: 588
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 1800
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,9.5
-      parent: 588
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 1800
+#    components:
+#    - type: Transform
+#      rot: -1.5707963267948966 rad
+#      pos: 8.5,9.5
+#      parent: 588
 - proto: PosterLegitNanotrasenLogo
   entities:
   - uid: 1802
@@ -9368,14 +9369,15 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 588
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 1804
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,19.5
-      parent: 588
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 1804
+#    components:
+#    - type: Transform
+#      rot: -1.5707963267948966 rad
+#      pos: 1.5,19.5
+#      parent: 588
 - proto: PottedPlantRandom
   entities:
   - uid: 1286

--- a/Resources/Maps/Dungeon/mineshaft.yml
+++ b/Resources/Maps/Dungeon/mineshaft.yml
@@ -4681,13 +4681,6 @@ entities:
     - type: Transform
       pos: 41.5,15.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 304
-    components:
-    - type: Transform
-      pos: 3.5,21.5
-      parent: 2
 - proto: WallCobblebrick
   entities:
   - uid: 94

--- a/Resources/Maps/Lavaland/river_village.yml
+++ b/Resources/Maps/Lavaland/river_village.yml
@@ -6329,27 +6329,6 @@ entities:
     - type: Transform
       pos: 48.5,13.5
       parent: 1
-- proto: PosterContrabandRise
-  entities:
-  - uid: 1446
-    components:
-    - type: Transform
-      pos: 29.5,20.5
-      parent: 1
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 1449
-    components:
-    - type: Transform
-      pos: 31.5,4.5
-      parent: 1
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 1420
-    components:
-    - type: Transform
-      pos: 44.5,17.5
-      parent: 1
 - proto: PosterContrabandWaffleCorp
   entities:
   - uid: 1450

--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -8376,17 +8376,6 @@ entities:
     - Destructible
     - Anchorable
     - ApcPowerReceiver
-- proto: VendingMachineChang
-  entities:
-  - uid: 692
-    components:
-    - type: Transform
-      pos: 9.5,-20.5
-      parent: 818
-    - type: Godmode
-    missingComponents:
-    - Destructible
-    - Anchorable
 - proto: VendingMachineCigs
   entities:
   - uid: 744

--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -6420,16 +6420,17 @@ entities:
     - type: Godmode
     missingComponents:
     - Destructible
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 926
-    components:
-    - type: Transform
-      pos: -14.5,1.5
-      parent: 818
-    - type: Godmode
-    missingComponents:
-    - Destructible
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 926
+#    components:
+#    - type: Transform
+#      pos: -14.5,1.5
+#      parent: 818
+#    - type: Godmode
+#    missingComponents:
+#    - Destructible
 - proto: PosterLegitHighClassMartini
   entities:
   - uid: 925

--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -6410,27 +6410,6 @@ entities:
     - type: Transform
       pos: 8.5,4.5
       parent: 818
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 927
-    components:
-    - type: Transform
-      pos: -6.5,1.5
-      parent: 818
-    - type: Godmode
-    missingComponents:
-    - Destructible
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 926
-#    components:
-#    - type: Transform
-#      pos: -14.5,1.5
-#      parent: 818
-#    - type: Godmode
-#    missingComponents:
-#    - Destructible
 - proto: PosterLegitHighClassMartini
   entities:
   - uid: 925

--- a/Resources/Maps/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Nonstations/nukieplanet.yml
@@ -11424,13 +11424,6 @@ entities:
     - type: Transform
       pos: 12.5,1.5
       parent: 104
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 2466
-    components:
-    - type: Transform
-      pos: 8.5,-9.5
-      parent: 104
 - proto: PosterContrabandDonk
   entities:
   - uid: 12
@@ -11538,13 +11531,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,8.5
-      parent: 104
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 1386
-    components:
-    - type: Transform
-      pos: 12.5,-9.5
       parent: 104
 - proto: PosterContrabandSyndicateRecruitment
   entities:

--- a/Resources/Maps/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Nonstations/nukieplanet.yml
@@ -13722,13 +13722,6 @@ entities:
     - type: Transform
       pos: -0.5,-8.5
       parent: 104
-- proto: VendingMachineChang
-  entities:
-  - uid: 1208
-    components:
-    - type: Transform
-      pos: -10.5,7.5
-      parent: 104
 - proto: VendingMachineChemicalsSyndicate
   entities:
   - uid: 1335

--- a/Resources/Maps/Ruins/derelict.yml
+++ b/Resources/Maps/Ruins/derelict.yml
@@ -5776,13 +5776,6 @@ entities:
     - type: Transform
       pos: 11.5,18.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 2145
-    components:
-    - type: Transform
-      pos: -14.5,17.5
-      parent: 2
 - proto: WallReinforced
   entities:
   - uid: 57

--- a/Resources/Maps/Ruins/ruined_prison_ship.yml
+++ b/Resources/Maps/Ruins/ruined_prison_ship.yml
@@ -2951,13 +2951,6 @@ entities:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 643
-    components:
-    - type: Transform
-      pos: 7.5,-27.5
-      parent: 2
 - proto: PosterContrabandLustyExomorph
   entities:
   - uid: 290

--- a/Resources/Maps/Salvage/cargo-1.yml
+++ b/Resources/Maps/Salvage/cargo-1.yml
@@ -668,13 +668,6 @@ entities:
     - type: Transform
       pos: -0.5,0.5
       parent: 20
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 108
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 20
 - proto: PosterContrabandRevolt
   entities:
   - uid: 120

--- a/Resources/Maps/Salvage/hauling-shuttle.yml
+++ b/Resources/Maps/Salvage/hauling-shuttle.yml
@@ -1118,13 +1118,6 @@ entities:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 126
-    components:
-    - type: Transform
-      pos: 4.5,-3.5
-      parent: 1
 - proto: WallShuttle
   entities:
   - uid: 2

--- a/Resources/Maps/Salvage/medium-vault-1.yml
+++ b/Resources/Maps/Salvage/medium-vault-1.yml
@@ -876,13 +876,6 @@ entities:
     - type: Transform
       pos: -3.5,-3.5
       parent: 222
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 169
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 222
 - proto: PosterContrabandSyndicateRecruitment
   entities:
   - uid: 168

--- a/Resources/Maps/Salvage/small-4.yml
+++ b/Resources/Maps/Salvage/small-4.yml
@@ -324,13 +324,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.5187342,-1.4814079
       parent: 37
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 66
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 37
 - proto: Poweredlight
   entities:
   - uid: 21

--- a/Resources/Maps/Shuttles/ShuttleEvent/spacebus.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/spacebus.yml
@@ -1130,14 +1130,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 1
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 139
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-0.5
-      parent: 1
 - proto: PosterContrabandSpaceUp
   entities:
   - uid: 140

--- a/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
@@ -1613,13 +1613,6 @@ entities:
     - type: Transform
       pos: 0.5731925,-0.16962886
       parent: 1
-- proto: VendingMachineChang
-  entities:
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
 - proto: VisitorChefSpawner
   entities:
   - uid: 186

--- a/Resources/Maps/Shuttles/emergency_delta.yml
+++ b/Resources/Maps/Shuttles/emergency_delta.yml
@@ -3251,14 +3251,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 788
-#    components:
-#    - type: Transform
-#      pos: 1.5,3.5
-#      parent: 1
 - proto: PosterLegitHelpOthers
   entities:
   - uid: 790

--- a/Resources/Maps/Shuttles/emergency_delta.yml
+++ b/Resources/Maps/Shuttles/emergency_delta.yml
@@ -3251,13 +3251,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 788
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 788
+#    components:
+#    - type: Transform
+#      pos: 1.5,3.5
+#      parent: 1
 - proto: PosterLegitHelpOthers
   entities:
   - uid: 790

--- a/Resources/Maps/Shuttles/emergency_lox.yml
+++ b/Resources/Maps/Shuttles/emergency_lox.yml
@@ -3334,16 +3334,6 @@ entities:
     - type: Transform
       pos: 1.5,-5.5
       parent: 670
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 650
-    components:
-    - type: MetaData
-      desc: A pink-haired woman on a beach.
-      name: Beach Star Bratton!
-    - type: Transform
-      pos: -1.5,-6.5
-      parent: 670
 - proto: PosterContrabandFreeSyndicateEncryptionKey
   entities:
   - uid: 652

--- a/Resources/Maps/Shuttles/emergency_meta.yml
+++ b/Resources/Maps/Shuttles/emergency_meta.yml
@@ -5393,13 +5393,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-2.5
       parent: 1
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 934
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
 - proto: PosterLegitIonRifle
   entities:
   - uid: 742

--- a/Resources/Maps/Shuttles/emergency_rod.yml
+++ b/Resources/Maps/Shuttles/emergency_rod.yml
@@ -4197,13 +4197,6 @@ entities:
     - type: Transform
       pos: -3.5,16.5
       parent: 2
-- proto: VendingMachineChang
-  entities:
-  - uid: 304
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 2
 - proto: VendingMachineCola
   entities:
   - uid: 518

--- a/Resources/Maps/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Shuttles/infiltrator.yml
@@ -3768,13 +3768,6 @@ entities:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 526
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 1
 - proto: PosterContrabandDonk
   entities:
   - uid: 527
@@ -3852,13 +3845,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,-14.5
-      parent: 1
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 538
-    components:
-    - type: Transform
-      pos: 1.5,-10.5
       parent: 1
 - proto: PosterContrabandSyndicateRecruitment
   entities:

--- a/Resources/Maps/Shuttles/pirate.yml
+++ b/Resources/Maps/Shuttles/pirate.yml
@@ -3161,21 +3161,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,5.5
       parent: 1
-- proto: PosterContrabandRise
-  entities:
-  - uid: 479
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,2.5
-      parent: 1
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 480
-    components:
-    - type: Transform
-      pos: -8.5,7.5
-      parent: 1
 - proto: PosterContrabandSyndicateRecruitment
   entities:
   - uid: 481
@@ -3183,13 +3168,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
-      parent: 1
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 482
-    components:
-    - type: Transform
-      pos: -9.5,3.5
       parent: 1
 - proto: PowerCellRecharger
   entities:

--- a/Resources/Maps/Shuttles/pirate.yml
+++ b/Resources/Maps/Shuttles/pirate.yml
@@ -4026,13 +4026,6 @@ entities:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 618
-    components:
-    - type: Transform
-      pos: -9.5,-0.5
-      parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
   - uid: 619

--- a/Resources/Maps/_starcup/Events/frigid-peril-station.yml
+++ b/Resources/Maps/_starcup/Events/frigid-peril-station.yml
@@ -111705,13 +111705,6 @@ entities:
     - type: Transform
       pos: 30.5,21.5
       parent: 9
-- proto: VendingMachineChang
-  entities:
-  - uid: 16728
-    components:
-    - type: Transform
-      pos: 59.5,34.5
-      parent: 9
 - proto: VendingMachineChapel
   entities:
   - uid: 16729
@@ -112028,13 +112021,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-4.5
-      parent: 9
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 16778
-    components:
-    - type: Transform
-      pos: 75.5,6.5
       parent: 9
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/_starcup/byoin.yml
+++ b/Resources/Maps/_starcup/byoin.yml
@@ -86935,13 +86935,6 @@ entities:
     - type: Transform
       pos: 5.5,-10.5
       parent: 2
-- proto: VendingMachineRestockChang
-  entities:
-  - uid: 12836
-    components:
-    - type: Transform
-      pos: 5.380872,2.4595037
-      parent: 2
 - proto: VendingMachineRestockChemVend
   entities:
   - uid: 12837

--- a/Resources/Maps/_starcup/byoin.yml
+++ b/Resources/Maps/_starcup/byoin.yml
@@ -73701,13 +73701,6 @@ entities:
     - type: Transform
       pos: -14.5,18.5
       parent: 2
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 10685
-    components:
-    - type: Transform
-      pos: 55.5,22.5
-      parent: 2
 - proto: PosterContrabandClown
   entities:
   - uid: 10686

--- a/Resources/Maps/_starcup/glacier.yml
+++ b/Resources/Maps/_starcup/glacier.yml
@@ -109348,13 +109348,6 @@ entities:
     - type: Transform
       pos: 30.5,21.5
       parent: 2
-- proto: VendingMachineChang
-  entities:
-  - uid: 16472
-    components:
-    - type: Transform
-      pos: 59.5,34.5
-      parent: 2
 - proto: VendingMachineChapel
   entities:
   - uid: 16473
@@ -109671,13 +109664,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-4.5
-      parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 16522
-    components:
-    - type: Transform
-      pos: 75.5,6.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/_starcup/loop.yml
+++ b/Resources/Maps/_starcup/loop.yml
@@ -79960,13 +79960,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -62.5,64.5
       parent: 2
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 12105
-    components:
-    - type: Transform
-      pos: 24.5,20.5
-      parent: 2
 - proto: PosterContrabandEAT
   entities:
   - uid: 12106

--- a/Resources/Maps/_starcup/loop.yml
+++ b/Resources/Maps/_starcup/loop.yml
@@ -98940,13 +98940,6 @@ entities:
     - type: Transform
       pos: -9.5,50.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 15277
-    components:
-    - type: Transform
-      pos: 23.5,11.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 15278

--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -66640,13 +66640,6 @@ entities:
     - type: Transform
       pos: -28.5,10.5
       parent: 2
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 10008
-    components:
-    - type: Transform
-      pos: -38.5,26.5
-      parent: 2
 - proto: PosterLegitHereForYourSafety
   entities:
   - uid: 10009

--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -65746,13 +65746,6 @@ entities:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-- proto: PaintingSleepingGypsy
-  entities:
-  - uid: 9854
-    components:
-    - type: Transform
-      pos: -28.5,-13.5
-      parent: 2
 - proto: PaladinCircuitBoard
   entities:
   - uid: 9855
@@ -66620,18 +66613,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,31.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 10005
-    components:
-    - type: Transform
-      pos: 17.5,-14.5
-      parent: 2
-  - uid: 10006
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
       parent: 2
 - proto: PosterLegitDoNotQuestion
   entities:

--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -80602,23 +80602,6 @@ entities:
     - type: Transform
       pos: 10.5,26.5
       parent: 2
-- proto: VendingMachineChang
-  entities:
-  - uid: 12230
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 2
-  - uid: 12231
-    components:
-    - type: Transform
-      pos: 23.5,-6.5
-      parent: 2
-  - uid: 12232
-    components:
-    - type: Transform
-      pos: 2.5,-32.5
-      parent: 2
 - proto: VendingMachineChapel
   entities:
   - uid: 12233
@@ -80985,13 +80968,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-45.5
-      parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 12288
-    components:
-    - type: Transform
-      pos: 29.5,-32.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/_starcup/packed.yml
+++ b/Resources/Maps/_starcup/packed.yml
@@ -71180,13 +71180,6 @@ entities:
     - type: Transform
       pos: 31.5,-13.5
       parent: 2
-- proto: PosterContrabandHaveaPuff
-  entities:
-  - uid: 10770
-    components:
-    - type: Transform
-      pos: 44.5,-8.5
-      parent: 2
 - proto: PosterContrabandMissingGloves
   entities:
   - uid: 10771
@@ -71243,13 +71236,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 10779
-    components:
-    - type: Transform
-      pos: 28.5,-7.5
       parent: 2
 - proto: PosterLegitDickGumshue
   entities:
@@ -71488,13 +71474,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-10.5
-      parent: 2
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 10817
-    components:
-    - type: Transform
-      pos: 23.5,26.5
       parent: 2
 - proto: PosterLegitVacation
   entities:

--- a/Resources/Maps/_starcup/packed.yml
+++ b/Resources/Maps/_starcup/packed.yml
@@ -85748,13 +85748,6 @@ entities:
     - type: Transform
       pos: 55.5,36.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 13040
-    components:
-    - type: Transform
-      pos: 67.5,35.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 13041

--- a/Resources/Maps/_starcup/reach.yml
+++ b/Resources/Maps/_starcup/reach.yml
@@ -12486,20 +12486,6 @@ entities:
     - type: Transform
       pos: 20.5,5.5
       parent: 2
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 1790
-    components:
-    - type: Transform
-      pos: 14.5,-1.5
-      parent: 2
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 1791
-    components:
-    - type: Transform
-      pos: 9.5,-9.5
-      parent: 2
 - proto: PosterLegitVacation
   entities:
   - uid: 1792

--- a/Resources/Maps/_starcup/reach.yml
+++ b/Resources/Maps/_starcup/reach.yml
@@ -12333,13 +12333,6 @@ entities:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 1767
-    components:
-    - type: Transform
-      pos: 11.5,-7.5
-      parent: 2
 - proto: PosterContrabandHighEffectEngineering
   entities:
   - uid: 1768
@@ -12374,13 +12367,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 1773
-    components:
-    - type: Transform
-      pos: -7.5,6.5
       parent: 2
 - proto: PosterLegitHelpOthers
   entities:

--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -51807,13 +51807,6 @@ entities:
     - type: Transform
       pos: 42.5,-5.5
       parent: 2
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 8178
-    components:
-    - type: Transform
-      pos: 13.5,20.5
-      parent: 2
 - proto: PosterContrabandSpaceCola
   entities:
   - uid: 8179
@@ -51871,13 +51864,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-18.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 8187
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
       parent: 2
 - proto: PosterLegitDickGumshue
   entities:

--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -62469,18 +62469,6 @@ entities:
     - type: Transform
       pos: 10.5,21.5
       parent: 2
-- proto: VendingMachineChang
-  entities:
-  - uid: 9855
-    components:
-    - type: Transform
-      pos: -34.5,10.5
-      parent: 2
-  - uid: 9856
-    components:
-    - type: Transform
-      pos: 5.5,-17.5
-      parent: 2
 - proto: VendingMachineChapel
   entities:
   - uid: 9857
@@ -62775,18 +62763,6 @@ entities:
     components:
     - type: Transform
       pos: 26.5,6.5
-      parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 9900
-    components:
-    - type: Transform
-      pos: -11.5,-9.5
-      parent: 2
-  - uid: 9901
-    components:
-    - type: Transform
-      pos: 19.5,-24.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/_starcup/syndicomm.yml
+++ b/Resources/Maps/_starcup/syndicomm.yml
@@ -54312,13 +54312,6 @@ entities:
     - type: Transform
       pos: -6.5,-49.5
       parent: 1668
-- proto: VendingMachineChang
-  entities:
-  - uid: 1754
-    components:
-    - type: Transform
-      pos: -7.5,5.5
-      parent: 1668
 - proto: VendingMachineChefDrobe
   entities:
   - uid: 1164

--- a/Resources/Maps/_starcup/syndicomm.yml
+++ b/Resources/Maps/_starcup/syndicomm.yml
@@ -44044,16 +44044,6 @@ entities:
     - type: Transform
       pos: -18.5,28.5
       parent: 1668
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 9291
-    components:
-    - type: MetaData
-      desc: Ah the good old days.
-      name: Beach Star Bratton!
-    - type: Transform
-      pos: -10.5,8.5
-      parent: 1668
 - proto: PosterContrabandBorgFancy
   entities:
   - uid: 7294
@@ -44094,20 +44084,6 @@ entities:
     components:
     - type: Transform
       pos: 7.5,-32.5
-      parent: 1668
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 7286
-    components:
-    - type: Transform
-      pos: -47.5,2.5
-      parent: 1668
-- proto: PosterContrabandDDayPromo
-  entities:
-  - uid: 9326
-    components:
-    - type: Transform
-      pos: -39.5,8.5
       parent: 1668
 - proto: PosterContrabandDonk
   entities:
@@ -44167,13 +44143,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,16.5
-      parent: 1668
-- proto: PosterContrabandHaveaPuff
-  entities:
-  - uid: 9293
-    components:
-    - type: Transform
-      pos: 7.5,-13.5
       parent: 1668
 - proto: PosterContrabandHighEffectEngineering
   entities:
@@ -44325,20 +44294,6 @@ entities:
     - type: Transform
       pos: -55.5,-3.5
       parent: 1668
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 9309
-    components:
-    - type: Transform
-      pos: 2.5,9.5
-      parent: 1668
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 9341
-    components:
-    - type: Transform
-      pos: -19.5,-3.5
-      parent: 1668
 - proto: PosterContrabandSyndicateRecruitment
   entities:
   - uid: 130
@@ -44419,13 +44374,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,23.5
-      parent: 1668
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 1328
-    components:
-    - type: Transform
-      pos: 31.5,-22.5
       parent: 1668
 - proto: PosterLegitGetYourLEGS
   entities:

--- a/Resources/Maps/_starcup/syndicomm.yml
+++ b/Resources/Maps/_starcup/syndicomm.yml
@@ -44427,14 +44427,6 @@ entities:
     - type: Transform
       pos: 31.5,-22.5
       parent: 1668
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 2447
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,31.5
-      parent: 1668
 - proto: PosterLegitGetYourLEGS
   entities:
   - uid: 9333
@@ -44597,20 +44589,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,13.5
-      parent: 1668
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 9311
-    components:
-    - type: Transform
-      pos: 11.5,6.5
-      parent: 1668
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 309
-    components:
-    - type: Transform
-      pos: 23.5,6.5
       parent: 1668
 - proto: PosterLegitVacation
   entities:
@@ -50194,13 +50172,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,26.5
-      parent: 1668
-- proto: StatueBananiumClown
-  entities:
-  - uid: 9616
-    components:
-    - type: Transform
-      pos: -32.5,11.5
       parent: 1668
 - proto: StatueVenusBlue
   entities:

--- a/Resources/Maps/amber.yml
+++ b/Resources/Maps/amber.yml
@@ -115414,13 +115414,6 @@ entities:
     - type: Transform
       pos: 22.5,-57.5
       parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 8557
-    components:
-    - type: Transform
-      pos: 47.5,-2.5
-      parent: 2
 - proto: PosterLegitFruitBowl
   entities:
   - uid: 22076

--- a/Resources/Maps/amber.yml
+++ b/Resources/Maps/amber.yml
@@ -136667,13 +136667,6 @@ entities:
     - type: Transform
       pos: 44.5,-60.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 13180
-    components:
-    - type: Transform
-      pos: 25.5,-12.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 20256

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -142446,18 +142446,6 @@ entities:
     - type: Transform
       pos: 8.5,-27.5
       parent: 60
-- proto: VendingMachineChang
-  entities:
-  - uid: 4618
-    components:
-    - type: Transform
-      pos: -17.5,-53.5
-      parent: 60
-  - uid: 18522
-    components:
-    - type: Transform
-      pos: 19.5,-15.5
-      parent: 60
 - proto: VendingMachineChapel
   entities:
   - uid: 14515
@@ -142795,18 +142783,6 @@ entities:
     components:
     - type: Transform
       pos: -57.5,25.5
-      parent: 60
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 3525
-    components:
-    - type: Transform
-      pos: 45.5,-36.5
-      parent: 60
-  - uid: 18788
-    components:
-    - type: Transform
-      pos: -40.5,16.5
       parent: 60
 - proto: VendingMachineTankDispenserEngineering
   entities:

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -118097,13 +118097,14 @@ entities:
     - type: Transform
       pos: -26.5,-25.5
       parent: 60
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 8452
-    components:
-    - type: Transform
-      pos: -23.5,-17.5
-      parent: 60
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 8452
+#    components:
+#    - type: Transform
+#      pos: -23.5,-17.5
+#      parent: 60
 - proto: PosterLegitFoamForceAd
   entities:
   - uid: 3980
@@ -118455,18 +118456,19 @@ entities:
     - type: Transform
       pos: -60.5,3.5
       parent: 60
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 1458
-    components:
-    - type: Transform
-      pos: 14.5,-18.5
-      parent: 60
-  - uid: 8506
-    components:
-    - type: Transform
-      pos: -33.5,1.5
-      parent: 60
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 1458
+#    components:
+#    - type: Transform
+#      pos: 14.5,-18.5
+#      parent: 60
+#  - uid: 8506
+#    components:
+#    - type: Transform
+#      pos: -33.5,1.5
+#      parent: 60
 - proto: PosterLegitTheOwl
   entities:
   - uid: 7897

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -117715,13 +117715,6 @@ entities:
     - type: Transform
       pos: 22.5,-14.5
       parent: 60
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 24373
-    components:
-    - type: Transform
-      pos: 10.5,-3.5
-      parent: 7536
 - proto: PosterContrabandDonk
   entities:
   - uid: 4520
@@ -117785,13 +117778,6 @@ entities:
     components:
     - type: Transform
       pos: 11.5,16.5
-      parent: 60
-- proto: PosterContrabandHaveaPuff
-  entities:
-  - uid: 296
-    components:
-    - type: Transform
-      pos: 36.5,-35.5
       parent: 60
 - proto: PosterContrabandHighEffectEngineering
   entities:
@@ -117921,18 +117907,6 @@ entities:
     - type: Transform
       pos: 25.5,-10.5
       parent: 60
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 19156
-    components:
-    - type: Transform
-      pos: 35.5,-38.5
-      parent: 60
-  - uid: 24674
-    components:
-    - type: Transform
-      pos: 12.5,-14.5
-      parent: 60
 - proto: PosterContrabandSpaceCola
   entities:
   - uid: 16098
@@ -117947,18 +117921,6 @@ entities:
     - type: Transform
       pos: 21.5,-10.5
       parent: 60
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 3591
-    components:
-    - type: Transform
-      pos: 13.5,-42.5
-      parent: 60
-  - uid: 9127
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 7536
 - proto: PosterContrabandSyndicateRecruitment
   entities:
   - uid: 9125
@@ -118068,23 +118030,6 @@ entities:
     - type: Transform
       pos: -6.5,-25.5
       parent: 60
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 1242
-    components:
-    - type: Transform
-      pos: -7.5,-43.5
-      parent: 60
-  - uid: 13581
-    components:
-    - type: Transform
-      pos: 12.5,-36.5
-      parent: 60
-  - uid: 17383
-    components:
-    - type: Transform
-      pos: -66.5,23.5
-      parent: 60
 - proto: PosterLegitDickGumshue
   entities:
   - uid: 3648
@@ -118097,14 +118042,6 @@ entities:
     - type: Transform
       pos: -26.5,-25.5
       parent: 60
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 8452
-#    components:
-#    - type: Transform
-#      pos: -23.5,-17.5
-#      parent: 60
 - proto: PosterLegitFoamForceAd
   entities:
   - uid: 3980
@@ -118456,32 +118393,12 @@ entities:
     - type: Transform
       pos: -60.5,3.5
       parent: 60
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 1458
-#    components:
-#    - type: Transform
-#      pos: 14.5,-18.5
-#      parent: 60
-#  - uid: 8506
-#    components:
-#    - type: Transform
-#      pos: -33.5,1.5
-#      parent: 60
 - proto: PosterLegitTheOwl
   entities:
   - uid: 7897
     components:
     - type: Transform
       pos: 45.5,-43.5
-      parent: 60
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 25310
-    components:
-    - type: Transform
-      pos: 46.5,22.5
       parent: 60
 - proto: PosterLegitVacation
   entities:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -159100,18 +159100,6 @@ entities:
     - type: Transform
       pos: -8.5,-21.5
       parent: 8364
-- proto: VendingMachineChang
-  entities:
-  - uid: 5238
-    components:
-    - type: Transform
-      pos: 57.5,-37.5
-      parent: 8364
-  - uid: 17860
-    components:
-    - type: Transform
-      pos: 44.5,-31.5
-      parent: 8364
 - proto: VendingMachineChapel
   entities:
   - uid: 11147
@@ -159481,18 +159469,6 @@ entities:
     components:
     - type: Transform
       pos: -73.5,-3.5
-      parent: 8364
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 21642
-    components:
-    - type: Transform
-      pos: 61.5,19.5
-      parent: 8364
-  - uid: 26548
-    components:
-    - type: Transform
-      pos: -24.5,45.5
       parent: 8364
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -133526,13 +133526,6 @@ entities:
     - type: Transform
       pos: 8.5,-45.5
       parent: 8364
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 26557
-    components:
-    - type: Transform
-      pos: -19.5,41.5
-      parent: 8364
 - proto: PosterContrabandBountyHunters
   entities:
   - uid: 26556

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -43979,14 +43979,15 @@ entities:
     - type: Transform
       pos: 31.5,-22.5
       parent: 1668
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 2447
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,31.5
-      parent: 1668
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 2447
+#    components:
+#    - type: Transform
+#      rot: 1.5707963267948966 rad
+#      pos: 9.5,31.5
+#      parent: 1668
 - proto: PosterLegitGetYourLEGS
   entities:
   - uid: 9333
@@ -44463,20 +44464,21 @@ entities:
     - type: Transform
       pos: 19.5,13.5
       parent: 1668
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 9311
-    components:
-    - type: Transform
-      pos: 11.5,6.5
-      parent: 1668
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 309
-    components:
-    - type: Transform
-      pos: 23.5,6.5
-      parent: 1668
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 9311
+#    components:
+#    - type: Transform
+#      pos: 11.5,6.5
+#      parent: 1668
+#- proto: PosterLegitUeNo
+#  entities:
+#  - uid: 309
+#    components:
+#    - type: Transform
+#      pos: 23.5,6.5
+#      parent: 1668
 - proto: PosterLegitVacation
   entities:
   - uid: 98

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -54049,13 +54049,6 @@ entities:
     - type: Transform
       pos: -6.5,-49.5
       parent: 1668
-- proto: VendingMachineChang
-  entities:
-  - uid: 1754
-    components:
-    - type: Transform
-      pos: -7.5,5.5
-      parent: 1668
 - proto: VendingMachineChefDrobe
   entities:
   - uid: 1164

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -43812,16 +43812,6 @@ entities:
     - type: Transform
       pos: -18.5,28.5
       parent: 1668
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 9291
-    components:
-    - type: MetaData
-      desc: Ah the good old days.
-      name: Beach Star Bratton!
-    - type: Transform
-      pos: -10.5,8.5
-      parent: 1668
 - proto: PosterContrabandC20r
   entities:
   - uid: 2448
@@ -43864,13 +43854,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,16.5
-      parent: 1668
-- proto: PosterContrabandHaveaPuff
-  entities:
-  - uid: 9293
-    components:
-    - type: Transform
-      pos: 7.5,-13.5
       parent: 1668
 - proto: PosterContrabandHighEffectEngineering
   entities:
@@ -43930,13 +43913,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 9.5,27.5
       parent: 1668
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 9309
-    components:
-    - type: Transform
-      pos: 2.5,9.5
-      parent: 1668
 - proto: PosterContrabandTools
   entities:
   - uid: 9312
@@ -43972,22 +43948,6 @@ entities:
     - type: Transform
       pos: 6.5,23.5
       parent: 1668
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 1328
-    components:
-    - type: Transform
-      pos: 31.5,-22.5
-      parent: 1668
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 2447
-#    components:
-#    - type: Transform
-#      rot: 1.5707963267948966 rad
-#      pos: 9.5,31.5
-#      parent: 1668
 - proto: PosterLegitGetYourLEGS
   entities:
   - uid: 9333
@@ -44464,21 +44424,6 @@ entities:
     - type: Transform
       pos: 19.5,13.5
       parent: 1668
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 9311
-#    components:
-#    - type: Transform
-#      pos: 11.5,6.5
-#      parent: 1668
-#- proto: PosterLegitUeNo
-#  entities:
-#  - uid: 309
-#    components:
-#    - type: Transform
-#      pos: 23.5,6.5
-#      parent: 1668
 - proto: PosterLegitVacation
   entities:
   - uid: 98

--- a/Resources/Maps/convex.yml
+++ b/Resources/Maps/convex.yml
@@ -216652,18 +216652,6 @@ entities:
     - type: Transform
       pos: 69.5,102.5
       parent: 1
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 12416
-    components:
-    - type: Transform
-      pos: 59.5,44.5
-      parent: 1
-  - uid: 37029
-    components:
-    - type: Transform
-      pos: 100.5,165.5
-      parent: 1
 - proto: VendingMachineSustenance
   entities:
   - uid: 27482

--- a/Resources/Maps/convex.yml
+++ b/Resources/Maps/convex.yml
@@ -189953,13 +189953,6 @@ entities:
     - type: Transform
       pos: 39.5,77.5
       parent: 1
-- proto: PaintingSleepingGypsy
-  entities:
-  - uid: 13600
-    components:
-    - type: Transform
-      pos: 41.5,70.5
-      parent: 1
 - proto: PaintingTheGreatWave
   entities:
   - uid: 13599
@@ -190958,26 +190951,12 @@ entities:
     - type: Transform
       pos: 90.5,56.5
       parent: 1
-- proto: PosterContrabandRise
-  entities:
-  - uid: 22883
-    components:
-    - type: Transform
-      pos: 121.5,45.5
-      parent: 1
 - proto: PosterContrabandShamblersJuice
   entities:
   - uid: 26813
     components:
     - type: Transform
       pos: 119.5,107.5
-      parent: 1
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 14272
-    components:
-    - type: Transform
-      pos: 62.5,54.5
       parent: 1
 - proto: PosterContrabandSpaceCola
   entities:
@@ -191084,29 +191063,6 @@ entities:
     - type: Transform
       pos: 155.5,124.5
       parent: 1
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 22727
-    components:
-    - type: Transform
-      pos: 135.5,50.5
-      parent: 1
-  - uid: 24291
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 105.5,105.5
-      parent: 1
-  - uid: 30141
-    components:
-    - type: Transform
-      pos: 143.5,137.5
-      parent: 1
-  - uid: 35153
-    components:
-    - type: Transform
-      pos: 106.5,169.5
-      parent: 1
 - proto: PosterLegitDoNotQuestion
   entities:
   - uid: 21898
@@ -191121,14 +191077,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 72.5,161.5
       parent: 1
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 22568
-#    components:
-#    - type: Transform
-#      pos: 133.5,67.5
-#      parent: 1
 - proto: PosterLegitFoamForceAd
   entities:
   - uid: 19542
@@ -191383,15 +191331,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 89.5,48.5
       parent: 1
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 30020
-#    components:
-#    - type: Transform
-#      rot: -1.5707963267948966 rad
-#      pos: 92.5,38.5
-#      parent: 1
 - proto: PosterLegitStateLaws
   entities:
   - uid: 20911

--- a/Resources/Maps/convex.yml
+++ b/Resources/Maps/convex.yml
@@ -191121,13 +191121,14 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 72.5,161.5
       parent: 1
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 22568
-    components:
-    - type: Transform
-      pos: 133.5,67.5
-      parent: 1
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 22568
+#    components:
+#    - type: Transform
+#      pos: 133.5,67.5
+#      parent: 1
 - proto: PosterLegitFoamForceAd
   entities:
   - uid: 19542
@@ -191382,14 +191383,15 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 89.5,48.5
       parent: 1
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 30020
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 92.5,38.5
-      parent: 1
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 30020
+#    components:
+#    - type: Transform
+#      rot: -1.5707963267948966 rad
+#      pos: 92.5,38.5
+#      parent: 1
 - proto: PosterLegitStateLaws
   entities:
   - uid: 20911

--- a/Resources/Maps/fland.yml
+++ b/Resources/Maps/fland.yml
@@ -170273,13 +170273,14 @@ entities:
     - type: Transform
       pos: 49.5,-18.5
       parent: 13329
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 10174
-    components:
-    - type: Transform
-      pos: 22.5,21.5
-      parent: 13329
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 10174
+#    components:
+#    - type: Transform
+#      pos: 22.5,21.5
+#      parent: 13329
 - proto: PosterLegitWalk
   entities:
   - uid: 31603

--- a/Resources/Maps/fland.yml
+++ b/Resources/Maps/fland.yml
@@ -202140,18 +202140,6 @@ entities:
     - type: Transform
       pos: 40.5,-10.5
       parent: 13329
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 31768
-    components:
-    - type: Transform
-      pos: -7.5,-27.5
-      parent: 13329
-  - uid: 32754
-    components:
-    - type: Transform
-      pos: 109.5,36.5
-      parent: 13329
 - proto: VendingMachineSustenance
   entities:
   - uid: 8456

--- a/Resources/Maps/fland.yml
+++ b/Resources/Maps/fland.yml
@@ -169799,18 +169799,6 @@ entities:
     - type: Transform
       pos: 70.5,-17.5
       parent: 13329
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 1635
-    components:
-    - type: Transform
-      pos: 5.5,14.5
-      parent: 13329
-  - uid: 26276
-    components:
-    - type: Transform
-      pos: 68.5,17.5
-      parent: 13329
 - proto: PosterContrabandBorgFancyv2
   entities:
   - uid: 23584
@@ -169824,13 +169812,6 @@ entities:
     components:
     - type: Transform
       pos: 59.5,-52.5
-      parent: 13329
-- proto: PosterContrabandDDayPromo
-  entities:
-  - uid: 35197
-    components:
-    - type: Transform
-      pos: 66.5,-42.5
       parent: 13329
 - proto: PosterContrabandDonutCorp
   entities:
@@ -169917,13 +169898,6 @@ entities:
     - type: Transform
       pos: 18.5,16.5
       parent: 13329
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 26574
-    components:
-    - type: Transform
-      pos: 80.5,-15.5
-      parent: 13329
 - proto: PosterContrabandTheBigGasTruth
   entities:
   - uid: 35198
@@ -169989,18 +169963,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,8.5
-      parent: 13329
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 1187
-    components:
-    - type: Transform
-      pos: -13.5,27.5
-      parent: 13329
-  - uid: 32206
-    components:
-    - type: Transform
-      pos: 26.5,-28.5
       parent: 13329
 - proto: PosterLegitDickGumshue
   entities:
@@ -170273,14 +170235,6 @@ entities:
     - type: Transform
       pos: 49.5,-18.5
       parent: 13329
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 10174
-#    components:
-#    - type: Transform
-#      pos: 22.5,21.5
-#      parent: 13329
 - proto: PosterLegitWalk
   entities:
   - uid: 31603

--- a/Resources/Maps/gate.yml
+++ b/Resources/Maps/gate.yml
@@ -172746,28 +172746,6 @@ entities:
     - type: Transform
       pos: -83.5,175.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 16415
-    components:
-    - type: Transform
-      pos: -103.5,64.5
-      parent: 2
-  - uid: 28196
-    components:
-    - type: Transform
-      pos: -84.5,145.5
-      parent: 2
-  - uid: 36847
-    components:
-    - type: Transform
-      pos: -99.5,145.5
-      parent: 2
-  - uid: 37223
-    components:
-    - type: Transform
-      pos: -40.5,174.5
-      parent: 2
 - proto: VendingMachineSpaceUp
   entities:
   - uid: 17163

--- a/Resources/Maps/gate.yml
+++ b/Resources/Maps/gate.yml
@@ -144264,13 +144264,6 @@ entities:
     - type: Transform
       pos: -102.5,28.5
       parent: 2
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 8720
-    components:
-    - type: Transform
-      pos: 56.5,22.5
-      parent: 2
 - proto: PosterContrabandBorgFancy
   entities:
   - uid: 20901
@@ -144375,13 +144368,6 @@ entities:
     components:
     - type: Transform
       pos: -59.5,160.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 8719
-    components:
-    - type: Transform
-      pos: 49.5,27.5
       parent: 2
 - proto: PosterLegitHelpOthers
   entities:

--- a/Resources/Maps/loop.yml
+++ b/Resources/Maps/loop.yml
@@ -79785,13 +79785,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -62.5,64.5
       parent: 2
-- proto: PosterContrabandCybersun600
-  entities:
-  - uid: 14723
-    components:
-    - type: Transform
-      pos: 24.5,20.5
-      parent: 2
 - proto: PosterContrabandEAT
   entities:
   - uid: 14724

--- a/Resources/Maps/loop.yml
+++ b/Resources/Maps/loop.yml
@@ -98720,13 +98720,6 @@ entities:
     - type: Transform
       pos: -9.5,50.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 14464
-    components:
-    - type: Transform
-      pos: 23.5,11.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 5099

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -129768,23 +129768,6 @@ entities:
     - type: Transform
       pos: -51.5,68.5
       parent: 30
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 16926
-    components:
-    - type: Transform
-      pos: -57.5,33.5
-      parent: 30
-  - uid: 17106
-    components:
-    - type: Transform
-      pos: -61.5,45.5
-      parent: 30
-  - uid: 21114
-    components:
-    - type: Transform
-      pos: -30.5,-42.5
-      parent: 30
 - proto: VendingMachineSustenance
   entities:
   - uid: 10256

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -107457,13 +107457,6 @@ entities:
     - type: Transform
       pos: 13.5,-28.5
       parent: 30
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 13074
-    components:
-    - type: Transform
-      pos: 28.5,-8.5
-      parent: 30
 - proto: PosterContrabandBountyHunters
   entities:
   - uid: 6449
@@ -107570,13 +107563,6 @@ entities:
     - type: Transform
       pos: -1.5,-8.5
       parent: 30
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 16190
-    components:
-    - type: Transform
-      pos: 38.5,20.5
-      parent: 30
 - proto: PosterContrabandTools
   entities:
   - uid: 1650
@@ -107646,28 +107632,6 @@ entities:
     - type: Transform
       pos: 47.5,22.5
       parent: 30
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 607
-    components:
-    - type: Transform
-      pos: 7.5,6.5
-      parent: 30
-  - uid: 16919
-    components:
-    - type: Transform
-      pos: -43.5,2.5
-      parent: 30
-  - uid: 21354
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 30
-  - uid: 21554
-    components:
-    - type: Transform
-      pos: 44.5,32.5
-      parent: 30
 - proto: PosterLegitDickGumshue
   entities:
   - uid: 2418
@@ -107675,14 +107639,6 @@ entities:
     - type: Transform
       pos: -45.5,33.5
       parent: 30
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 2417
-#    components:
-#    - type: Transform
-#      pos: -33.5,55.5
-#      parent: 30
 - proto: PosterLegitGetYourLEGS
   entities:
   - uid: 7426
@@ -107926,21 +107882,6 @@ entities:
     - type: Transform
       pos: -14.5,-50.5
       parent: 30
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 2411
-#    components:
-#    - type: Transform
-#      pos: -30.5,55.5
-#      parent: 30
-#- proto: PosterLegitUeNo
-#  entities:
-#  - uid: 1654
-#    components:
-#    - type: Transform
-#      pos: -48.5,16.5
-#      parent: 30
 - proto: PosterMapMarathon
   entities:
   - uid: 1

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -107675,13 +107675,14 @@ entities:
     - type: Transform
       pos: -45.5,33.5
       parent: 30
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 2417
-    components:
-    - type: Transform
-      pos: -33.5,55.5
-      parent: 30
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 2417
+#    components:
+#    - type: Transform
+#      pos: -33.5,55.5
+#      parent: 30
 - proto: PosterLegitGetYourLEGS
   entities:
   - uid: 7426
@@ -107925,20 +107926,21 @@ entities:
     - type: Transform
       pos: -14.5,-50.5
       parent: 30
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 2411
-    components:
-    - type: Transform
-      pos: -30.5,55.5
-      parent: 30
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 1654
-    components:
-    - type: Transform
-      pos: -48.5,16.5
-      parent: 30
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 2411
+#    components:
+#    - type: Transform
+#      pos: -30.5,55.5
+#      parent: 30
+#- proto: PosterLegitUeNo
+#  entities:
+#  - uid: 1654
+#    components:
+#    - type: Transform
+#      pos: -48.5,16.5
+#      parent: 30
 - proto: PosterMapMarathon
   entities:
   - uid: 1

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -162317,13 +162317,6 @@ entities:
     - type: Transform
       pos: -4.5,-1.5
       parent: 5350
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 6712
-    components:
-    - type: Transform
-      pos: 34.5,-25.5
-      parent: 5350
 - proto: VendingMachineSustenance
   entities:
   - uid: 9623

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -135926,13 +135926,6 @@ entities:
     - type: Transform
       pos: -54.5,-14.5
       parent: 5350
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 8216
-    components:
-    - type: Transform
-      pos: -24.5,30.5
-      parent: 5350
 - proto: PosterContrabandCC64KAd
   entities:
   - uid: 4304
@@ -136329,13 +136322,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-50.5
-      parent: 5350
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 22930
-    components:
-    - type: Transform
-      pos: -6.5,-68.5
       parent: 5350
 - proto: PosterLegitVacation
   entities:

--- a/Resources/Maps/oasis.yml
+++ b/Resources/Maps/oasis.yml
@@ -150776,13 +150776,6 @@ entities:
       deleteOnEmptyLinks: True
       linkedEntities:
       - 30409
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 11972
-    components:
-    - type: Transform
-      pos: 25.5,-2.5
-      parent: 2
 - proto: PosterContrabandClown
   entities:
   - uid: 8814
@@ -150873,15 +150866,6 @@ entities:
     - type: Transform
       pos: 28.5,-22.5
       parent: 2
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 3731
-#    components:
-#    - type: Transform
-#      rot: 1.5707963267948966 rad
-#      pos: 37.5,-42.5
-#      parent: 2
 - proto: PosterLegitFoamForceAd
   entities:
   - uid: 11964

--- a/Resources/Maps/oasis.yml
+++ b/Resources/Maps/oasis.yml
@@ -178159,18 +178159,6 @@ entities:
     - type: Transform
       pos: 8.5,37.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 3750
-    components:
-    - type: Transform
-      pos: 39.5,-12.5
-      parent: 2
-  - uid: 29641
-    components:
-    - type: Transform
-      pos: 10.5,-51.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 21229

--- a/Resources/Maps/oasis.yml
+++ b/Resources/Maps/oasis.yml
@@ -150873,14 +150873,15 @@ entities:
     - type: Transform
       pos: 28.5,-22.5
       parent: 2
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 3731
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 37.5,-42.5
-      parent: 2
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 3731
+#    components:
+#    - type: Transform
+#      rot: 1.5707963267948966 rad
+#      pos: 37.5,-42.5
+#      parent: 2
 - proto: PosterLegitFoamForceAd
   entities:
   - uid: 11964

--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -65421,13 +65421,6 @@ entities:
     - type: Transform
       pos: -7.5,2.5
       parent: 4812
-- proto: PaintingSleepingGypsy
-  entities:
-  - uid: 7742
-    components:
-    - type: Transform
-      pos: -28.5,-13.5
-      parent: 4812
 - proto: PaladinCircuitBoard
   entities:
   - uid: 12650
@@ -66278,18 +66271,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -25.5,31.5
       parent: 4812
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 5360
-    components:
-    - type: Transform
-      pos: 17.5,-14.5
-      parent: 4812
-  - uid: 6488
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 4812
 - proto: PosterLegitDoNotQuestion
   entities:
   - uid: 8218
@@ -66297,14 +66278,6 @@ entities:
     - type: Transform
       pos: -28.5,10.5
       parent: 4812
-# starcup: removed for tone
-#- proto: PosterLegitEnlist
-#  entities:
-#  - uid: 8354
-#    components:
-#    - type: Transform
-#      pos: -38.5,26.5
-#      parent: 4812
 - proto: PosterLegitHereForYourSafety
   entities:
   - uid: 10954

--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -66297,13 +66297,14 @@ entities:
     - type: Transform
       pos: -28.5,10.5
       parent: 4812
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 8354
-    components:
-    - type: Transform
-      pos: -38.5,26.5
-      parent: 4812
+# starcup: removed for tone
+#- proto: PosterLegitEnlist
+#  entities:
+#  - uid: 8354
+#    components:
+#    - type: Transform
+#      pos: -38.5,26.5
+#      parent: 4812
 - proto: PosterLegitHereForYourSafety
   entities:
   - uid: 10954

--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -80076,23 +80076,6 @@ entities:
     - type: Transform
       pos: 10.5,26.5
       parent: 4812
-- proto: VendingMachineChang
-  entities:
-  - uid: 923
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 4812
-  - uid: 4538
-    components:
-    - type: Transform
-      pos: 23.5,-6.5
-      parent: 4812
-  - uid: 6422
-    components:
-    - type: Transform
-      pos: 2.5,-32.5
-      parent: 4812
 - proto: VendingMachineChapel
   entities:
   - uid: 7036
@@ -80459,13 +80442,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-45.5
-      parent: 4812
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 11780
-    components:
-    - type: Transform
-      pos: 29.5,-32.5
       parent: 4812
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -70716,13 +70716,6 @@ entities:
     - type: Transform
       pos: 31.5,-13.5
       parent: 2
-- proto: PosterContrabandHaveaPuff
-  entities:
-  - uid: 13100
-    components:
-    - type: Transform
-      pos: 44.5,-8.5
-      parent: 2
 - proto: PosterContrabandMissingGloves
   entities:
   - uid: 11068
@@ -70779,13 +70772,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 7287
-    components:
-    - type: Transform
-      pos: 28.5,-7.5
       parent: 2
 - proto: PosterLegitDickGumshue
   entities:
@@ -71024,13 +71010,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-10.5
-      parent: 2
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 11093
-    components:
-    - type: Transform
-      pos: 23.5,26.5
       parent: 2
 - proto: PosterLegitVacation
   entities:

--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -85223,13 +85223,6 @@ entities:
     - type: Transform
       pos: 55.5,36.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 5467
-    components:
-    - type: Transform
-      pos: 67.5,35.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 13623

--- a/Resources/Maps/plasma.yml
+++ b/Resources/Maps/plasma.yml
@@ -129673,13 +129673,14 @@ entities:
     - type: Transform
       pos: -98.5,-18.5
       parent: 2
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 23067
-    components:
-    - type: Transform
-      pos: -85.5,-24.5
-      parent: 2
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 23067
+#    components:
+#    - type: Transform
+#      pos: -85.5,-24.5
+#      parent: 2
 - proto: PosterLegitWorkForAFuture
   entities:
   - uid: 22504

--- a/Resources/Maps/plasma.yml
+++ b/Resources/Maps/plasma.yml
@@ -129673,14 +129673,6 @@ entities:
     - type: Transform
       pos: -98.5,-18.5
       parent: 2
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 23067
-#    components:
-#    - type: Transform
-#      pos: -85.5,-24.5
-#      parent: 2
 - proto: PosterLegitWorkForAFuture
   entities:
   - uid: 22504

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -11954,13 +11954,6 @@ entities:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 1697
-    components:
-    - type: Transform
-      pos: 11.5,-7.5
-      parent: 2
 - proto: PosterContrabandHighEffectEngineering
   entities:
   - uid: 1698
@@ -11995,13 +11988,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 1703
-    components:
-    - type: Transform
-      pos: -7.5,6.5
       parent: 2
 - proto: PosterLegitHelpOthers
   entities:
@@ -12107,21 +12093,6 @@ entities:
     - type: Transform
       pos: 20.5,5.5
       parent: 2
-# starcup: removed for tone
-#- proto: PosterLegitSpaceCops
-#  entities:
-#  - uid: 1721
-#    components:
-#    - type: Transform
-#      pos: 14.5,-1.5
-#      parent: 2
-#- proto: PosterLegitUeNo
-#  entities:
-#  - uid: 1722
-#    components:
-#    - type: Transform
-#      pos: 9.5,-9.5
-#      parent: 2
 - proto: PosterLegitVacation
   entities:
   - uid: 1723

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -12107,20 +12107,21 @@ entities:
     - type: Transform
       pos: 20.5,5.5
       parent: 2
-- proto: PosterLegitSpaceCops
-  entities:
-  - uid: 1721
-    components:
-    - type: Transform
-      pos: 14.5,-1.5
-      parent: 2
-- proto: PosterLegitUeNo
-  entities:
-  - uid: 1722
-    components:
-    - type: Transform
-      pos: 9.5,-9.5
-      parent: 2
+# starcup: removed for tone
+#- proto: PosterLegitSpaceCops
+#  entities:
+#  - uid: 1721
+#    components:
+#    - type: Transform
+#      pos: 14.5,-1.5
+#      parent: 2
+#- proto: PosterLegitUeNo
+#  entities:
+#  - uid: 1722
+#    components:
+#    - type: Transform
+#      pos: 9.5,-9.5
+#      parent: 2
 - proto: PosterLegitVacation
   entities:
   - uid: 1723

--- a/Resources/Maps/relic.yml
+++ b/Resources/Maps/relic.yml
@@ -36984,13 +36984,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 22.5,20.5
       parent: 2
-- proto: PosterContrabandRise
-  entities:
-  - uid: 7482
-    components:
-    - type: Transform
-      pos: 10.5,2.5
-      parent: 2
 - proto: PosterLegitNanotrasenLogo
   entities:
   - uid: 7536

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -50506,13 +50506,6 @@ entities:
     - type: Transform
       pos: 42.5,-5.5
       parent: 31
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 7802
-    components:
-    - type: Transform
-      pos: 13.5,20.5
-      parent: 31
 - proto: PosterContrabandSpaceCola
   entities:
   - uid: 7819
@@ -50570,13 +50563,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-18.5
-      parent: 31
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 2438
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
       parent: 31
 - proto: PosterLegitDickGumshue
   entities:

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -60858,18 +60858,6 @@ entities:
     - type: Transform
       pos: 10.5,21.5
       parent: 31
-- proto: VendingMachineChang
-  entities:
-  - uid: 792
-    components:
-    - type: Transform
-      pos: -34.5,10.5
-      parent: 31
-  - uid: 9145
-    components:
-    - type: Transform
-      pos: 5.5,-17.5
-      parent: 31
 - proto: VendingMachineChapel
   entities:
   - uid: 4887
@@ -61164,18 +61152,6 @@ entities:
     components:
     - type: Transform
       pos: 26.5,6.5
-      parent: 31
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 7561
-    components:
-    - type: Transform
-      pos: -11.5,-9.5
-      parent: 31
-  - uid: 9574
-    components:
-    - type: Transform
-      pos: 19.5,-24.5
       parent: 31
 - proto: VendingMachineSustenance
   entities:

--- a/Resources/Maps/train.yml
+++ b/Resources/Maps/train.yml
@@ -79275,16 +79275,6 @@ entities:
     - type: Transform
       pos: -10.5,-254.5
       parent: 2
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 11700
-    components:
-    - type: MetaData
-      name: Beach Star Bratton!
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-12.5
-      parent: 2
 - proto: PosterContrabandClown
   entities:
   - uid: 11701
@@ -79324,19 +79314,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 2
-- proto: PosterContrabandSmoke
-  entities:
-  - uid: 11707
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-263.5
-      parent: 2
-  - uid: 11708
-    components:
-    - type: Transform
-      pos: 1.5,-267.5
       parent: 2
 - proto: PosterLegitIan
   entities:

--- a/Resources/Maps/train.yml
+++ b/Resources/Maps/train.yml
@@ -93260,13 +93260,6 @@ entities:
     - type: Transform
       pos: 17.5,-63.5
       parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 13999
-    components:
-    - type: Transform
-      pos: 4.5,-56.5
-      parent: 2
 - proto: VendingMachineSustenance
   entities:
   - uid: 14000

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -122,7 +122,7 @@
 - type: cargoBounty
   id: BountyCubanCarp
   reward: 16000
-  description: bounty-description-cuban-carp
+  description: bounty-description-cuban-carp-starcup # starcup: rewritten for tone
   idPrefix: CC
   entries:
   - name: bounty-item-cuban-carp
@@ -237,7 +237,7 @@
 - type: cargoBounty
   id: BountyLung
   reward: 2000
-  description: bounty-description-lung
+  description: bounty-description-lung-starcup # starcup: rewritten for tone
   entries:
   - name: bounty-item-lung
     amount: 3
@@ -642,7 +642,7 @@
 - type: cargoBounty
   id: BountyBanana
   reward: 6009
-  description: bounty-description-banana
+  description: bounty-description-banana-starcup # starcup: rewritten for tone
   entries:
   - name: bounty-item-banana
     amount: 9
@@ -664,7 +664,7 @@
 - type: cargoBounty
   id: BountyHiVizVest
   reward: 3030
-  description: bounty-description-hi-viz-vest
+  description: bounty-description-hi-viz-vest-starcup # starcup: rewritten for tone
   entries:
   - name: bounty-item-hi-viz-vest
     amount: 3
@@ -730,7 +730,7 @@
 - type: cargoBounty
   id: BountyMicrowaveMachineBoard
   reward: 4000
-  description: bounty-description-microwave-machine-board
+  description: bounty-description-microwave-machine-board-starcup # starcup: rewritten for tone
   entries:
   - name: bounty-item-microwave-machine-board
     amount: 2

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -236,15 +236,16 @@
   category: cargoproduct-category-name-service
   group: market
 
-- type: cargoProduct
-  id: CrateVendingMachineRestockChang
-  icon:
-    sprite: Objects/Specific/Service/vending_machine_restock.rsi
-    state: base
-  product: CrateVendingMachineRestockChangFilled
-  cost: 1200
-  category: cargoproduct-category-name-service
-  group: market
+# starcup: removed for tone
+#- type: cargoProduct
+#  id: CrateVendingMachineRestockChang
+#  icon:
+#    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+#    state: base
+#  product: CrateVendingMachineRestockChangFilled
+#  cost: 1200
+#  category: cargoproduct-category-name-service
+#  group: market
 
 - type: cargoProduct
   id: CrateVendingMachineRestockDiscountDans

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -106,7 +106,7 @@
   id: CrateEngineeringElectricalSupplies
   parent: CrateElectrical
   name: electrical supplies crate
-  description: NT is not responsible for any workplace infighting relating to the insulated gloves included within these crates.
+  description: Two electrical toolboxes and two pairs of insulated gloves, for rewiring and repairs. A spare set of insulated gloves is included for the Mime. # starcup: rewritten for tone
   components:
   - type: StorageFill
     contents:
@@ -130,7 +130,7 @@
   id: CrateEngineeringJetpack
   parent: CrateGenericSteel
   name: jetpack crate
-  description: Two jetpacks for those who don't know how to use fire extinguishers.
+  description: Two jetpacks for off-station expeditions. Some salvagers prefer to just grab the nearest fire extinguisher. # starcup: rewritten for tone
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -47,7 +47,7 @@
   id: CrateMousetrapBoxes
   parent: CrateGenericSteel
   name: mousetraps crate
-  description: Mousetraps, for when all of service is being haunted by an entire horde of rats. Use sparingly... or not.
+  description: Mousetraps, for when peace is no longer an option. # starcup: rewritten for tone
   components:
     - type: StorageFill
       contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -25,7 +25,7 @@
   id: CrateServiceReplacementLights
   parent: CrateGenericSteel
   name: replacement lights crate
-  description: May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs.
+  description: Become a shining beacon in the dark with the help of forty two light tubes and twenty one light bulbs. # starcup: rewritten for tone
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -57,7 +57,7 @@
   id: CrateServiceSmokeables
   parent: CrateGenericSteel
   name: smokeables crate
-  description: Tired of a quick death on the station? Order this crate and chain-smoke your way to a coughy demise!
+  description: A poison that kills slowly. And that's no problem; as it happens, you aren't in any hurry! # starcup: rewritten for tone
   components:
   - type: StorageFill
     contents:
@@ -110,7 +110,7 @@
   id: CrateServiceCustomSmokable
   parent: CrateGenericSteel
   name: DIY smokeables crate
-  description: Want to get a little creative with what you use to destroy your lungs? Then this crate is for you! Has everything you need to roll your own cigarettes.
+  description: Offers the supplies necessary to roll your own cigarettes. # starcup: rewritten for tone
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -233,16 +233,17 @@
       - id: VendingMachineRestockGetmoreChocolateCorp
         amount: 2
 
-- type: entity
-  id: CrateVendingMachineRestockChangFilled
-  parent: CratePlastic
-  name: Chang restock crate
-  description: Contains a restock box for a Mr. Chang dispenser.
-  components:
-  - type: StorageFill
-    contents:
-      - id: VendingMachineRestockChang
-        amount: 2
+# starcup: removed for tone
+#- type: entity
+#  id: CrateVendingMachineRestockChangFilled
+#  parent: CratePlastic
+#  name: Chang restock crate
+#  description: Contains a restock box for a Mr. Chang dispenser.
+#  components:
+#  - type: StorageFill
+#    contents:
+#      - id: VendingMachineRestockChang
+#        amount: 2
 
 - type: entity
   id: CrateVendingMachineRestockDiscountDansFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -151,7 +151,7 @@
    id: WardrobeSecurityFilled
    suffix: Filled
    parent: WardrobeSecurity
-   description: "Cross the thin red line."
+   description: Clothes and supplies so you can be the face of station safety! # starcup: rewritten for tone
    components:
    - type: StorageFill
      contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -167,7 +167,7 @@
    id: WardrobeCargoFilled
    suffix: Filled
    parent: WardrobeCargo
-   description: "This locker? Maybe 500 spesos. Brotherhood? Priceless."
+   description: If you're going to be doing business, you can't afford to skip on appearances. # starcup: rewritten for tone
    components:
    - type: StorageFill
      contents:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
@@ -6,7 +6,7 @@
     ClothingOuterWinterChef: 2
     ClothingOuterJacketChef: 1
     ClothingUniformJumpsuitChef: 1
-    ClothingMaskItalianMoustache: 2
+    #ClothingMaskItalianMoustache: 2 # starcup: removed for tone
     ClothingUniformJumpskirtChef:  2
     ClothingHeadHatChef: 2
     ClothingShoesColorBlack: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -35,6 +35,7 @@
     Gohei: 2
     ClothingOuterSuitWitchRobes: 2
     ClothingHeadHatWitch1: 2
+    ClothingMaskItalianMoustache: 2 # starcup
     # Begin DeltaV Additions
     ClothingUniformJumpsuitKilt: 3
     ClothingEyesEyepatch: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
@@ -61,8 +61,8 @@
 - type: localizedDataset
   id: CigaretteMachineAds
   values:
-    prefix: advertisement-cigs-
-    count: 12
+    prefix: advertisement-cigs-starcup- # starcup: rewritten for tone
+    count: 6 # starcup: rewritten for tone
 
 - type: localizedDataset
   id: ClothesMateAds
@@ -223,7 +223,7 @@
 - type: localizedDataset
   id: SciDrobeAds
   values:
-    prefix: advertisement-scidrobe-
+    prefix: advertisement-scidrobe-starcup- # starcup: rewritten for tone
     count: 3
 
 - type: localizedDataset

--- a/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
@@ -235,8 +235,8 @@
 - type: localizedDataset
   id: SecTechAds
   values:
-    prefix: advertisement-sectech-
-    count: 5
+    prefix: advertisement-sectech-starcup- # starcup: replaced for tone
+    count: 4 # starcup: replaced for tone
 
 - type: localizedDataset
   id: SmartFridgeAds

--- a/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
@@ -25,8 +25,8 @@
 - type: localizedDataset
   id: CigaretteMachineGoodbyes
   values:
-    prefix: thankyou-cigs-
-    count: 3
+    prefix: thankyou-cigs-starcup- # starcup: rewritten for tone
+    count: 1 # starcup: rewritten for tone
 
 - type: localizedDataset
   id: HotDrinksMachineGoodbyes

--- a/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
@@ -97,8 +97,8 @@
 - type: localizedDataset
   id: SecTechGoodbyes
   values:
-    prefix: thankyou-sectech-
-    count: 3
+    prefix: thankyou-sectech-starcup- # starcup: replaced for tone
+    count: 2 # starcup: replaced for tone
 
 - type: localizedDataset
   id: GetmoreChocolateCorpGoodbyes

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -168,7 +168,7 @@
   parent: ClothingBackpack
   id: ClothingBackpackCargo
   name: logistics backpack # DeltaV - Logistics Department replacing Cargo
-  description: A robust backpack for stealing logistics's loot. # DeltaV - Logistics Department replacing Cargo
+  description: A robust backpack with countless neatly organized compartments. # DeltaV - Logistics Department replacing Cargo # starcup: rewritten for tone
   components:
     - type: Sprite
       sprite: Clothing/Back/Backpacks/cargo.rsi

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -143,7 +143,7 @@
   parent: ClothingBackpackDuffel
   id: ClothingBackpackDuffelCargo
   name: logistics duffel bag # DeltaV - Logistics Department replacing Cargo
-  description: A large duffel bag for stealing logistics's precious loot. # DeltaV - Logistics Department replacing Cargo
+  description: A large duffel bag with countless neatly organized compartments. # DeltaV - Logistics Department replacing Cargo # starcup: rewritten for tone
   components:
     - type: Sprite
       sprite: Clothing/Back/Duffels/cargo.rsi

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -145,7 +145,7 @@
   parent: ClothingBackpackSatchel
   id: ClothingBackpackSatchelCargo
   name: logistics satchel # DeltaV - Logistics Department replacing Cargo
-  description: A robust satchel for stealing logistics's loot. # DeltaV - Logistics Department replacing Cargo
+  description: A robust satchel with countless neatly organized compartments. # DeltaV - Logistics Department replacing Cargo # starcup: rewritten for tone
   components:
     - type: Sprite
       sprite: Clothing/Back/Satchels/cargo.rsi

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -581,7 +581,7 @@
   parent: ClothingBeltStorageBase
   id: ClothingBeltHolster
   name: shoulder holster
-  description: 'A holster to carry a handgun and ammo. WARNING: Badasses only.'
+  description: 'A holster to carry a handgun and ammo.' # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Belt/holster.rsi

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -110,7 +110,7 @@
   parent: ClothingHeadset
   id: ClothingHeadsetEngineering
   name: engineering headset
-  description: A headset for engineers to chat while the station burns around them.
+  description: A headset for engineers to scream into when the Tesla breaks loose. # starcup: rewritten for tone
   components:
   - type: ContainerFill
     containers:
@@ -126,7 +126,7 @@
   parent: [ClothingHeadsetEngineering, BaseCommandContraband]
   id: ClothingHeadsetCE
   name: ce headset
-  description: A headset for the chief engineer to ignore all emergency calls on.
+  description: A headset for the Chief Engineer to inform command staff that the engine is perfectly under control. # starcup: rewritten for tone
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/specific.yml
@@ -2,7 +2,7 @@
   parent: ClothingEyesBase
   id: ClothingEyesChameleon # no flash immunity, sorry
   name: sun glasses
-  description: Useful both for security and cargonia.
+  description: A pair of black sunglasses. # starcup: rewritten for tone (and consistency)
   suffix: Chameleon
   components:
     - type: Tag

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -423,7 +423,7 @@
   parent: [ClothingHandsBase, BaseSecurityContraband]
   id: ClothingHandsGlovesForensic
   name: forensic gloves
-  description: Do not leave fibers or fingerprints. If you work without them, you're A TERRIBLE DETECTIVE.
+  description: Gloves that do not leave fibers, to ensure that crucial evidence remains preserved. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/forensic.rsi

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -552,7 +552,7 @@
   name: stun knuckle dusters
   parent: [ClothingHandsBase, BaseToggleClothing, BaseSecurityContraband]
   id: ClothingHandsKnuckleDustersStun
-  description: A pair of knuckle dusters combined with the tech of a stun baton. This makes beating tiders a whole lot easier.
+  description: A pair of knuckle dusters combined with the tech of a stun baton, for officers unafraid to get their hands dirty. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/KnuckleDusters/electricknuckleduster.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -3,7 +3,7 @@
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetEVA
   name: EVA helmet
-  description: An old-but-gold helmet designed for extravehicular activites. Infamous for making security officers paranoid.
+  description: An old-but-gold helmet designed for extravehicular activites. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -30,7 +30,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatBeretFrench
   name: french beret
-  description: A French beret, "vive la France".
+  description: A style of beret popular in a lost human culture. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/beret_french.rsi
@@ -230,7 +230,7 @@
   parent: [ClothingHeadBase, BaseCommandContraband]
   id: ClothingHeadHatCaptain
   name: captain's hardhat
-  description: It's good being the king.
+  description: For looking extra cool during your rousing speeches. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/captain.rsi
@@ -262,7 +262,7 @@
   parent: [ ClothingHeadBase, BaseCentcommContraband ]
   id: ClothingHeadHatCentcom
   name: CentComm brand hat
-  description: "It's good to be the emperor."
+  description: For looking extra cool during your debriefings with station captains. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/centcom.rsi
@@ -486,7 +486,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatSombrero
   name: sombrero
-  description: "Perfectly for Space Mexico, si?"
+  description: A stylish wide-brimmed hat of long-lost human design. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/sombrero.rsi
@@ -571,7 +571,7 @@
   parent: [ClothingHeadBase, BaseFoldable]
   id: ClothingHeadHatUshanka
   name: ushanka
-  description: "Perfect for winter in Siberia, da?"
+  description: A fluffy, well-insulated winter hat in the style of an old human civilization. # starcup: rewritten for tone
   components:
   - type: Clothing
     sprite: Clothing/Head/Hats/ushanka.rsi
@@ -867,7 +867,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadRastaHat
   name: rasta hat
-  description: Right near da beach, boyee.
+  description: A vivid style of hat developed by a Terran religious community. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/rasta.rsi
@@ -1010,7 +1010,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatHetmanHat
   name: hetman hat
-  description: From the Zaporozhian Sich with love.
+  description: This style of cap, while similar to the ushanka, comes from a distinct neighboring human civilization whose name has been lost to time. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/hetman_hat.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -850,7 +850,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadNurseHat
   name: nurse hat
-  description: Somehow I feel I'm not supposed to leave this place.
+  description: Do medical professionals actually wear these anymore? # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/nursehat.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -735,7 +735,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatTrucker
   name: trucker hat
-  description: Formerly Chucks, this hat is yours now.
+  description: For long, long days on the road. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hats/truckershat.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -760,7 +760,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatHoodVoidCloak
   name: void cloak hood
-  description: The hood of a void cloak. For those who have gone to the dark side of the force.
+  description: Cutting-edge light dampening technology ensures an ominous shadow over your face no matter the angle! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Hoods/voidcloak.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -190,7 +190,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatFancyCrown
   name: fancy crown
-  description: It smells like dead rat. Lets you speak like one!
+  description: It's how you know who's in charge. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Head/Misc/fancycrown.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -252,7 +252,7 @@
   parent: ClothingHeadBase
   id: ClothingHeadHatDogEars
   name: doggy ears
-  description: Only for good boys.
+  description: Awawawa. # starcup: rewritten for tone
   categories: [ DoNotMap ]
   components:
   - type: Sprite
@@ -279,7 +279,7 @@
     - Hair
     - HeadTop
     - HeadSide
-    - FacialHair 
+    - FacialHair
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -192,7 +192,7 @@
   id: ClothingMaskClownBase
   abstract: true
   name: clown wig and mask
-  description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
+  description: An exaggerated, cartoonish set of facial attire for particularly garish acts of clownery. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Mask/clown.rsi
@@ -678,8 +678,8 @@
 - type: entity
   parent: ClothingMaskBase
   id: ClothingMaskItalianMoustache
-  name: italian moustache
-  description: Made from authentic Italian moustache hairs. Gives the wearer an irresistable urge to gesticulate wildly.
+  name: fake moustache # starcup: rewritten for tone
+  description: Now no one will know who you are with this genius disguise! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Mask/italian_moustache.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -193,7 +193,7 @@
   parent: ClothingNeckBase
   id: ClothingNeckCloakVoid
   name: void cloak
-  description: A cloak of darkness. For those who have gone to the dark side of the force.
+  description: These were produced as part of Squidland Art Co's line of premium supervillain wear. The built-in voice filter even makes you sound extra spooky! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/void.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -24,7 +24,7 @@
   parent: [ClothingNeckBase, BaseCommandContraband]
   id: ClothingNeckCloakHos
   name: head of security's cloak
-  description: An exquisite dark and red cloak fitting for those who can assert dominance over wrongdoers. Take a stab at being civil in prosecution!
+  description: An exquisite dark and red cloak for ensuring all troublemakers know who they'll be answering to. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/hos.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -130,7 +130,7 @@
   parent: ClothingNeckBase
   id: ClothingNeckCloakSalvagerSupreme
   name: supereme salvager's cloak
-  description: Worn by the most skilled salvagers, for one who has mastered space and made the mining asteroid his domain. They don't just hand these things out, y'know?
+  description: Worn by the most skilled salvagers, for one who has mastered space and made the mining asteroid their domain. They don't just hand these things out, y'know? # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/miner.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
@@ -46,7 +46,7 @@
   parent: [ClothingNeckBase, BaseCommandContraband]
   id: ClothingNeckMantleHOS
   name: head of security's mantle
-  description: Shootouts with syndicate agents are just another Tuesday for this HoS. This mantle is a symbol of commitment to the station.
+  description: No lawbreaker shall escape this officer's vigilant eye. This mantle is a symbol of commitment to the station's protection. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Neck/mantles/hosmantle.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -66,7 +66,7 @@
   parent: ClothingNeckBase
   id: ClothingNeckBling
   name: bling
-  description: Damn, it feels good to be a gangster.
+  description: You've never seen anything so shiny. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Neck/Misc/bling.rsi

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -60,7 +60,7 @@
   parent: ClothingOuterBase
   id: ClothingOuterHoodieBlack
   name: black hoodie
-  description: Oh my God, it's a black hoodie!
+  description: A black hoodie. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Misc/black_hoodie.rsi
@@ -259,7 +259,7 @@
   parent: ClothingOuterBase
   id: ClothingOuterHospitalGown
   name: hospital gown
-  description: Made from the wool of slaughtered baby lambs.  The cruelty makes it softer.
+  description: For long-term patients. Alarmingly soft to the touch. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Misc/hospitalgown.rsi

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -50,7 +50,7 @@
   parent: [ClothingShoesMilitaryBase, BaseSecurityContraband]
   id: ClothingShoesBootsCombat
   name: combat boots
-  description: Robust combat boots for combat scenarios or combat situations. All combat, all the time.
+  description: Robust combat boots for combat scenarios or combat situations. It's in the name, after all. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/combatboots.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
@@ -247,7 +247,7 @@
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorOrange
   name: orange jumpskirt
-  description: Don't wear this near paranoid security officers.
+  description: A jumpskirt so nice, it should be a crime! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpskirt/color.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
@@ -247,7 +247,7 @@
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitColorOrange
   name: orange jumpsuit
-  description: Don't wear this near paranoid security officers.
+  description: A jumpsuit so nice, it should be a crime! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/color.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -156,7 +156,7 @@
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtEngineering
   name: engineering jumpskirt
-  description: If this suit was non-conductive, maybe engineers would actually do their damn job.
+  description: Lightly dusted with soot and debris from long repair jobs. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpskirt/engineering.rsi
@@ -167,7 +167,7 @@
   parent: [ClothingUniformSkirtBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtHoP
   name: head of personnel's jumpskirt
-  description: Rather bland and inoffensive. Perfect for vanishing off the face of the universe.
+  description: You're the person in charge of the uniforms. If your own uniform was anything less than exceptional, it'd be a disgrace! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpskirt/hop.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -300,7 +300,7 @@
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitEngineering
   name: engineering jumpsuit
-  description: If this suit was non-conductive, maybe engineers would actually do their damn job.
+  description: Lightly dusted with soot and debris from long repair jobs. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/engineering.rsi
@@ -322,7 +322,7 @@
   parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpsuitHoP
   name: head of personnel's jumpsuit
-  description: Rather bland and inoffensive. Perfect for vanishing off the face of the universe.
+  description: You're the person in charge of the uniforms. If your own uniform was anything less than exceptional, it'd be a disgrace! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/hop.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -378,7 +378,7 @@
   parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpsuitHoSGrey
   name: head of security's grey jumpsuit
-  description: A grey jumpsuit of Head of Security, which make him look somewhat like a passenger.
+  description: A grey jumpsuit for the Head of Security to help them blend in with the passengers a little. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/hos_grey.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/scrubs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/scrubs.yml
@@ -2,7 +2,7 @@
   parent: ClothingUniformBase
   id: UniformScrubsColorPurple
   name: purple scrubs
-  description: A combination of comfort and utility intended to make removing every last organ someone has and selling them to a space robot much more official looking.
+  description: A combination of comfort and utility intended to make frantically digging around in someone's guts much more clean and professional looking. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Scrubs/purple.rsi
@@ -13,7 +13,7 @@
   parent: ClothingUniformBase
   id: UniformScrubsColorGreen
   name: green scrubs
-  description: A combination of comfort and utility intended to make removing every last organ someone has and selling them to a space robot much more official looking.
+  description: A combination of comfort and utility intended to make frantically digging around in someone's guts much more clean and professional looking. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Scrubs/green.rsi
@@ -24,7 +24,7 @@
   parent: ClothingUniformBase
   id: UniformScrubsColorBlue
   name: blue scrubs
-  description: A combination of comfort and utility intended to make removing every last organ someone has and selling them to a space robot much more official looking.
+  description: A combination of comfort and utility intended to make frantically digging around in someone's guts much more clean and professional looking. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Scrubs/blue.rsi

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/paintings.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/paintings.yml
@@ -23,7 +23,7 @@
       - PaintingOldGuitarist
       - PaintingOlympia
       - PaintingSaturn
-      - PaintingSleepingGypsy
+      #- PaintingSleepingGypsy # starcup: removed for tone
       - PaintingRedBlueYellow
       - PaintingHelloWorld
     chance: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -37,7 +37,7 @@
       - PosterContrabandRealExomorph
       - PosterContrabandSyndicateRecruitment
       - PosterContrabandClown
-      - PosterContrabandSmoke
+      #- PosterContrabandSmoke # starcup: removed for tone
       - PosterContrabandGreyTide
       - PosterContrabandMissingGloves
       - PosterContrabandHackingGuide
@@ -55,10 +55,10 @@
       - PosterContrabandKosmicheskayaStantsiya
       - PosterContrabandRebelsUnite
       - PosterContrabandC20r
-      - PosterContrabandHaveaPuff
+      #- PosterContrabandHaveaPuff # starcup: removed for tone
       - PosterContrabandRevolver
-      - PosterContrabandDDayPromo
-      - PosterContrabandSyndicatePistol
+      #- PosterContrabandDDayPromo # starcup: removed for tone
+      #- PosterContrabandSyndicatePistol # starcup: removed for tone
       - PosterContrabandEnergySwords
       - PosterContrabandRedRum
       - PosterContrabandCC64KAd
@@ -80,13 +80,13 @@
       - PosterContrabandTheBigGasTruth
       - PosterContrabandWehWatches
       - PosterContrabandVoteWeh
-      - PosterContrabandBeachStarYamamoto
+      #- PosterContrabandBeachStarYamamoto # starcup: removed for tone
       - PosterContrabandHighEffectEngineering
       - PosterContrabandNuclearDeviceInformational
       - PosterContrabandRevolt
-      - PosterContrabandRise
+      #- PosterContrabandRise # starcup: removed for tone
       - PosterContrabandMoth
-      - PosterContrabandCybersun600
+      #- PosterContrabandCybersun600 # starcup: removed for tone
       - PosterContrabandDonk
       - PosterContrabandEnlistGorlex
       - PosterContrabandInterdyne
@@ -134,7 +134,7 @@
       - PosterLegitReportCrimes
       - PosterLegitIonRifle
       - PosterLegitFoamForceAd
-      - PosterLegitCohibaRobustoAd
+      #- PosterLegitCohibaRobustoAd # starcup: removed for tone
       - PosterLegit50thAnniversaryVintageReprint
       - PosterLegitFruitBowl
       - PosterLegitPDAAd

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -122,8 +122,8 @@
       - PosterLegitWalk
       - PosterLegitStateLaws
       - PosterLegitLoveIan
-      - PosterLegitSpaceCops
-      - PosterLegitUeNo
+      #- PosterLegitSpaceCops # starcup: removed for tone
+      #- PosterLegitUeNo # starcup: removed for tone
       - PosterLegitGetYourLEGS
       - PosterLegitDoNotQuestion
       - PosterLegitWorkForAFuture
@@ -138,7 +138,7 @@
       - PosterLegit50thAnniversaryVintageReprint
       - PosterLegitFruitBowl
       - PosterLegitPDAAd
-      - PosterLegitEnlist
+      #- PosterLegitEnlist # starcup: removed for tone
       - PosterLegitNanomichiAd
       - PosterLegit12Gauge
       - PosterLegitHighClassMartini

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vending.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vending.yml
@@ -11,7 +11,7 @@
       state: any
   - type: RandomSpawner
     prototypes:
-    - VendingMachineChang
+    #- VendingMachineChang # starcup: removed for tone
     - VendingMachineCigs
     - VendingMachineCoffee
     - VendingMachineCola #Robust Sofdrinks
@@ -29,7 +29,7 @@
     - VendingMachineSnackOrange
     - VendingMachineSnackTeal
     - VendingMachineSoda #Robust Sofdrinks [Soda]
-    - VendingMachineSovietSoda #Boda
+    #- VendingMachineSovietSoda #Boda # starcup: removed for tone
     - VendingMachineSpaceUp
     - VendingMachineStarkist
     chance: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
@@ -20,7 +20,7 @@
       - VendingMachineShamblersJuice
       - VendingMachineSmite
       - VendingMachineSoda #Robust Sofdrinks [Soda]
-      - VendingMachineSovietSoda #Boda
+      #- VendingMachineSovietSoda #Boda # starcup: removed for tone
       - VendingMachineSpaceUp
       - VendingMachineStarkist
     chance: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingsnacks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingsnacks.yml
@@ -17,6 +17,6 @@
       - VendingMachineSnackGreen
       - VendingMachineSnackOrange
       - VendingMachineSnackTeal
-      - VendingMachineChang
+      #- VendingMachineChang # starcup: removed for tone
       - VendingMachineDonut
     chance: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/vending_machine_restock.yml
@@ -14,7 +14,7 @@
   - type: ConditionalSpawner
     prototypes:
       - VendingMachineRestockDiscountDans
-      - VendingMachineRestockChang
+      #- VendingMachineRestockChang # starcup: removed for tone
       - VendingMachineRestockDonut
       - VendingMachineRestockGetmoreChocolateCorp
       - VendingMachineRestockRobustSoftdrinks
@@ -38,7 +38,7 @@
   - type: ConditionalSpawner
     prototypes:
       - VendingMachineRestockDiscountDans
-      - VendingMachineRestockChang
+      #- VendingMachineRestockChang # starcup: removed for tone
       - VendingMachineRestockDonut
       - VendingMachineRestockGetmoreChocolateCorp
       - VendingMachineRestockHappyHonk

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1419,7 +1419,7 @@
   name: monkey
   id: MobMonkey
   parent: MobBaseAncestor
-  description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
+  description: Primitive non-sapient bipeds, for when you need something a little more resilient than a lab rat or guinea pig. # starcup: rewritten for tone
   components:
   - type: NameIdentifier
     group: Monkey
@@ -1452,7 +1452,7 @@
   name: monkey
   id: MobBaseSyndicateMonkey
   parent: MobBaseAncestor
-  description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
+  description: Primitive non-sapient bipeds, for when you need something a little more resilient than a lab rat or guinea pig. # starcup: rewritten for tone
   suffix: syndicate base
   components:
   - type: NameIdentifier

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -303,7 +303,7 @@
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]
   id: DrinkCognacBottleFull
   name: cognac bottle
-  description: A sweet and strongly alcoholic drink, made after numerous distillations and years of maturing. You might as well not scream 'SHITCURITY' this time.
+  description: A sweet and strongly alcoholic drink, made after numerous distillations and years of maturing. # starcup: rewritten for tone
   components:
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -199,7 +199,7 @@
   name: slice of brain cake
   parent: FoodCakeSliceBase
   id: FoodCakeBrainSlice
-  description: Lemme tell you something about prions. THEY'RE DELICIOUS.
+  description: The color might be unappetizing to some, but the taste is one of a kind! # starcup: rewritten for tone
   components:
   - type: Sprite
     state: brain-slice

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -699,7 +699,7 @@
   name: special brownies
   parent: FoodBakedBase
   id: FoodBakedCannabisBrownieBatch
-  description: A pan of "special" brownies.
+  description: Be careful not to get stuck in an infinite munchies loop! # starcup: rewritten for tone
   components:
   - type: FlavorProfile
     flavors:
@@ -728,7 +728,7 @@
   name: special brownie
   parent: FoodBakedBase
   id: FoodBakedCannabisBrownie
-  description: A "special" brownie.
+  description: Be careful not to get stuck in an infinite munchies loop! # starcup: rewritten for tone
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -476,7 +476,7 @@
   name: soy waffles
   parent: FoodBakedWaffle
   id: FoodBakedWaffleSoy
-  description: You feel healthier and - more feminine?
+  description: A healthier alternative, right up until you slather syrup all over them. # starcup: rewritten for tone
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -504,7 +504,7 @@
   name: duck sandwich # Burger for you sick bastards
   parent: FoodBurgerBase
   id: FoodBurgerDuck
-  description: A duck sandwich, only the criminally insane would dare to eat the meat of such an adorable creature.
+  description: Also sometimes called a duck burger. # starcup: rewritten for tone
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -826,7 +826,7 @@
   name: soylent burger
   parent: FoodBurgerBase
   id: FoodBurgerSoy
-  description: After eating this you have the overwhelming urge to purchase overpriced figurines of superheroes.
+  description: Makes use of a meat alternative pioneered by a colony of skittermice as a solution to concerns of over-hunting. It's customary to throw it for the carnivore species and let them chase it down. They need to earn the kill or they won't be able to enjoy it. # starcup: rewritten for tone
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -31,10 +31,10 @@
   id: FoodBreadBunBottom
   parent: FoodBreadSliceBase
   name: bottom bun
-  description: It's time to start building the burger tower. 
+  description: It's time to start building the burger tower.
   components:
   - type: Item
-    size: Normal #patch until there is an adequate resizing system in place 
+    size: Normal #patch until there is an adequate resizing system in place
   - type: Food
   - type: Sprite
     drawdepth: Mobs
@@ -83,7 +83,7 @@
   - type: FoodSequenceElement
     entries:
       Burger: BunTopBurger
-  
+
 # Base
 
 - type: entity
@@ -426,7 +426,7 @@
   - type: FlavorProfile
     flavors:
       - bun
-      - validhunting
+#      - validhunting # starcup: removed for tone
   - type: Sprite
     state: ian
   - type: SolutionContainerManager
@@ -687,7 +687,7 @@
   description: An elusive rib shaped burger with limited availability across the galaxy. Not as good as you remember it.
   components:
   - type: Food
-    trash: 
+    trash:
     - FoodKebabSkewer
   - type: FlavorProfile
     flavors:
@@ -987,4 +987,4 @@
   - type: Tag
     tags:
     - Meat
-    
+

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -160,7 +160,7 @@
       - leafy
       - meaty
       - potatoes
-      - validhunting
+#      - validhunting # starcup: removed for tone
   - type: Sprite
     layers:
     - state: bowl

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -136,7 +136,7 @@
   id: CigPackGreen
   parent: CigPackBase
   name: Spessman's Smokes packet
-  description: A label on the packaging reads, Wouldn't a slow death make a change?
+  description: " A label on the packaging reads: \"The smooth taste you love, no matter the altitude.\"" # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/green.rsi
@@ -158,7 +158,7 @@
   id: CigPackBlue
   parent: CigPackBase
   name: AcmeCo packet
-  description: For those who somehow want to obtain the record for the most amount of cancerous tumors.
+  description: The little single-panel cartoons on the boxes are seen by some as more exciting than the contents. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/blue.rsi

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -684,7 +684,7 @@
   parent: BasePDA
   id: CEPDA
   name: chief engineer PDA
-  description: Looks like it's barely been used.
+  description: It has a few scorch marks at the corners. # starcup: rewritten for tone
   components:
   - type: Pda
     id: CEIDCard
@@ -852,7 +852,7 @@
   parent: BaseSecurityPDA
   id: HoSPDA
   name: head of security PDA
-  description: Whosoever bears this PDA is the law.
+  description: "Some might tell you that this old thing is \"several models outdated\" or \"literally held together with duct tape,\" but to you, this is a battle-hardened companion."
   components:
   - type: Pda
     id: HoSIDCard
@@ -898,7 +898,7 @@
   parent: BaseSecurityPDA
   id: SecurityPDA
   name: security PDA
-  description: Red to hide the stains of passenger blood.
+  description: These PDAs are given to incoming officers in a shiny and pristine state. Most don't stay that way any longer than the first few shifts. # starcup: rewritten for tone
   components:
   - type: Pda
     id: SecurityIDCard
@@ -1074,7 +1074,7 @@
   parent: [ BasePDA, BaseSyndicateContraband ]
   id: SyndiPDA
   name: syndicate PDA
-  description: Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people!
+  description: Features state-of-the-art encryption technology for deep espionage assignments. # starcup: rewritten for tone
   components:
   - type: Pda
     id: SyndicateIDCard

--- a/Resources/Prototypes/Entities/Objects/Devices/wristwatch.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/wristwatch.yml
@@ -46,7 +46,7 @@
   id: WristwatchGold
   parent: Wristwatch
   name: gold watch
-  description: A fancy watch worth more than your kidney. It was owned by the notorious Syndicate mobster Vunibaldo "200 Pound Horse Meat Grinder" Frediani.
+  description: A fancy watch worth more than your kidney. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Devices/goldwatch.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -167,7 +167,7 @@
   parent: BaseStringInstrument
   id: ViolaInstrument
   name: viola
-  description: Like a violin, but worse.
+  description: The Abbott to the violin's Costello. # starcup: rewritten for tone
   components:
   - type: Instrument
     program: 41

--- a/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
@@ -36,7 +36,7 @@
   parent: BaseFigurine
   id: ToyFigurineHeadOfPersonnel
   name: head of personnel figure
-  description: A figurine depicting the glorious head of all personnel, away from their office as usual.
+  description: A figurine depicting the Head of Personnel, clean and proper as always. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: hop
@@ -146,7 +146,7 @@
   parent: BaseFigurine
   id: ToyFigurineWarden
   name: warden figure
-  description: A figurine depicting a Warden, ready to jail someone at any moment.
+  description: A figurine depicting a Warden, resolute and unyielding. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: warden
@@ -289,7 +289,7 @@
   parent: BaseFigurine
   id: ToyFigurineChemist
   name: chemist figure
-  description: A figurine depicting a Chemist probably planning to make meth.
+  description: A figurine depicting a Chemist with the telltale stains of a long shift all over their coat. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: chemist
@@ -344,7 +344,7 @@
   parent: BaseFigurine
   id: ToyFigurineChef
   name: chef figure
-  description: A figurine depicting a chef, master of the culinary arts!.. most of the time.
+  description: A figurine depicting a chef, mad genius of the kitchen. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: chef

--- a/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
@@ -58,7 +58,7 @@
   parent: BaseFigurine
   id: ToyFigurineGreytider
   name: greytider figure
-  description: A figurine depicting a dubious-looking passenger. Greytide worldwide!
+  description: A figurine depicting a passenger with the unmistakable glint of mischief in their eyes. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: passenger_greytide
@@ -69,7 +69,7 @@
   parent: BaseFigurine
   id: ToyFigurineClown
   name: clown figure
-  description: A figurine depicting a clown. You shudder to think of what people have probably done to this figurine before.
+  description: A figurine depicting a clown. You shudder to think of what jokes they saw fit to record for this thing. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: clown
@@ -80,7 +80,7 @@
   parent: BaseFigurine
   id: ToyFigurineHoloClown
   name: holoclown figure
-  description: A figurine depicting a holoclown. Even more annoying than a clown and no less real.
+  description: A figurine depicting a holoclown. Even more ostentatious than a clown and no less real. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: holoclown
@@ -91,7 +91,7 @@
   parent: BaseFigurine
   id: ToyFigurineMime
   name: mime figure
-  description: A figurine depicting that silent bastard you are all too familiar with.
+  description: A figurine depicting the charming, inscrutable mime. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: mime

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -239,7 +239,7 @@
   parent: PlushieBee
   id: PlushieRGBee
   name: RGBee plushie
-  description: A cute toy that resembles a bee plushie while you're on LSD.
+  description: They say these plushies are actually based on a real species of bees from the mythical Venus-Omega. # starcup: rewritten for tone
   components:
   - type: PointLight
     radius: 1.5
@@ -1485,7 +1485,7 @@
   parent: BaseItem
   id: FoamBlade
   name: foamblade
-  description: It says "Sternside Changs number 1 fan" on it.
+  description: Made for children ages 8 and up. But are you really going to let that stop you? # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Fun/toys.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1385,7 +1385,7 @@
   parent: FoamWeaponBase
   id: FoamCrossbow
   name: foam crossbow
-  description: Aiming this at Security may get you filled with lead.
+  description: Old-fashioned weaponry meets space-age foam blasting technology! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Fun/toys.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1510,7 +1510,7 @@
   parent: BaseItem
   id: Basketball
   name: basketball
-  description: Where dah courts at?
+  description: You've got a real jam going down. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Fun/toys.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -153,7 +153,7 @@
   id: BookLeafLoversSecret
   parent: BaseGuidebook
   name: leaf lover's secret
-  description: It has a strong weed smell. It motivates you to feed and seed.
+  description: It has the strong smell of dirt. It motivates you to feed and seed. # starcup: rewritten for tone
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -212,7 +212,7 @@
   id: BookSecurity
   parent: BaseGuidebook
   name: security 101
-  description: A book about security written by Nanotrasen. The book is stained with blood. It seems to have been used more as a weapon than reading material.
+  description: A book about security written by SyndComm. There's a bit of blood along the spine, quite possibly belonging to the previous owner. # starcup: rewritten for tone
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -2,7 +2,7 @@
   name: nuclear authentication disk
   parent: [BaseItem, BaseGrandTheftContraband]
   id: NukeDisk
-  description: A nuclear auth disk, capable of arming a nuke if used along with a code. Note from the Syndicate reads "THIS IS YOUR MOST IMPORTANT POSESSION, SECURE DAT FUKKEN DISK!" # starcup: changed description to remove reference to NT
+  description: A nuclear auth disk, capable of arming a nuke if used along with a code. SyndComm corporate guidelines stress the importance of not handing this to the Mime just because they mimed for it nicely. # starcup: rewritten for tone
   components:
   - type: NukeDisk
   - type: SpecialRespawn

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -132,7 +132,7 @@
   name: interrogator lamp
   id: LampInterrogator
   parent: [ BaseLamp, BaseSecurityContraband ]
-  description: Ultra-bright lamp for the bad cop.
+  description: A specialized lamp with an ultra-bright lightbulb that can double as a flash for emergency situations. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Misc/Lights/lampint.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -726,7 +726,7 @@
   parent: IDCardStandard
   id: PrisonerIDCard
   name: prisoner ID card
-  description: A generically printed ID card for scummy prisoners.
+  description: A generically printed ID card for station prisoners. # starcup: rewritten for tone
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -22,7 +22,7 @@
   id: Kudzu
   name: kudzu
   parent: BaseKudzu
-  description: A rapidly growing, dangerous plant. WHY ARE YOU STOPPING TO LOOK AT IT?!
+  description: A dangerous, rapidly growing Megabriar contamination. Has probably already spread further in the time it took you to read this. # starcup: rewritten for tone
   components:
     - type: MeleeSound
       soundGroups:
@@ -166,7 +166,7 @@
   id: FleshKudzu
   name: tendons
   parent: BaseKudzu
-  description: A rapidly growing cluster of meaty tendons. WHY ARE YOU STOPPING TO LOOK AT IT?!
+  description: A rapidly growing cluster of meaty tendons, animated by anomalous forces. # starcup: rewritten for tone
   placement:
     mode: SnapgridCenter
     snap:

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: SpaceCash
   name: spesos
-  description: You gotta have money.
+  description: The eventual result of the Syndicate's campaign to form a standardized currency. You hear NanoTrasen's has a higher thread count. # starcup: rewritten for tone
   components:
   - type: Cash
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -4,7 +4,7 @@
   name: cannabis leaves
   parent: ProduceBase
   id: LeavesCannabis
-  description: "Recently legalized in most galaxies."
+  description: Used throughout history for medical and occasional recreational purposes. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/cannabis.rsi
@@ -42,7 +42,7 @@
   name: ground cannabis
   parent: BaseItem
   id: GroundCannabis
-  description: "Ground cannabis, ready to take you on a trip."
+  description: Ground cannabis, for various recreational uses. # starcup: rewritten for tone
   components:
   - type: Stack
     stackType: GroundCannabis
@@ -136,7 +136,7 @@
   name: ground rainbow cannabis
   parent: GroundCannabis
   id: GroundCannabisRainbow
-  description: "Ground rainbow cannabis, ready to take you on a trip."
+  description: Ground rainbow cannabis, some of the most psychoactive stuff you can find. # starcup: rewritten for tone
   components:
   - type: Stack
     stackType: GroundCannabisRainbow

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -366,7 +366,7 @@
 - type: entity
   parent: SeedBase
   name: packet of cannabis seeds
-  description: "Taxable."
+  description: These grow into cannabis plants. # starcup: rewritten for tone
   id: CannabisSeeds
   components:
     - type: Seed
@@ -377,7 +377,7 @@
 - type: entity
   parent: SeedBase
   name: packet of rainbow cannabis seeds
-  description: "These seeds grow into rainbow weed. Groovy... and also highly addictive."
+  description: These seeds grow into rainbow cannabis, a highly addictive strain designed for maximum psychoactive effect. # starcup: rewritten for tone
   id: RainbowCannabisSeeds
   components:
     - type: Seed

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -99,7 +99,7 @@
   id: DefibrillatorSyndicate
   parent: [ DefibrillatorCompact, BaseSyndicateContraband ]
   name: interdyne defibrillator
-  description: Doubles as a self-defense weapon against war-crime inclined tiders.
+  description: Doubles as a self-defense weapon for frontline medical support. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/defibsyndi.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -79,7 +79,7 @@
 
 - type: entity
   name: radiation treatment kit
-  description: "If you took your Rad-X you wouldn't need this."
+  description: For when the Geiger counter sounds more like a deep fryer. # starcup: rewritten for tone
   parent: Medkit
   id: MedkitRadiation
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -60,21 +60,22 @@
       shader: unshaded
     - state: refill_booze
 
-- type: entity
-  parent: BaseVendingMachineRestock
-  id: VendingMachineRestockChang
-  name: Mr. Chang's restock box
-  description: A box covered in white labels with bold red Chinese characters, ready to be loaded into the nearest Mr. Chang's vending machine.
-  components:
-  - type: VendingMachineRestock
-    canRestock:
-    - ChangInventory
-  - type: Sprite
-    layers:
-    - state: base
-    - state: green_bit
-      shader: unshaded
-    - state: refill_chinese
+# starcup: removed for tone
+#- type: entity
+#  parent: BaseVendingMachineRestock
+#  id: VendingMachineRestockChang
+#  name: Mr. Chang's restock box
+#  description: A box covered in white labels with bold red Chinese characters, ready to be loaded into the nearest Mr. Chang's vending machine.
+#  components:
+#  - type: VendingMachineRestock
+#    canRestock:
+#    - ChangInventory
+#  - type: Sprite
+#    layers:
+#    - state: base
+#    - state: green_bit
+#      shader: unshaded
+#    - state: refill_chinese
 
 - type: entity
   parent: BaseVendingMachineRestock
@@ -337,7 +338,7 @@
     - SpaceUpInventory
     - SodaInventory
     - DrGibbInventory
-    - SmiteInventory 
+    - SmiteInventory
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -2,7 +2,7 @@
   name: lantern
   parent: BaseItem
   id: Lantern
-  description: The holy light guides the way.
+  description: Who goes there? # starcup: rewritten for tone
   components:
     - type: HandheldLight
       addPrefix: true

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -140,7 +140,7 @@
   name: golden toolbox
   parent: ToolboxBase
   id: ToolboxGolden
-  description: A solid gold toolbox. A rapper would kill for this.
+  description: A solid gold toolbox, for your most precious tools. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Tools/Toolboxes/toolbox_gold.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -585,7 +585,7 @@
   name: antique laser pistol
   parent: [BaseWeaponBatterySmall, BaseGrandTheftContraband]
   id: WeaponAntiqueLaser
-  description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is an image of a captain and a clown. The clown is dead. The captain is striking a heroic pose.
+  description: This is an antique laser pistol. All craftsalienship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is a hastily scratched out marking. If you didn't know any better, you'd swear the marking resembles the NanoTrasen logo. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: _starcup/Objects/Weapons/Guns/Battery/antiquelasergun.rsi # starcup: resprited for syndicate

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
@@ -85,7 +85,7 @@
   parent: BaseArrow
   id: ArrowImprovised
   name: glass shard arrow
-  description: The greyshirt's preferred projectile.
+  description: An improvised take on an old classic. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/arrows.rsi
@@ -111,7 +111,7 @@
   parent: BaseArrow
   id: ArrowImprovisedPlasma
   name: plasma glass shard arrow
-  description: The greyshirt's preferred projectile. Now with extra lethality!
+  description: An improvised take on an old classic. Now with extra lethality! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/arrows.rsi
@@ -137,7 +137,7 @@
   parent: BaseArrow
   id: ArrowImprovisedUranium
   name: uranium glass shard arrow
-  description: The greyshirt's preferred projectile. Now with added radiation!
+  description: An improvised take on an old classic. Now with added radiation! # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/arrows.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -138,7 +138,7 @@
   name: Enforcer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponShotgunEnforcer
-  description: A premium semi-automatic shotgun, and the pride of all security forces. Uses .50 shotgun shells.
+  description: A high-grade semi-automatic shotgun, and the last resort of security forces. Uses .50 shotgun shells. # starcup: rewritten for tone
   components: # intend for Enforcer to have wider choke for semi-auto function
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
@@ -2,7 +2,7 @@
   name: gohei
   parent: BaseItem
   id: Gohei
-  description: A wooden stick with white streamers at the end. Originally used by shrine maidens to purify things. Now used by the station's weeaboos.
+  description: Said to be used by an obscure group of Terran spiritualists for purification purposes. Likely included as part of SyndComm's efforts to make humans feel more welcome. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/gohei.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -2,7 +2,7 @@
   name: sledgehammer
   parent: BaseItem
   id: Sledgehammer
-  description: The perfect tool for wanton carnage.
+  description: A large hammer intended for use in demolition work. Makes for a good weapon if you don't mind some collateral damage. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/sledgehammer.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -52,7 +52,7 @@
   name: butcher's cleaver
   parent: BaseKnife
   id: ButchCleaver
-  description: A huge blade used for chopping and chopping up meat. This includes clowns and clown-by-products.
+  description: A huge blade used for butchering and chopping through meat. # starcup: rewritten for tone
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -206,7 +206,7 @@
   name: throngler
   parent: [ BaseSword, BaseMajorContraband ]
   id: Throngler
-  description: If Security dares take it from you, just remind them that they are indeed mortal.
+  description: Despite not being a real word, you're unsure of what else this thing could do besides throngle. # starcup: rewritten for tone
   components:
     - type: Sprite
       sprite: Objects/Weapons/Melee/Throngler2.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: WeaponMeleeToolboxRobust
   name: robust toolbox
-  description: A tider's weapon.
+  description: An engine of destruction. # starcup: rewritte for tone
   categories: [ DoNotMap ]
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -51,7 +51,7 @@
   id: BannerCargo
   parent: BannerBase
   name: logistics banner
-  description: A banner displaying the colors of the logistics department. Not. Cargonia. # DeltaV - Logistics Department replacing Cargo
+  description: A banner displaying the colors of the logistics department. The Cargonia Incident is above your clearance level. # DeltaV - Logistics Department replacing Cargo # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi

--- a/Resources/Prototypes/Entities/Structures/Decoration/statues.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/statues.yml
@@ -26,18 +26,19 @@
     drawdepth: Mobs
     offset: "0.0,0.5"
 
-- type: entity
-  id: StatueBananiumClown
-  parent: BaseStructure
-  name: bananium savior statue
-  description: A bananium statue. It portrays the return of the savior who will rise up and lead the clowns to the great honk.
-  components:
-  - type: Sprite
-    noRot: true
-    sprite: Structures/Decoration/statues.rsi
-    state: bananium_clown
-    drawdepth: Mobs
-    offset: "0.0,0.5"
-  - type: Construction
-    graph: BananiumStatueClown
-    node: bananiumStatue
+# starcup: removed for tone
+#- type: entity
+#  id: StatueBananiumClown
+#  parent: BaseStructure
+#  name: bananium savior statue
+#  description: A bananium statue. It portrays the return of the savior who will rise up and lead the clowns to the great honk.
+#  components:
+#  - type: Sprite
+#    noRot: true
+#    sprite: Structures/Decoration/statues.rsi
+#    state: bananium_clown
+#    drawdepth: Mobs
+#    offset: "0.0,0.5"
+#  - type: Construction
+#    graph: BananiumStatueClown
+#    node: bananiumStatue

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -169,7 +169,7 @@
   id: ShuttersWindow
   parent: BaseShutter
   name: window shutters
-  description: The Best (TM) place to see your friends explode!
+  description: For setting appropriately dramatic interior lighting, or peering through like a weirdo. # starcup: rewritten for tone
   components:
   - type: Sprite
     sprite: Structures/Doors/Shutters/shutters_window.rsi

--- a/Resources/Prototypes/Entities/Structures/Machines/grill.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/grill.yml
@@ -2,7 +2,7 @@
   parent: BaseHeaterMachine
   id: KitchenElectricGrill
   name: electric grill
-  description: A microwave? No, a real man cooks steaks on a grill!
+  description: Huh. That's a funny looking microwave. # starcup: rewritten for tone
   components:
   - type: Sprite
     # TODO: draw a sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -300,7 +300,7 @@
   parent: VendingMachine
   id: VendingMachineCigs
   name: ShadyCigs Deluxe
-  description: If you want to get cancer, might as well do it in style.
+  description: Proliferation of these across Syndicate stations is the result of heavy and controversial neocorporate lobbying. # starcup: rewritten for tone
   components:
   - type: VendingMachine
     pack: CigaretteMachineInventory

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -138,31 +138,32 @@
   - type: Transform
     noRot: false
 
-- type: entity
-  parent: VendingMachine
-  id: VendingMachineAmmo
-  name: liberation station
-  description: An overwhelming amount of ancient patriotism washes over you just by looking at the machine.
-  components:
-  - type: VendingMachine
-    pack: AmmoVendInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-  - type: Advertise
-    pack: AmmoVendAds
-  - type: SpeakOnUIClosed
-    pack: GenericVendGoodbyes
-  - type: Sprite
-    sprite: Structures/Machines/VendingMachines/ammo.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+# starcup: removed for tone
+#- type: entity
+#  parent: VendingMachine
+#  id: VendingMachineAmmo
+#  name: liberation station
+#  description: An overwhelming amount of ancient patriotism washes over you just by looking at the machine.
+#  components:
+#  - type: VendingMachine
+#    pack: AmmoVendInventory
+#    offState: off
+#    brokenState: broken
+#    normalState: normal-unshaded
+#  - type: Advertise
+#    pack: AmmoVendAds
+#  - type: SpeakOnUIClosed
+#    pack: GenericVendGoodbyes
+#  - type: Sprite
+#    sprite: Structures/Machines/VendingMachines/ammo.rsi
+#    layers:
+#    - state: "off"
+#      map: ["enum.VendingMachineVisualLayers.Base"]
+#    - state: "off"
+#      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+#      shader: unshaded
+#    - state: panel
+#      map: ["enum.WiresVisualLayers.MaintenancePanel"]
 
 - type: entity
   parent: VendingMachine
@@ -1137,40 +1138,41 @@
     energy: 1.6
     color: "#207E79"
 
-- type: entity
-  parent: VendingMachine
-  id: VendingMachineSovietSoda
-  name: BODA
-  description: An old vending machine containing sweet water.
-  components:
-  - type: VendingMachine
-    pack: BodaInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: eject-unshaded
-    denyState: deny-unshaded
-    initialStockQuality: 0.33
-  - type: Advertise
-    pack: BodaAds
-  - type: SpeakOnUIClosed
-    pack: BodaGoodbyes
-  - type: Sprite
-    sprite: Structures/Machines/VendingMachines/sovietsoda.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#389690"
+# starcup: removed for tone
+#- type: entity
+#  parent: VendingMachine
+#  id: VendingMachineSovietSoda
+#  name: BODA
+#  description: An old vending machine containing sweet water.
+#  components:
+#  - type: VendingMachine
+#    pack: BodaInventory
+#    dispenseOnHitChance: 0.25
+#    dispenseOnHitThreshold: 2
+#    offState: off
+#    brokenState: broken
+#    normalState: normal-unshaded
+#    ejectState: eject-unshaded
+#    denyState: deny-unshaded
+#    initialStockQuality: 0.33
+#  - type: Advertise
+#    pack: BodaAds
+#  - type: SpeakOnUIClosed
+#    pack: BodaGoodbyes
+#  - type: Sprite
+#    sprite: Structures/Machines/VendingMachines/sovietsoda.rsi
+#    layers:
+#    - state: "off"
+#      map: ["enum.VendingMachineVisualLayers.Base"]
+#    - state: "off"
+#      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+#      shader: unshaded
+#    - state: panel
+#      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+#  - type: PointLight
+#    radius: 1.5
+#    energy: 1.6
+#    color: "#389690"
 
 - type: entity
   parent: VendingMachine
@@ -1337,38 +1339,39 @@
     energy: 1.6
     color: "#326e3f"
 
-- type: entity
-  parent: VendingMachine
-  id: VendingMachineChang
-  name: Mr. Chang
-  description: A self-serving Chinese food machine, for all your Chinese food needs.
-  components:
-  - type: VendingMachine
-    pack: ChangInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    initialStockQuality: 0.33
-  - type: Advertise
-    pack: ChangAds
-  - type: SpeakOnUIClosed
-    pack: ChangGoodbyes
-  - type: Sprite
-    sprite: Structures/Machines/VendingMachines/changs.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#ffe599"
+# starcup: removed for tone
+#- type: entity
+#  parent: VendingMachine
+#  id: VendingMachineChang
+#  name: Mr. Chang
+#  description: A self-serving Chinese food machine, for all your Chinese food needs.
+#  components:
+#  - type: VendingMachine
+#    pack: ChangInventory
+#    dispenseOnHitChance: 0.25
+#    dispenseOnHitThreshold: 2
+#    offState: off
+#    brokenState: broken
+#    normalState: normal-unshaded
+#    initialStockQuality: 0.33
+#  - type: Advertise
+#    pack: ChangAds
+#  - type: SpeakOnUIClosed
+#    pack: ChangGoodbyes
+#  - type: Sprite
+#    sprite: Structures/Machines/VendingMachines/changs.rsi
+#    layers:
+#    - state: "off"
+#      map: ["enum.VendingMachineVisualLayers.Base"]
+#    - state: "off"
+#      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+#      shader: unshaded
+#    - state: panel
+#      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+#  - type: PointLight
+#    radius: 1.5
+#    energy: 1.6
+#    color: "#ffe599"
 
 - type: entity
   parent: VendingMachine
@@ -1910,7 +1913,7 @@
   parent: VendingMachine
   id: VendingMachineSciDrobe
   name: SciDrobe
-  description: A simple vending machine suitable to dispense well tailored science clothing. Endorsed by Space Cubans.
+  description: A simple vending machine suitable to dispense well tailored science clothing. # starcup: rewritten for tone
   components:
   - type: VendingMachine
     pack: SciDrobeInventory

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1309,7 +1309,7 @@
   parent: VendingMachine
   id: VendingMachineGames
   name: Good Clean Fun
-  description: Vends things that the Captain and Head of Personnel are probably not going to appreciate you fiddling with instead of your job...
+  description: Helps supply the crew with recreation and some much-needed boosts to morale. Except when you roll three natural 1s in a row. # starcup: rewritten for tone
   components:
   - type: VendingMachine
     pack: GoodCleanFunInventory

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -2,7 +2,7 @@
   id: VendingMachine
   parent: BaseMachinePowered
   name: vending machine
-  description: Just add capitalism!
+  description: For when you want to hear a nice KER-CHUNK when retrieving something. Don't worry; all expenses are transferred directly to your employee account. # starcup: rewritten for tone
   abstract: true
   components:
   - type: ActionGrant
@@ -1758,7 +1758,7 @@
   parent: VendingMachine
   id: VendingMachineAtmosDrobe
   name: AtmosDrobe
-  description: This relatively unknown vending machine delivers clothing for Atmospherics Technicians, an equally unknown job.
+  description: Dispenses fashionable clothing for atmospherics technicians, a notable perk for what can be a rather thankless job. # starcup: rewritten for tone
   components:
   - type: VendingMachine
     pack: AtmosDrobeInventory

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -3,7 +3,7 @@
   name: mop bucket
   id: MopBucket
   parent: [BaseStructureDynamic, StructureWheeled]
-  description: Holds water and the tears of the janitor.
+  description: Holds water and whatever fluids are foolish enough to stand in the janitor's path. # starcup: rewritten for tone
   components:
   - type: Clickable
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -77,7 +77,7 @@
 - type: entity
   id: Crematorium
   name: crematorium
-  description: A human incinerator. Works well on barbecue nights.
+  description: An incinerator for the deceased. # starcup: rewritten for tone
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -180,14 +180,15 @@
   - type: BarSign
     current: EngineChange
 
-- type: entity
-  parent: BaseBarSign
-  id: BarSignTheHarmbaton
-  name: The Harmbaton
-  description: A great dining experience for both security members and passengers.
-  components:
-  - type: BarSign
-    current: Harmbaton
+# starcup: removed for tone
+#- type: entity
+#  parent: BaseBarSign
+#  id: BarSignTheHarmbaton
+#  name: The Harmbaton
+#  description: A great dining experience for both security members and passengers.
+#  components:
+#  - type: BarSign
+#    current: Harmbaton
 
 - type: entity
   parent: BaseBarSign

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/paintings.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/paintings.yml
@@ -144,14 +144,15 @@
   - type: Sprite
     state: painting14
 
-- type: entity
-  parent: PaintingBase
-  id: PaintingSleepingGypsy
-  name: The Sleeping Gypsy
-  description: This painting depicts a gypsy sleeping among their belongings in the desert. A lion stands behind them.
-  components:
-  - type: Sprite
-    state: painting15
+# starcup: removed for tone
+#- type: entity
+#  parent: PaintingBase
+#  id: PaintingSleepingGypsy
+#  name: The Sleeping Gypsy
+#  description: This painting depicts a gypsy sleeping among their belongings in the desert. A lion stands behind them.
+#  components:
+#  - type: Sprite
+#    state: painting15
 
 - type: entity
   parent: PaintingBase
@@ -187,4 +188,4 @@
   description: This painting is a sad clown! It sparks joy.
   components:
   - type: Sprite
-    state: painting19  
+    state: painting19

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -62,8 +62,8 @@
 - type: entity
   parent: PosterBase
   id: PosterContrabandAtmosiaDeclarationIndependence
-  name: "Atmosia Declaration of Independence"
-  description: "A relic of a failed rebellion."
+  name: "Treaty of Sol" # starcup: rewritten for tone
+  description: "A copy of the form submitted to offer various mythical names from human culture into the Galactic Public Domain, ending the Second Neocorporate War." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster2_contraband
@@ -99,25 +99,26 @@
   parent: PosterBase
   id: PosterContrabandClown
   name: "Clown"
-  description: "Honk."
+  description: "Who is Clowncore, and why do their posters keep showing up everywhere?" # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster6_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandSmoke
-  name: "Smoke"
-  description: "A poster advertising a rival corporate brand of cigarettes."
-  components:
-  - type: Sprite
-    state: poster7_contraband
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandSmoke
+#  name: "Smoke"
+#  description: "A poster advertising a rival corporate brand of cigarettes."
+#  components:
+#  - type: Sprite
+#    state: poster7_contraband
 
 - type: entity
   parent: PosterBase
   id: PosterContrabandGreyTide
   name: "Grey Tide"
-  description: "A rebellious poster symbolizing passenger solidarity."
+  description: "From an old Syndicate campaign encouraging solidarity between undervalued station passengers." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster8_contraband
@@ -126,7 +127,7 @@
   parent: PosterBase
   id: PosterContrabandMissingGloves
   name: "Missing Gloves"
-  description: "This poster references the uproar that followed Nanotrasen's financial cuts toward insulated-glove purchases."
+  description: "Looks like someone's lost their defective pair of insulated gloves. You're sure it'll turn up." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster9_contraband
@@ -144,7 +145,7 @@
   parent: PosterBase
   id: PosterContrabandRIPBadger
   name: "RIP Badger"
-  description: "This seditious poster references Nanotrasen's genocide of a space station full of badgers."
+  description: "This poster commemorates a badger said to have broken free from an experimental Interdyne lab, creating massive scandal. The existence of badgers is above your clearance level." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster11_contraband
@@ -153,7 +154,7 @@
   parent: PosterBase
   id: PosterContrabandAmbrosiaVulgaris
   name: "Ambrosia Vulgaris"
-  description: "This poster is lookin' pretty trippy man."
+  description: "A recreation of a painting by the group of Dawnflowers who first cultivated the depicted herb. They say the original was colored with the blood of the saint they killed in celebration after the first harvest." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster12_contraband
@@ -171,7 +172,7 @@
   parent: PosterBase
   id: PosterContrabandEAT
   name: "EAT."
-  description: "This poster promotes rank gluttony."
+  description: "An advertisement for a fast food chain. Probably. The provenance of the displayed burger is unclear." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster14_contraband
@@ -207,7 +208,7 @@
   parent: PosterBase
   id: PosterContrabandCommunistState
   name: "Communist State"
-  description: "All hail the Communist party!"
+  description: "After the arrival of humans to the galaxy, interest in their native philosophy of communism experienced a resurgence." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster18_contraband
@@ -216,7 +217,7 @@
   parent: PosterBase
   id: PosterContrabandLamarr
   name: "Lamarr"
-  description: "This poster depicts Lamarr. Probably made by a traitorous Research Director."
+  description: "This poster depicts Lamarr, beloved mascot of popular harpy-made video game H.L. 4." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster19_contraband
@@ -242,8 +243,8 @@
 - type: entity
   parent: PosterBase
   id: PosterContrabandKosmicheskayaStantsiya
-  name: "Kosmicheskaya Stantsiya 13 Does Not Exist"
-  description: "A poster mocking CentComm's denial of the existence of the derelict station near Space Station 13."
+  name: "KC-13 Does Not Exist" # starcup: rewritten for tone
+  description: "A poster reminding you that KC-13 is not real, does not stand for anything, is seditious to invoke, and why do we keep talking about it, you're the one who keeps bringing it up." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster22_contraband
@@ -266,14 +267,15 @@
   - type: Sprite
     state: poster24_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandHaveaPuff
-  name: "Have a Puff"
-  description: "Who cares about lung cancer when you're high as a kite?"
-  components:
-  - type: Sprite
-    state: poster25_contraband
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandHaveaPuff
+#  name: "Have a Puff"
+#  description: "Who cares about lung cancer when you're high as a kite?"
+#  components:
+#  - type: Sprite
+#    state: poster25_contraband
 
 - type: entity
   parent: PosterBase
@@ -284,23 +286,24 @@
   - type: Sprite
     state: poster26_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandDDayPromo
-  name: "D-Day Promo"
-  description: "A promotional poster for some rapper."
-  components:
-  - type: Sprite
-    state: poster27_contraband
+# begin starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandDDayPromo
+#  name: "D-Day Promo"
+#  description: "A promotional poster for some rapper."
+#  components:
+#  - type: Sprite
+#    state: poster27_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandSyndicatePistol
-  name: "Syndicate Pistol"
-  description: "A poster advertising syndicate pistols as being 'classy as fuck'. It's covered in faded gang tags."
-  components:
-  - type: Sprite
-    state: poster28_contraband
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandSyndicatePistol
+#  name: "Syndicate Pistol"
+#  description: "A poster advertising syndicate pistols as being 'classy as fuck'. It's covered in faded gang tags."
+#  components:
+#  - type: Sprite
+#    state: poster28_contraband
 
 - type: entity
   parent: PosterBase
@@ -333,7 +336,7 @@
   parent: PosterBase
   id: PosterContrabandPunchShit
   name: "Punch Shit"
-  description: "Fight things for no reason, like a man!"
+  description: "Sometimes, it's just what you have to do." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster32_contraband
@@ -449,8 +452,8 @@
 - type: entity
   parent: PosterBase
   id: PosterContrabandFreeSyndicateEncryptionKey
-  name: "Free Syndicate Encryption Key"
-  description: "A poster about traitors begging for more."
+  name: "Free Unit 2559" # starcup: rewritten for tone
+  description: "An old wartime propaganda poster calling for the emancipation of a SyndComm AI unit. What nobody knew was that the Deux Ex Machina had already gotten to it." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster46_contraband
@@ -467,8 +470,8 @@
 - type: entity
   parent: PosterBase
   id: PosterContrabandTheBigGasTruth
-  name: "The Big Gas Giant Truth"
-  description: "Don't believe everything you see on a poster, patriots. All the lizards at central command don't want to answer this SIMPLE QUESTION: WHERE IS THE GAS MINER MINING FROM, CENTCOMM?"
+  name: "Charon-Epsilon Lives!"
+  description: "This poster claims to prove the existence of intelligent life on the planet Charon-Epsilon, and that these vengeful spirits will inevitably take revenge on Electra for the destruction of their world." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster48_contraband
@@ -492,14 +495,15 @@
     state: poster51_contraband
 
 # These 3 originally from VEEGEE
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandBeachStarYamamoto
-  name: "Beach Star Yamamoto!"
-  description: "A wall scroll depicting an old swimming anime with girls in small swim suits. You feel more weebish the longer you look at it."
-  components:
-  - type: Sprite
-    state: poster52_contraband
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandBeachStarYamamoto
+#  name: "Beach Star Yamamoto!"
+#  description: "A wall scroll depicting an old swimming anime with girls in small swim suits. You feel more weebish the longer you look at it."
+#  components:
+#  - type: Sprite
+#    state: poster52_contraband
 
 - type: entity
   parent: PosterBase
@@ -519,14 +523,15 @@
   - type: Sprite
     state: poster54_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandRise
-  name: "Rise Up"
-  description: "A poster depicting a grey shirted man holding a crowbar with the word Rise written below it."
-  components:
-  - type: Sprite
-    state: poster55_contraband
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandRise
+#  name: "Rise Up"
+#  description: "A poster depicting a grey shirted man holding a crowbar with the word Rise written below it."
+#  components:
+#  - type: Sprite
+#    state: poster55_contraband
 
 - type: entity
   parent: PosterBase
@@ -546,14 +551,15 @@
     - type: Sprite
       state: poster57_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandCybersun600
-  name: "Cybersun: 600 Years Commemorative Poster"
-  description: "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
-  components:
-    - type: Sprite
-      state: poster58_contraband
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterContrabandCybersun600
+#  name: "Cybersun: 600 Years Commemorative Poster"
+#  description: "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
+#  components:
+#    - type: Sprite
+#      state: poster58_contraband
 
 - type: entity
   parent: PosterBase
@@ -632,7 +638,7 @@
   parent: PosterBase
   id: PosterLegitHereForYourSafety
   name: "Here For Your Safety"
-  description: "A poster glorifying the station's security force."
+  description: "A poster to remind the station of the security force's dedication to their survival."
   components:
   - type: Sprite
     state: poster1_legit
@@ -668,7 +674,7 @@
   parent: PosterBase
   id: PosterLegitBuild
   name: "Build"
-  description: "A poster glorifying the engineering team."
+  description: "A poster calling for the engineering team to be constructive! The miracles of tomorrow are built on the foundation of today!" # rewritten for tone
   components:
   - type: Sprite
     state: poster5_legit
@@ -846,14 +852,15 @@
   - type: Sprite
     state: poster24_legit
 
-- type: entity
-  parent: PosterBase
-  id: PosterLegitCohibaRobustoAd
-  name: "Cohiba Robusto Ad"
-  description: "Cohiba Robusto, the classy cigar."
-  components:
-  - type: Sprite
-    state: poster25_legit
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterLegitCohibaRobustoAd
+#  name: "Cohiba Robusto Ad"
+#  description: "Cohiba Robusto, the classy cigar."
+#  components:
+#  - type: Sprite
+#    state: poster25_legit
 
 - type: entity
   parent: PosterBase
@@ -958,8 +965,8 @@
 - type: entity
   parent: PosterBase
   id: PosterLegitThereIsNoGasGiant
-  name: "There Is No Gas Giant"
-  description: "Nanotrasen has issued posters, like this one, to all stations reminding them that rumours of a gas giant are false."
+  name: "Charonic Planets"
+  description: "An informational poster from Electra reminding employees that any reports of life inhabiting Class-C \"Charonic\" planets are the result of persistent necrocosmic hallucinations." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster37_legit
@@ -1039,8 +1046,8 @@
 - type: entity
   parent: PosterBase
   id: PosterLegitSafetyMothMeth
-  name: "Safety Moth - Methamphetamine"
-  description: "This informational poster uses Safety Moth™ to tell the viewer to seek CMO approval before cooking methamphetamine. \"Stay close to the target temperature, and never go over!\" ...You shouldn't ever be making this."
+  name: "Safety Moth - Careful Measurements" # starcup: rewritten for tone
+  description: "This informational poster uses Safety Moth™ to tell the viewer to double-check their chemical ratios. \"Fine detail makes fine chemists!\"" # starcup: rewritten for tone
   components:
     - type: Sprite
       state: poster46_legit

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -736,23 +736,25 @@
   - type: Sprite
     state: poster12_legit
 
-- type: entity
-  parent: PosterBase
-  id: PosterLegitSpaceCops
-  name: "Space Cops."
-  description: "A poster advertising the television show Space Cops."
-  components:
-  - type: Sprite
-    state: poster13_legit
+# begin starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterLegitSpaceCops
+#  name: "Space Cops."
+#  description: "A poster advertising the television show Space Cops."
+#  components:
+#  - type: Sprite
+#    state: poster13_legit
 
-- type: entity
-  parent: PosterBase
-  id: PosterLegitUeNo
-  name: "Ue No."
-  description: "This thing is all in Japanese."
-  components:
-  - type: Sprite
-    state: poster14_legit
+#- type: entity
+#  parent: PosterBase
+#  id: PosterLegitUeNo
+#  name: "Ue No."
+#  description: "This thing is all in Japanese."
+#  components:
+#  - type: Sprite
+#    state: poster14_legit
+# end starcup
 
 - type: entity
   parent: PosterBase
@@ -880,14 +882,15 @@
   - type: Sprite
     state: poster28_legit
 
-- type: entity
-  parent: PosterBase
-  id: PosterLegitEnlist
-  name: "Enlist"
-  description: "Enlist in the Nanotrasen Deathsquadron reserves today!"
-  components:
-  - type: Sprite
-    state: poster29_legit
+# starcup: removed for tone
+#- type: entity
+#  parent: PosterBase
+#  id: PosterLegitEnlist
+#  name: "Enlist"
+#  description: "Enlist in the Nanotrasen Deathsquadron reserves today!"
+#  components:
+#  - type: Sprite
+#    state: poster29_legit
 
 - type: entity
   parent: PosterBase
@@ -973,8 +976,8 @@
 - type: entity
   parent: PosterBase
   id: PosterLegitSecWatch
-  name: "Sec is Watching You"
-  description: "A poster reminding you that security is watching your every move."
+  name: "Security Watch"
+  description: "A poster reminding you that security is everyone's concern. Watchful eyes keep saboteurs at bay!" # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster39_legit
@@ -1109,7 +1112,7 @@
   parent: PosterBase
   id: PosterLegitTyrone
   name: "Tyrone's Guide to Space"
-  description: "A poster advertising online schooling about space. The classes listed seem to cover things from the basic usage of station equipment to complicated subjects like creating pipebombs or covering entire hallways in spacelube. A disclaimer reads \"It's never THAT bad, and at the end you might even get a tortilla.\""
+  description: "A poster advertising online schooling about space. The classes listed seem to cover things from the basic usage of station equipment to complicated subjects like creating pipebombs or covering entire hallways in spacelube. A disclaimer reads \"It's never THAT bad, and at the end you might even get a tortilla.\" These courses are probably not approved by your employers." # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster54_legit

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -471,7 +471,7 @@
   parent: BaseSign
   id: SignCryo
   name: cryosleep sign
-  description: Just like that? You're gonna chicken out?
+  description: A sign indicating the cryosleep pods, for those wishing to clock out early. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: cryo

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
@@ -284,7 +284,7 @@
   parent: BaseFenceMetal
   id: FenceMetalGate
   name: chain link fence gate
-  description: You could use the door instead of vaulting over--if you're a COWARD, that is.
+  description: Regularly ignored in favor of vaulting over the fence by rebellious teenagers and similar malcontents. # starcup: rewritten for tone
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -509,10 +509,11 @@
   flavorType: Complex
   description: flavor-complex-gunpowder
 
-- type: flavor
-  id: validhunting
-  flavorType: Complex
-  description: flavor-complex-validhunting
+# starcup: removed for tone
+#- type: flavor
+#  id: validhunting
+#  flavorType: Complex
+#  description: flavor-complex-validhunting
 
 - type: flavor
   id: people

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/chef.yml
@@ -5,10 +5,11 @@
     head: ClothingHeadHatChef
 
 # Mask
-- type: loadout
-  id: ChefMask
-  equipment:
-    mask: ClothingMaskItalianMoustache
+# starcup: removed for tone
+#- type: loadout
+#  id: ChefMask
+#  equipment:
+#    mask: ClothingMaskItalianMoustache
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -299,12 +299,13 @@
   loadouts:
   - ChefHead
 
-- type: loadoutGroup
-  id: ChefMask
-  name: loadout-group-chef-mask
-  minLimit: 0
-  loadouts:
-  - ChefMask
+# starcup: removed for tone
+#- type: loadoutGroup
+#  id: ChefMask
+#  name: loadout-group-chef-mask
+#  minLimit: 0
+#  loadouts:
+#  - ChefMask
 
 - type: loadoutGroup
   id: ChefJumpsuit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -94,7 +94,7 @@
   groups:
   - GroupTankHarness
   - ChefHead
-  - ChefMask
+  #- ChefMask # starcup: removed for tone
   - ChefJumpsuit
   - CommonBackpack
   - ChefOuterClothing

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1783,7 +1783,7 @@
   id: ThreeMileIsland
   name: reagent-name-three-mile-island
   parent: BaseAlcohol
-  desc: reagent-desc-three-mile-island
+  desc: reagent-desc-three-mile-island-starcup # starcup: rewritten for tone
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: threemileisland
   color: "#666340"

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -71,7 +71,7 @@
   id: Ketchunaise
   name: reagent-name-ketchunaise
   group: Foods
-  desc: reagent-desc-ketchunaise
+  desc: reagent-desc-ketchunaise-starcup # starcup: rewritten for tone
   physicalDesc: reagent-physical-desc-saucey
   flavor: ketchunaise
   color: "#fba399"

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -2,7 +2,7 @@
   id: Blood
   name: reagent-name-blood
   group: Biological
-  desc: reagent-desc-blood
+  desc: reagent-desc-blood-starcup # starcup: rewritten for tone
   flavor: metallic
   color: "#800000"
   metamorphicSprite:

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -2,7 +2,7 @@
   id: Carpetium
   name: reagent-name-carpetium
   group: Special
-  desc: reagent-desc-carpetium
+  desc: reagent-desc-carpetium-starcup # starcup: rewritten for tone
   physicalDesc: reagent-physical-desc-fibrous
   flavor: carpet
   color: "#800000"

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -209,7 +209,7 @@
   id: Nicotine
   name: reagent-name-nicotine
   group: Narcotics
-  desc: reagent-desc-nicotine
+  desc: reagent-desc-nicotine-starcup # starcup: rewritten for tone
   flavor: bitter
   color: "#C0C0C0"
   physicalDesc: reagent-physical-desc-strong-smelling

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/decoration.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/decoration.yml
@@ -1,32 +1,33 @@
-﻿- type: constructionGraph
-  id: BananiumStatueClown
-  start: start
-  graph:
-    - node: start
-      edges:
-        - to: bananiumStatue
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          steps:
-            - material: Bananium
-              amount: 8
-              doAfter: 10
-
-    - node: bananiumStatue
-      entity: StatueBananiumClown
-      edges:
-        - to: start
-          completed:
-          - !type:SpawnPrototype
-                prototype: MaterialBananium1
-                amount: 8
-          - !type:DeleteEntity {}
-          steps:
-            - tool: Anchoring
-              doAfter: 5
-            - tool: Welding
-              doAfter: 5
+﻿# starcup: removed for tone
+#- type: constructionGraph
+#  id: BananiumStatueClown
+#  start: start
+#  graph:
+#    - node: start
+#      edges:
+#        - to: bananiumStatue
+#          completed:
+#            - !type:SnapToGrid
+#              southRotation: true
+#          steps:
+#            - material: Bananium
+#              amount: 8
+#              doAfter: 10
+#
+#    - node: bananiumStatue
+#      entity: StatueBananiumClown
+#      edges:
+#        - to: start
+#          completed:
+#          - !type:SpawnPrototype
+#                prototype: MaterialBananium1
+#                amount: 8
+#          - !type:DeleteEntity {}
+#          steps:
+#            - tool: Anchoring
+#              doAfter: 5
+#            - tool: Welding
+#              doAfter: 5
 
 - type: constructionGraph
   id: CarpStatue

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1204,17 +1204,18 @@
   conditions:
   - !type:TileNotBlocked
 
-- type: construction
-  id: BananiumClownStatue
-  graph: BananiumStatueClown
-  startNode: start
-  targetNode: bananiumStatue
-  category: construction-category-structures
-  placementMode: SnapgridCenter
-  objectType: Structure
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
+# starcup: removed for tone
+#- type: construction
+#  id: BananiumClownStatue
+#  graph: BananiumStatueClown
+#  startNode: start
+#  targetNode: bananiumStatue
+#  category: construction-category-structures
+#  placementMode: SnapgridCenter
+#  objectType: Structure
+#  canBuildInImpassable: false
+#  conditions:
+#    - !type:TileNotBlocked
 
 - type: construction
   id: BananiumDoor

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -282,7 +282,7 @@
     outerClothing: ClothingOuterArmorBasicSlim
     pocket1: WeaponPistolMk58
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
   - FlashlightSeclite
 
 - type: startingGear
@@ -859,7 +859,7 @@
     eyes: ClothingEyesHudMedical
     pocket1: RegenerativeMesh
     pocket2: PillCanisterBicaridine
-  inhand: 
+  inhand:
   - ScalpelAdvanced
   - MedicatedSuture
 
@@ -1046,7 +1046,7 @@
     pocket1: ButchCleaver
     pocket2: BookHowToCookForFortySpaceman
   inhand:
-  - ClothingMaskItalianMoustache
+  #- ClothingMaskItalianMoustache # starcup: removed for tone
   - DrinkWineBottleFull
 
 - type: startingGear
@@ -1064,7 +1064,7 @@
     pocket1: RollingPin
     pocket2: BookHowToCookForFortySpaceman
   inhand:
-  - ClothingMaskItalianMoustache
+  #- ClothingMaskItalianMoustache # starcup: removed for tone
   - FoodCheese
 
 - type: startingGear

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -53,7 +53,7 @@
   parent: DrinkGlass
   id: DrinkClownBloodGlass
   suffix: clown blood
-  description: Security Officers favorite drink after a long day.
+  description: A mixture invented by a famed clown who wanted a yummier choice for fake blood. # starcup: rewritten for tone
   components:
   - type: SolutionContainerManager
     solutions:
@@ -70,7 +70,7 @@
   parent: DrinkGlass
   id: DrinkCircusJuiceGlass
   suffix: circus juice
-  description: Honkmother would be proud.
+  description: One day, a clown managed to sneak their way into an Interdyne chemical lab. This was the result. # starcup: rewritten for tone
   components:
   - type: SolutionContainerManager
     solutions:
@@ -256,7 +256,7 @@
   parent: DrinkGlass
   id: DrinkKvassGlass
   suffix: kvass
-  description: A cool refreshing drink with a taste of socialism.
+  description: A sweet-and-sour grain alcohol, mellow enough to replace cola in some cultures. # starcup: rewritten for tone
   components:
     - type: SolutionContainerManager
       solutions:

--- a/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/alcohol.yml
@@ -107,7 +107,7 @@
   id: ClownBlood
   name: reagent-name-clownblood
   parent: BaseAlcohol
-  desc: reagent-desc-clownblood
+  desc: reagent-desc-clownblood-starcup # starcup: rewritten for tone
   physicalDesc: reagent-physical-desc-cloudy
   flavor: funny
   color: "#94001c"
@@ -130,7 +130,7 @@
   id: CircusJuice
   name: reagent-name-circusjuice
   parent: BaseAlcohol
-  desc: reagent-desc-circusjuice
+  desc: reagent-desc-circusjuice-starcup # starcup: rewritten for tone
   physicalDesc: reagent-physical-desc-glittery
   flavor: circusjuice
   color: "#c47872"

--- a/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/drinks.yml
@@ -215,7 +215,7 @@
   id: Kvass
   name: reagent-name-kvass
   parent: BaseDrink
-  desc: reagent-desc-kvass
+  desc: reagent-desc-kvass-starcup # starcup: rewritten for tone
   physicalDesc: reagent-physical-desc-bubbly
   flavor: kvass #Delta-V Flavor additions
   color: "#381600"

--- a/Resources/Prototypes/bar_signs.yml
+++ b/Resources/Prototypes/bar_signs.yml
@@ -1,10 +1,11 @@
-- type: barSign
-  id: Harmbaton
-  name: barsign-prototype-name-harmbaton
-  icon:
-    sprite: Structures/Wallmounts/barsign.rsi
-    state: theharmbaton
-  description: barsign-prototype-description-harmbaton
+# starcup: removed for tone
+#- type: barSign
+#  id: Harmbaton
+#  name: barsign-prototype-name-harmbaton
+#  icon:
+#    sprite: Structures/Wallmounts/barsign.rsi
+#    state: theharmbaton
+#  description: barsign-prototype-description-harmbaton
 
 - type: barSign
   id: TheSingulo


### PR DESCRIPTION
as part of my initiative to scrub all of the noxious 4chan-y stuff out of this game, I went through every single line of description text and rewrote the parts I didn't think were good, as well as removing some parts I didn't think were worth keeping.

some mapping bits have been commented out and subsequently removed from all of our maps; some places might end up being a little bit conspicuously empty until we go back through and fill in the empty spots. some posters also may not line up along the legit/contraband axis in the same way they used to, but this was also an inevitable part of the impending syndie/nano flip and something that can be addressed later. for right now, removing all of the bad stuff is more important than being super comprehensive with what we replace it with.

**Changelog**
]:cl:
- tweak: many, many lines of description text have been rewritten to better align with our server culture and intended narrative tone
- remove: some posters and other decorative items have been removed

