### PR TITLE
fix: address recent regressions caused by deactivated tests

### DIFF
--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -78,8 +78,8 @@ PlushieLizardMirrored: PlushieLizard
 
 # 2024-1-22
 #Use these lights because they are better
-PoweredlightExterior: PoweredLightBlueInterior
-ExteriorLightTube: BlueLightTube
+#PoweredlightExterior: PoweredLightBlueInterior  # starcup: uncomment this when we get it
+#ExteriorLightTube: BlueLightTube  # starcup: uncomment this when we get it
 
 # 2024-01-26
 SalvagePartsSpawnerSubSpace: SalvagePartsSpawnerMid

--- a/Resources/Migrations/deltav-Migrations.yml
+++ b/Resources/Migrations/deltav-Migrations.yml
@@ -1,2 +1,0 @@
-﻿# 2024-04-23
-SpawnPointMailCarrier: SpawnPointCourier

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,9 +1,9 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.25 # starcup: 0.20 -> 0.25
-    Traitor: 0.65 # starcup: 0.55 -> 0.65
+    Nukeops: 0.20
+    Traitor: 0.55
     Zombie: 0.05
-    Survival: 0.00 # starcup: 0.10 -> 0.00, until we add more events we don't want this randomly rolling
+    Survival: 0.10
     Revolutionary: 0.05
-    Wizard: 0.00 # starcup: 0.05 -> 0.00, Wizard needs serious rebalancing before we will allow it
+    Wizard: 0.05 # Why not, should probably be lower


### PR DESCRIPTION
I renamed the master branch to main a week ago and forgot to update workflows. Some of them haven't been running since then. This has led to several regressions sneaking into main.

Reverts #168: This broke the Secret preset.
Fixes two issues caused by #174.

Hopefully nothing else remains.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
