### PR TITLE
fix: head of personnel shoes loadout fix

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -61,7 +61,7 @@
 - type: startingGear
   id: HoPGear
   equipment:
-    shoes: ClothingShoesColorBrown
+    #shoes: ClothingShoesLeather # DeltaV - Commented for Loadouts
     id: HoPPDA
     gloves: ClothingHandsGlovesHop
     ears: ClothingHeadsetAltCommand


### PR DESCRIPTION
a line for the head of personnel's starting gear didn't get commented during the loadouts update. oops!

**Changelog**
:cl:
- fix: the head of personnel can now properly select shoes in their loadout