### PR TITLE
feat: new job-specific access levels

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -72,6 +72,17 @@ public sealed partial class IdCardConsoleComponent : Component
         "Service",
         "Theatre",
         "Robotics", // DeltaV
+        // begin starcup additions
+        "Boxer",
+        "Clown",
+        "Library",
+        "Mime",
+        "Musician",
+        "Paramedic",
+        "Psychologist",
+        "Reporter",
+        "Zookeeper",
+        // end starcup
     };
 
     [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_starcup/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_starcup/prototypes/access/accesses.ftl
@@ -1,0 +1,10 @@
+id-card-access-level-paramedic = Paramedic
+id-card-access-level-psychologist = Psychologist
+
+id-card-access-level-boxer = Boxer
+id-card-access-level-clown = Clown
+id-card-access-level-librarian = Library
+id-card-access-level-mime = Mime
+id-card-access-level-musician = Musician
+id-card-access-level-reporter = Reporter
+id-card-access-level-zookeeper = Zookeeper

--- a/Resources/Prototypes/Access/medical.yml
+++ b/Resources/Prototypes/Access/medical.yml
@@ -9,7 +9,7 @@
 - type: accessLevel
   id: Chemistry
   name: id-card-access-level-chemistry
-  
+
 - type: accessLevel
   id: Paramedic
   name: id-card-access-level-paramedic
@@ -20,3 +20,7 @@
   - ChiefMedicalOfficer
   - Medical
   - Chemistry
+  # begin starcup additions
+  - Paramedic
+  - Psychologist
+  # end starcup additions

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -36,3 +36,14 @@
   - GenpopLeave
   - Mail # DeltaV
   - Robotics # DeltaV: Robotics access
+  # begin starcup additions
+  - Boxer
+  - Clown
+  - Library
+  - Mime
+  - Musician
+  - Paramedic
+  - Psychologist
+  - Reporter
+  - Zookeeper
+  # end starcup

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -49,6 +49,17 @@
       - Security
       - Service
       - Theatre
+      # begin starcup additions
+      - Boxer
+      - Clown
+      - Library
+      - Mime
+      - Musician
+      - Paramedic
+      - Psychologist
+      - Reporter
+      - Zookeeper
+      # end starcup
       privilegedIdSlot:
         name: id-card-console-privileged-id
         ejectSound: /Audio/Machines/id_swipe.ogg

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -9,6 +9,7 @@
   access:
   - Theatre
   - Maintenance
+  - Clown # starcup: added unique access level
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Library # starcup: added unique access level
 
 - type: startingGear
   id: LibrarianGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -14,6 +14,7 @@
   access:
   - Theatre
   - Maintenance
+  - Mime # starcup: added unique access level
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -9,6 +9,7 @@
   access:
   - Maintenance # TODO Remove maint access for all gimmick jobs once access work is completed
   - Theatre
+  - Mime # starcup: added unique access level
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: MikuDay

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -51,6 +51,18 @@
   - Cargo
   - Atmospherics
   - Medical
+  # begin starcup additions
+  - Boxer
+  - Clown
+  - Library
+  - Mime
+  - Musician
+  - Paramedic
+  - Psychologist
+  - Reporter
+  - Zookeeper
+  # end starcup
+
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -33,6 +33,10 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
+  # begin starcup additions
+  - Paramedic
+  - Psychologist
+  # end starcup additions
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Boxer # starcup: added unique access level
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: BoxingDay

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -9,6 +9,7 @@
   access:
   - Medical
   - Maintenance
+  - Psychologist # starcup: added unique access level
   extendedAccess:
   - Chemistry
 

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Reporter # starcup: added unique access level
 
 - type: startingGear
   id: ReporterGear

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Zookeeper # starcup: added unique access level
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: MonkeyDay

--- a/Resources/Prototypes/_starcup/Access/medical.yml
+++ b/Resources/Prototypes/_starcup/Access/medical.yml
@@ -1,0 +1,7 @@
+- type: accessLevel
+  id: Paramedic
+  name: id-card-access-level-paramedic
+
+- type: accessLevel
+  id: Psychologist
+  name: id-card-access-level-psychologist

--- a/Resources/Prototypes/_starcup/Access/service.yml
+++ b/Resources/Prototypes/_starcup/Access/service.yml
@@ -1,0 +1,27 @@
+- type: accessLevel
+  id: Boxer
+  name: id-card-access-level-boxer
+
+- type: accessLevel
+  id: Clown
+  name: id-card-access-level-clown
+
+- type: accessLevel
+  id: Library
+  name: id-card-access-level-librarian
+
+- type: accessLevel
+  id: Mime
+  name: id-card-access-level-mime
+
+- type: accessLevel
+  id: Musician
+  name: id-card-access-level-musician
+
+- type: accessLevel
+  id: Reporter
+  name: id-card-access-level-reporter
+
+- type: accessLevel
+  id: Zookeeper
+  name: id-card-access-level-zookeeper

--- a/Resources/Prototypes/_starcup/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Devices/Electronics/door_access.yml
@@ -1,0 +1,71 @@
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsBoxer
+  suffix: Boxer, Locked
+  components:
+  - type: AccessReader
+    access: [["Boxer"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsClown
+  suffix: Clown, Locked
+  components:
+  - type: AccessReader
+    access: [["Clown"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsLibrary
+  suffix: Library, Locked
+  components:
+  - type: AccessReader
+    access: [["Library"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMime
+  suffix: Mime, Locked
+  components:
+  - type: AccessReader
+    access: [["Mime"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMusician
+  suffix: Musician, Locked
+  components:
+  - type: AccessReader
+    access: [["Musician"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsParamedic
+  suffix: Paramedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Paramedic"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsPsychologist
+  suffix: Psychologist, Locked
+  components:
+  - type: AccessReader
+    access: [["Psychologist"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsReporter
+  suffix: Reporter, Locked
+  components:
+  - type: AccessReader
+    access: [["Reporter"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsZookeeper
+  suffix: Zookeeper, Locked
+  components:
+  - type: AccessReader
+    access: [["Zookeeper"]]

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/Windoors/windoor.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/Windoors/windoor.yml
@@ -1,0 +1,89 @@
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureBoxerLocked
+  suffix: Boxer, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureClownLocked
+  suffix: Clown, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureHydroponicsLocked
+  suffix: Hydroponics, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsHydroponics ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureLibraryLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureMimeLocked
+  suffix: Mime, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureMusicianLocked
+  suffix: Musician, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
+
+- type: entity
+  parent: WindoorSecureSecurityLocked
+  id: WindoorSecureParamedicLocked
+  suffix: Paramedic, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsParamedic ]
+
+- type: entity
+  parent: WindoorSecureMedicalLocked
+  id: WindoorSecurePsychologistLocked
+  suffix: Psychologist, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPsychologist ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureReporterLocked
+  suffix: Reporter, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureZookeeperLocked
+  suffix: Zookeeper, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsZookeeper ]

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
@@ -1,0 +1,227 @@
+# Airlocks
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockBoxerLocked
+  suffix: Boxer, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
+
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockClownLocked
+  suffix: Clown, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
+
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockLibraryLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockMimeLocked
+  suffix: Mime, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
+
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockMusicianLocked
+  suffix: Musician, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
+
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockReporterLocked
+  suffix: Reporter, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
+
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockZookeeperLocked
+  suffix: Zookeeper, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsZookeeper ]
+
+- type: entity
+  parent: AirlockMedicalLocked
+  id: AirlockParamedicLocked
+  suffix: Paramedic, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsParamedic ]
+
+- type: entity
+  parent: AirlockMedicalLocked
+  id: AirlockPsychologistLocked
+  suffix: Psychologist, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPsychologist ]
+
+# Glass Airlocks
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockBoxerGlassLocked
+  suffix: Boxer, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockClownGlassLocked
+  suffix: Clown, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockLibraryGlassLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockMimeGlassLocked
+  suffix: Mime, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockMusicianGlassLocked
+  suffix: Musician, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockReporterGlassLocked
+  suffix: Reporter, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockZookeeperGlassLocked
+  suffix: Zookeeper, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsZookeeper ]
+
+- type: entity
+  parent: AirlockMedicalGlassLocked
+  id: AirlockParamedicGlassLocked
+  suffix: Paramedic, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsParamedic ]
+
+- type: entity
+  parent: AirlockMedicalGlassLocked
+  id: AirlockPsychologistGlassLocked
+  suffix: Psychologist, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPsychologist ]
+
+# Maintenance Hatches
+- type: entity
+  parent: AirlockBoxerLocked
+  id: AirlockMaintBoxerLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockClownLocked
+  id: AirlockMaintClownLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockLibraryLocked
+  id: AirlockMaintLibraryocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockMimeLocked
+  id: AirlockMaintMimeLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockMusicianLocked
+  id: AirlockMaintMusicianLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockReporterLocked
+  id: AirlockMaintReporterLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockZookeeperLocked
+  id: AirlockMaintZookeeperLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockPsychologistLocked
+  id: AirlockMaintPsychologistLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: AirlockParamedicLocked
+  id: AirlockMaintParamedicLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi


### PR DESCRIPTION
gives assorted miscellaneous service jobs their own unique access levels, as a tool to help mappers give these jobs their own unique spaces!

## Why / Balance
highly requested from our local mime enthusiasts. these roles deserve their own special spaces that can't just be barged in by anyone!

**Changelog**
:cl:
- add: clowns, mimes, boxers, reporters, librarians, zoologists, paramedics, and psychologists now have their own access levels; these are non-functional for now, but will be included in upcoming map updates