### PR TITLE
fix: render undergarments below clothes

### DIFF
--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/rodentia.yml
@@ -45,6 +45,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]  # starcup
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]  # starcup
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -45,6 +45,8 @@
         sprite: _DeltaV/Mobs/Customization/Vulpkanin/masking_helpers.rsi
         state: female_full
         visible: false
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]  # starcup
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]  # starcup
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -115,6 +115,8 @@
           sprite: Mobs/Customization/masking_helpers.rsi
           state: female_full
           visible: false
+        - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]  # starcup
+        - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]  # starcup
         - map: ["enum.HumanoidVisualLayers.LFoot"]
         - map: ["enum.HumanoidVisualLayers.RFoot"]
         - map: ["socks"]


### PR DESCRIPTION
Set up undergarment layers for rodentia, vulpekin, and mkcs.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Undergarments now render correctly for rodentia, vulpekin, and MKCs.