### PR TITLE
tweak: drink adjustments (alcohol, coffee, etc)

### DIFF
--- a/Resources/Locale/en-US/_starcup/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/toxins.ftl
@@ -1,0 +1,2 @@
+reagent-name-caffeine = caffeine
+reagent-desc-caffeine = A stimulant found in many commercially available drinks. Toxic to animals.

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1420,6 +1420,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.07 # starcup: decreased from 0.15
+      # begin starcup: add caffeine
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.05
+      # end starcup
 
 - type: reagent
   id: JackRose
@@ -2283,7 +2288,7 @@
           reagent: Ethanol
           amount: 0.07 # starcup: decreased from 0.1
         - !type:AdjustReagent
-          reagent: Theobromine
+          reagent: Caffeine # starcup: replacement for theobromine
           amount: 0.05
         - !type:ModifyStatusEffect
           effectProto: StatusEffectDrowsiness
@@ -2314,7 +2319,7 @@
           reagent: Ethanol
           amount: 0.06 # starcup: decreased from 0.15
         - !type:AdjustReagent
-          reagent: Theobromine
+          reagent: Caffeine # starcup: replacement for theobromine
           amount: 0.05
         - !type:ModifyStatusEffect
           effectProto: StatusEffectDrowsiness
@@ -2345,7 +2350,7 @@
           reagent: Ethanol
           amount: 0.06 # starcup: decreased from 0.15
         - !type:AdjustReagent
-          reagent: Theobromine
+          reagent: Caffeine # starcup: replacement for theobromine
           amount: 0.05
         - !type:ModifyStatusEffect
           effectProto: StatusEffectDrowsiness
@@ -2376,7 +2381,7 @@
           reagent: Ethanol
           amount: 0.11 # starcup: decreased from 0.15
         - !type:AdjustReagent
-          reagent: Theobromine
+          reagent: Caffeine # starcup: replacement for theobromine
           amount: 0.05
         - !type:ModifyStatusEffect
           effectProto: StatusEffectDrowsiness
@@ -2407,7 +2412,7 @@
           reagent: Ethanol
           amount: 0.07
         - !type:AdjustReagent
-          reagent: Theobromine
+          reagent: Caffeine # starcup: replacement for theobromine
           amount: 0.05
         - !type:ModifyStatusEffect
           effectProto: StatusEffectDrowsiness
@@ -2438,7 +2443,7 @@
           reagent: Ethanol
           amount: 0.06 # starcup: decreased from 0.15
         - !type:AdjustReagent
-          reagent: Theobromine
+          reagent: Caffeine # starcup: replacement for theobromine
           amount: 0.05
         - !type:ModifyStatusEffect
           effectProto: StatusEffectDrowsiness
@@ -2667,6 +2672,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.08 # starcup: decreased from 0.2
+      # begin starcup: add caffeine
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.05
+      # end starcup
 
 - type: reagent
   id: Daiquiri

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -147,7 +147,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.07 # starcup: decreased from 0.2
 
 - type: reagent
   id: Ethanol
@@ -242,6 +242,16 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: MelonLiquor
@@ -257,6 +267,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: NTCahors
@@ -386,6 +406,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Vodka
@@ -507,6 +537,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: AlliesCocktail
@@ -522,6 +562,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.17 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Aloe
@@ -552,6 +602,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Andalusia
@@ -567,6 +627,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 #Antifreeze as a drink is a bright blue color while it is an orangish red otherwise.
 #As a result this sprite doesn't need changing.
@@ -592,7 +662,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.1 # starcup: decreased from 0.15
 
 - type: reagent
   id: AtomicBomb
@@ -615,7 +685,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.12 # starcup: decreased from 0.15
       - !type:AdjustReagent
         reagent: Uranium
         amount: 0.05
@@ -641,7 +711,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.13 # starcup: decreased from 0.15
 
 - type: reagent
   id: BahamaMama
@@ -657,6 +727,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: BananaHonk
@@ -672,6 +752,13 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup: removed alcohol content
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+  # end starcup
 
 - type: reagent
   id: Barefoot
@@ -709,7 +796,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.07 # starcup: decreased from 0.15
   fizziness: 0.3
 
 - type: reagent
@@ -733,7 +820,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.16 # starcup: decreased from 0.2
 
 - type: reagent
   id: BloodyMary
@@ -749,6 +836,17 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.07 # increased from 0.06
+  # end starcup
+
 
 - type: reagent
   id:  Booger
@@ -786,7 +884,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.16 # starcup: decreased from 0.2
 
 - type: reagent
   id: Bronx
@@ -802,6 +900,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.12 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: CoconutRum
@@ -824,7 +932,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.13 # starcup: decreased from 0.2
 
 - type: reagent
   id: Cosmopolitan
@@ -847,7 +955,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.1 # starcup: decreased from 0.15
 
 - type: reagent
   id: CrushDepth
@@ -863,6 +971,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: CubaLibre
@@ -902,6 +1020,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: DemonsBlood
@@ -933,6 +1061,16 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.09 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: DoctorsDelight
@@ -1003,6 +1141,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: ElectricShark
@@ -1018,6 +1166,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: ErikaSurprise
@@ -1127,7 +1285,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.18 # starcup: decreased from 0.2
 
 - type: reagent
   id: Grog
@@ -1158,6 +1316,16 @@
   metamorphicMaxFillLevels: 6
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Hooch
@@ -1205,7 +1373,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.1 # starcup: decreased from 0.15
 
 - type: reagent
   id: IrishCream
@@ -1228,7 +1396,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.13 # starcup: decreased from 0.2
 
 - type: reagent
   id: IrishCoffee
@@ -1251,7 +1419,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.07 # starcup: decreased from 0.15
 
 - type: reagent
   id: JackRose
@@ -1282,6 +1450,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Kalimotxo
@@ -1319,7 +1497,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.13 # starcup: decreased from 0.15
 
 - type: reagent
   id: Manhattan
@@ -1335,6 +1513,16 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.16 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: ManhattanProject
@@ -1350,6 +1538,16 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.18 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: ManlyDorf
@@ -1381,6 +1579,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.13 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Martini
@@ -1403,7 +1611,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.16 # starcup: increased from 0.15
 
 - type: reagent
   id: Mead
@@ -1436,6 +1644,16 @@
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
   fizziness: 0.3
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: MonkeyBusiness
@@ -1451,6 +1669,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.13 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Moonshine
@@ -1525,7 +1753,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.06 # starcup: decreased from 0.2
 
 - type: reagent
   id: Patron
@@ -1548,7 +1776,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.18 # starcup: decreased from 0.2
 
 - type: reagent
   id: RedMead
@@ -1625,6 +1853,16 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: ScrewdriverCocktail
@@ -1673,7 +1911,7 @@
           factor: 2
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.15
+          amount: 0.09 # starcup: decreased from 0.15
 
 - type: reagent
   id: Silencer
@@ -1782,7 +2020,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.06 # starcup: decreased from 0.15
 
 - type: reagent
   id: TheMartinez
@@ -1799,6 +2037,16 @@
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
   fizziness: 0.2
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.07 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: ThreeMileIsland
@@ -1821,7 +2069,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.12 # starcup: decreased from 0.15
       - !type:AdjustReagent
         reagent: Uranium
         amount: 0.05
@@ -1840,6 +2088,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: Vampiro
@@ -1855,6 +2113,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup additions
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08 # increased from 0.06
+  # end starcup
 
 - type: reagent
   id: VodkaMartini
@@ -1877,7 +2145,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.16 # starcup: increased from 0.15
 
 - type: reagent
   id: VodkaTonic
@@ -1966,7 +2234,7 @@
           factor: 1
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.15
+          amount: 0.06 # starcup: decreased from 0.15
   fizziness: 0.5
 
 - type: reagent
@@ -1990,7 +2258,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.08 # starcup: decreased from 0.15
 
 - type: reagent
   id: VodkaRedBool
@@ -2013,7 +2281,7 @@
           factor: 1
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.10
+          amount: 0.07 # starcup: decreased from 0.1
         - !type:AdjustReagent
           reagent: Theobromine
           amount: 0.05
@@ -2044,7 +2312,7 @@
           factor: 1
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.15
+          amount: 0.06 # starcup: decreased from 0.15
         - !type:AdjustReagent
           reagent: Theobromine
           amount: 0.05
@@ -2075,7 +2343,7 @@
           factor: 1
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.10
+          amount: 0.06 # starcup: decreased from 0.15
         - !type:AdjustReagent
           reagent: Theobromine
           amount: 0.05
@@ -2106,7 +2374,7 @@
           factor: 1
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.15
+          amount: 0.11 # starcup: decreased from 0.15
         - !type:AdjustReagent
           reagent: Theobromine
           amount: 0.05
@@ -2168,7 +2436,7 @@
           factor: 1
         - !type:AdjustReagent
           reagent: Ethanol
-          amount: 0.15
+          amount: 0.06 # starcup: decreased from 0.15
         - !type:AdjustReagent
           reagent: Theobromine
           amount: 0.05
@@ -2199,7 +2467,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.07 # starcup: decreased from 0.2
 
 - type: reagent
   id: Caipirinha
@@ -2222,7 +2490,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.1
+        amount: 0.08 # starcup: decreased from 0.1
 
 - type: reagent
   id: MoscowMule
@@ -2245,7 +2513,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.13 # starcup: decreased from 0.2
       - !type:AdjustReagent
         reagent: Copper
         amount: 0.05
@@ -2329,7 +2597,7 @@
         factor: 1
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.06 # starcup: decreased from 0.15
 
 - type: reagent
   id: DeathInTheAfternoon
@@ -2352,7 +2620,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.3
+        amount: 0.22 # starcup: decreased from 0.3
 
 - type: reagent
   id: Empress75
@@ -2375,7 +2643,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.3
+        amount: 0.06 # starcup: decreased from 0.3
 
 - type: reagent
   id: EspressoMartini
@@ -2398,7 +2666,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.08 # starcup: decreased from 0.2
 
 - type: reagent
   id: Daiquiri
@@ -2421,7 +2689,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.1
+        amount: 0.13 # starcup: increased from 0.1
 
 - type: reagent
   id: TheSunAlsoRises
@@ -2444,7 +2712,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.3
+        amount: 0.16 # starcup: decreased from 0.3
 
 - type: reagent
   id: WhiskeySour
@@ -2467,7 +2735,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.08 # starcup: decreased from 0.2
 
 - type: reagent
   id: ZombieCocktail

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -17,7 +17,7 @@
         time: 2
         type: Remove
       - !type:AdjustReagent
-        reagent: Theobromine
+        reagent: Caffeine # starcup: replacement for theobromine
         amount: 0.05
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
@@ -109,6 +109,11 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      # begin starcup: add caffeine
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.05
+      # end starcup
 
 - type: reagent
   id: GreenTea
@@ -124,6 +129,14 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup: add theobromine
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+  # end starcup
 
 - type: reagent
   id: Grenadine
@@ -165,6 +178,11 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      # begin starcup: add caffeine
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.05
+      # end starcup
 
 - type: reagent
   id: IcedGreenTea
@@ -180,6 +198,14 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup: add theobromine
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+  # end starcup
 
 - type: reagent
   id: IcedTea
@@ -589,6 +615,14 @@
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
   fizziness: 0.3
+  # begin starcup: add caffeine
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.05
+  # end starcup
 
 - type: reagent
   id: Mopwata
@@ -618,3 +652,11 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # begin starcup: add theobromine
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+  # end starcup

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -85,7 +85,7 @@
         time: 2
         type: Remove
       - !type:AdjustReagent
-        reagent: Theobromine
+        reagent: Caffeine # starcup: replacement for theobromine
         amount: 0.1
   fizziness: 0.4
 
@@ -268,8 +268,13 @@
       - !type:SatiateThirst
         factor: 2
       - !type:AdjustReagent
-        reagent: Theobromine
+        reagent: Caffeine # starcup: replacement for theobromine
         amount: 0.1
+      # begin starcup: add alcohol content
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.06
+      # end starcup
     Poison:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -256,13 +256,13 @@
   - Shake
   reactants:
     Gin:
-      amount: 1
+      amount: 2 # starcup: increased from 1
     Vermouth:
       amount: 1
     JuiceOrange:
       amount: 1
   products:
-    Bronx: 3
+    Bronx: 4 # starcup: increased from 3
 
 - type: reaction
   id: CafeLatte
@@ -288,13 +288,13 @@
   id: Cosmopolitan
   reactants:
     Vodka:
-      amount: 1
+      amount: 2 # starcup: increased from 1
     JuiceBerry:
       amount: 1
     JuiceLime:
       amount: 1
   products:
-    Cosmopolitan: 3
+    Cosmopolitan: 4 # starcup: increased from 3
 
 - type: reaction
   id: CreamOfCoconut
@@ -845,13 +845,13 @@
     JuiceLime:
       amount: 1
     Rum:
-      amount: 1
+      amount: 2 # starcup: increased from 1
     SodaWater:
       amount: 1
     Sugar:
       amount: 1
   products:
-    Mojito: 4
+    Mojito: 5 # starcup: increased from 4
 
 - type: reaction
   id: MonkeyBusiness
@@ -1166,12 +1166,16 @@
 - type: reaction
   id: TequilaSunrise
   reactants:
+  # begin starcup: recipe change
     JuiceOrange:
-      amount: 1
+      amount: 2 # increased from 1
     Tequila:
-      amount: 2
+      amount: 1 # decreased from 2
+    Grenadine:
+      amount: 1 # added
   products:
-    TequilaSunrise: 3
+    TequilaSunrise: 4
+  # end starcup
 
 - type: reaction
   id: ThreeMileIsland
@@ -1398,7 +1402,7 @@
   - Shake
   reactants:
     Rum:
-      amount: 1
+      amount: 2 # starcup: increased from 1
     JuiceLime:
       amount: 1
     Sugar:
@@ -1406,7 +1410,7 @@
     Ice:
       amount: 1
   products:
-    Caipirinha: 4
+    Caipirinha: 5 # starcup: increased from 4
 
 - type: reaction
   id: Daiquiri

--- a/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/alcohol.yml
@@ -42,7 +42,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.05
+        amount: 0.07 # starcup: increased from 0.05
 
 - type: reagent
   id: Silverjack
@@ -65,7 +65,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.0625
+        amount: 0.09 # starcup: increased from 0.0625
 
 - type: reagent
   id: Brainbomb
@@ -95,7 +95,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.085
+        amount: 0.07 # starcup: decreased from 0.085
       - !type:AdjustReagent
         reagent: THC
         amount: 0.33
@@ -196,9 +196,9 @@
       effects:
       - !type:SatiateThirst
         factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.03
+#      - !type:AdjustReagent # starcup: <0.06 ethanol doesn't do anything
+#        reagent: Ethanol
+#        amount: 0.03
 - type: reagent
   id: Angobitters
   name: reagent-name-angobitters

--- a/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/alcohol.yml
@@ -122,9 +122,9 @@
       effects:
       - !type:SatiateThirst
         factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.025
+#      - !type:AdjustReagent # starcup: <0.06 ethanol doesn't do anything
+#        reagent: Ethanol
+#        amount: 0.025
 
 - type: reagent
   id: CircusJuice
@@ -147,7 +147,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.0625
+        amount: 0.06 # starcup: rounded down from 0.0625 for standardization
       - !type:Emote #It's very funny
         emote: Laugh
         probability: 0.15
@@ -173,7 +173,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.065
+        amount: 0.06 # starcup: rounded down from 0.065 for standardization
       - !type:AdjustTemperature
         amount: 75 # thermal energy, not temperature!
 
@@ -213,6 +213,6 @@
       effects:
       - !type:SatiateThirst
         factor: 1
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.3
+#      - !type:AdjustReagent # starcup: <0.06 ethanol doesn't do anything
+#        reagent: Ethanol
+#        amount: 0.03

--- a/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/drinks.yml
@@ -67,6 +67,11 @@
       - !type:AdjustReagent
         reagent: Nutriment
         amount: 0.1
+      # begin starcup: add theobromine
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+      # end starcup
 - type: reagent
   id: HealthViolation
   name: reagent-name-healthviolation
@@ -248,6 +253,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.25
+      # begin starcup: add caffeine
+      - !type:AdjustReagent
+        reagent: Caffeine
+        amount: 0.05
+      # end starcup
     Poison:
       effects:
       - !type:Jitter

--- a/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_DeltaV/Reagents/Consumable/Drink/drinks.yml
@@ -124,7 +124,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.20
+        amount: 0.09 # starcup: decreased from 0.2
     Poison:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/_starcup/Reagents/toxins.yml
+++ b/Resources/Prototypes/_starcup/Reagents/toxins.yml
@@ -1,0 +1,5 @@
+- type: reagent
+  id: Caffeine
+  parent: Theobromine
+  name: reagent-name-caffeine
+  desc: reagent-desc-caffeine


### PR DESCRIPTION
tweaks the amount of ethanol many cocktails and other drinks produce on metabolism, and adjusts the ratios on a couple of cocktails. also adds a new reagent, caffeine, which is functionally identical to theobromine in all but name, and distributes the two reagents across a few drinks that probably ought to have them.

## Why / Balance
a lot of ethanol contents in this game don't make much sense. why does xeno basher magically acquire twice the ethanol content of its component drinks? why does a manhattan have nearly a quarter of the ethanol of whiskey despite being two-thirds whiskey by volume? why is a black russian just as alcoholic as vodka despite there being something besides vodka in it?

to remedy this, I've gone through every mixed drink in the game and calculated their ethanol content based on how much of a given base alcohol is in it proportional to other ingredients. I did leave a few drinks alone, mainly the explicitly fantastical ones like the arsonist's brew and zombie, and I also adjusted a few base alcohols like vermouth and coffee liqueur to more accurately reflect their real-world alcohol content.

this is another change to try and deal with the confusing, frustratingly inconsistent way alcohol is handled in this game and reduce the number of unexpected mishaps players experience during trips to the bar. by making cocktails' alcohol strength more intuitive based on what goes into it, this will also help bartenders have a better idea of what exactly they're serving their guests. this desire for intuitive assessment of drinks is also why I adjusted some of the recipes; as someone who's has cosmopolitans in real life, I can tell you firsthand that the distribution of vodka to juice in those things is NOT perfectly even.

the addition of caffeine is also largely a player awareness consideration. the game basically uses theobromine as a substitute for caffeine since they both do the same thing, which is fair, but those two chemicals don't come from the same place and it won't be obvious to the furries of our server why an energy drink is poisoning them if they're only told to watch out for theobromine, which in real life, is found in chocolate but not red bull. the widespread inconsistency with which things have these chemicals (cafe lattes don't have caffeine, green tea doesn't have theobromine, etc) can also create player confusion, so I fixed that too.

## Technical details
I adjusted alcohol contents for mixed drinks by taking the total alcohol content of its components and dividing it across the entire cocktail's volume. for example, a gin and tonic is made up of 3 parts—2 tonic water, 1 gin—and so I took the base 0.2 ethanol from that 1 gin, divided it by 3, and got the new result of 0.07 (rounding up).

here is the full list of drinks I've changed the contents of! they're sorted by their pre-pr ethanol content, and are listed alongside their new post-pr ethanol content
<details>

**0.06 ethanol**
vermouth: 0.08
coffee liqueur: 0.08
melon liquor: 0.08
amasec: 0.1
andalusia: 0.13
banana honk: 0
bloody mary: 0.07
bronx: 0.12
dark & stormy: 0.1
devil's kiss: 0.09
jungle bird: 0.1
manhattan: 0.16
manhattan project: 0.18
margarita: 0.13
mojito: 0.08
monkey business: 0.13
sbiten: 0.1
silverjack: 0.09
the martinez: 0.07
toxins special: 0.1
alien brain hemorrhage: 0.08
allies cocktail: 0.17
bahama mama: 0.1
crush depth: 0.1
electric shark: 0.1
hippie's delight: 0.08
vampiro: 0.08
eggnog: 0.1

**0.07 ethanol**
mimeosa: 0.06

**0.08 ethanol**
brainbomb: 0.07

**0.1 ethanol**
caipirinha: 0.08
daiquiri: 0.13
vodka red bool: 0.07
irish bool: 0.06

**0.15 ethanol**
antifreeze: 0.1
beepsky smash: 0.07
classic martini: 0.16
cosmopolitan: 0.1
tequila sunrise: 0.06
vodka martini: 0.16
white gilgamesh: 0.06
cogchamp: 0.09
irish coffee: 0.07
grenade penguin: 0.1
long island iced tea: 0.13
mayojito: 0.06
white russian: 0.08
B-52: 0.13
three mile island iced tea: 0.12
atomic bomb: 0.12
budget insuls: 0.11
rubberneck: 0.06
xeno basher: 0.06

**0.2 ethanol**
black russian: 0.16
brave bull: 0.16
coconut rum: 0.13
gildlager: 0.18
gunmetal: 0.09
irish cream: 0.13
moscow mule: 0.13
patron: 0.18
whiskey sour: 0.08
blue hawaiian: 0.07
deadrum: 0.07
espresso martini: 0.08
painkiller: 0.06

**0.3 ethanol**
death in the afternoon: 0.22
empress 75: 0.06
the sun also rises: 0.16
</details>

**Changelog**
:cl:
- tweak: changed the ethanol content of many drinks to make more sense
- add: some sources of theobromine now give caffeine, a new functionally identical reagent added for player clarity
- fix: theobromine (and caffeine) have been added to many drinks where they should have been but weren't
