### PR TITLE
feat: unique glove fibers

### DIFF
--- a/Content.Server/Forensics/Components/FiberComponent.cs
+++ b/Content.Server/Forensics/Components/FiberComponent.cs
@@ -12,5 +12,8 @@ namespace Content.Server.Forensics
 
         [DataField]
         public string? FiberColor;
+
+        [DataField]
+        public string? Fiberprint; // DeltaV, unique glove fibers
     }
 }

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -34,6 +34,7 @@ namespace Content.Server.Forensics
         public override void Initialize()
         {
             SubscribeLocalEvent<HandsComponent, ContactInteractionEvent>(OnInteract);
+            SubscribeLocalEvent<FiberComponent, MapInitEvent>(OnFiberInit); // DeltaV #1455 - unique glove fibers;
             SubscribeLocalEvent<FingerprintComponent, MapInitEvent>(OnFingerprintInit, after: new[] { typeof(BloodstreamSystem) });
             // The solution entities are spawned on MapInit as well, so we have to wait for that to be able to set the DNA in the bloodstream correctly without ResolveSolution failing
             SubscribeLocalEvent<DnaComponent, MapInitEvent>(OnDNAInit, after: new[] { typeof(BloodstreamSystem) });
@@ -65,6 +66,14 @@ namespace Content.Server.Forensics
         {
             ApplyEvidence(uid, args.Other);
         }
+
+        // Begin DeltaV Additions
+        // #1455 - unique glove fibers
+        private void OnFiberInit(Entity<FiberComponent> ent, ref MapInitEvent args)
+        {
+            ent.Comp.Fiberprint = GenerateFingerprint(length: 7);
+        }
+        // End DeltaV Additions
 
         private void OnFingerprintInit(Entity<FingerprintComponent> ent, ref MapInitEvent args)
         {
@@ -270,9 +279,9 @@ namespace Content.Server.Forensics
                 targetComp.Residues.Add(string.IsNullOrEmpty(residue.ResidueColor) ? Loc.GetString("forensic-residue", ("adjective", residue.ResidueAdjective)) : Loc.GetString("forensic-residue-colored", ("color", residue.ResidueColor), ("adjective", residue.ResidueAdjective)));
         }
 
-        public string GenerateFingerprint()
+        public string GenerateFingerprint(int length = 16) // DeltaV #1455 - allow changing the length of the fingerprint hash
         {
-            var fingerprint = new byte[16];
+            var fingerprint = new byte[length]; // DeltaV #1455 - allow changing the length of the fingerprint hash
             _random.NextBytes(fingerprint);
             return Convert.ToHexString(fingerprint);
         }
@@ -298,8 +307,18 @@ namespace Content.Server.Forensics
             var component = EnsureComp<ForensicsComponent>(target);
             if (_inventory.TryGetSlotEntity(user, "gloves", out var gloves))
             {
+                // DeltaV #1455 - unique glove fibers
                 if (TryComp<FiberComponent>(gloves, out var fiber) && !string.IsNullOrEmpty(fiber.FiberMaterial))
-                    component.Fibers.Add(string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial)) : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial)));
+                {
+                    var fiberLocale = string.IsNullOrEmpty(fiber.FiberColor)
+                        ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial))
+                        : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial));
+                    component.Fibers.Add(fiberLocale + " ; " + fiber.Fiberprint);
+                }
+                // End of DeltaV code
+
+                if (HasComp<FingerprintMaskComponent>(gloves))
+                    return;
             }
 
             if (TryComp<FingerprintComponent>(user, out var fingerprint) && CanAccessFingerprint(user, out _))

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Forensics
         public override void Initialize()
         {
             SubscribeLocalEvent<HandsComponent, ContactInteractionEvent>(OnInteract);
-            SubscribeLocalEvent<FiberComponent, MapInitEvent>(OnFiberInit); // DeltaV #1455 - unique glove fibers;
+            SubscribeLocalEvent<FiberComponent, MapInitEvent>(OnFiberInit, after: [typeof(BloodstreamSystem)]); // DeltaV - (#1455) unique glove fibers
             SubscribeLocalEvent<FingerprintComponent, MapInitEvent>(OnFingerprintInit, after: new[] { typeof(BloodstreamSystem) });
             // The solution entities are spawned on MapInit as well, so we have to wait for that to be able to set the DNA in the bloodstream correctly without ResolveSolution failing
             SubscribeLocalEvent<DnaComponent, MapInitEvent>(OnDNAInit, after: new[] { typeof(BloodstreamSystem) });
@@ -316,9 +316,6 @@ namespace Content.Server.Forensics
                     component.Fibers.Add(fiberLocale + " ; " + fiber.Fiberprint);
                 }
                 // End of DeltaV code
-
-                if (HasComp<FingerprintMaskComponent>(gloves))
-                    return;
             }
 
             if (TryComp<FingerprintComponent>(user, out var fingerprint) && CanAccessFingerprint(user, out _))


### PR DESCRIPTION
port of ["Unique glove fibers"](https://github.com/DeltaV-Station/Delta-v/pull/1455) from delta-v, giving each glove a unique fiber id similarly to fingerprints. notably you can't actually scan a glove's fingerprints directly due to weird refactoring stuff that happened since this was implemented, but this needs to be out by tomorrow afternooon and is technically workable so we can address that later

## Why / Balance
forensics are already hard enough and having gloves be utterly unrecognizable from one another on the forensic scanner just makes it harder

**Changelog**
:cl:
- add: gloves now have unique fiber IDs