### PR TITLE
fix: imitation chocolate cake slices properly

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -5,7 +5,7 @@
   description: A cake with added imitation chocolate.
   components:
   - type: SliceableFood
-    slice: FoodCakeChocolateSlice
+    slice: FoodCakeChocolateSliceImitation
   - type: SolutionContainerManager
     solutions:
       food:


### PR DESCRIPTION
fixes a typo leading to imitation chocolate cake producing slices of real chocolate cake when cut

**Changelog**
:cl:
- fix: imitation chocolate cake no longer splits into slices of real chocolate cake when cut