### PR TITLE
tweak: gamemode/antag selection changes

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/FailAndStartPresetTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/FailAndStartPresetTest.cs
@@ -74,7 +74,7 @@ public sealed class FailAndStartPresetTest
 
         Assert.That(server.CfgMan.GetCVar(CCVars.GridFill), Is.False);
         Assert.That(server.CfgMan.GetCVar(CCVars.GameLobbyFallbackEnabled), Is.True);
-        Assert.That(server.CfgMan.GetCVar(CCVars.GameLobbyDefaultPreset), Is.EqualTo("greenshift")); // starcup: change default to greenshift
+        Assert.That(server.CfgMan.GetCVar(CCVars.GameLobbyDefaultPreset), Is.EqualTo("secret"));
         server.CfgMan.SetCVar(CCVars.GridFill, true);
         server.CfgMan.SetCVar(CCVars.GameLobbyFallbackEnabled, false);
         server.CfgMan.SetCVar(CCVars.GameLobbyDefaultPreset, "TestPreset");

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -33,7 +33,7 @@ public sealed partial class CCVars
     ///     Controls the default game preset.
     /// </summary>
     public static readonly CVarDef<string>
-        GameLobbyDefaultPreset = CVarDef.Create("game.defaultpreset", "greenshift", CVar.ARCHIVE); // starcup: make greenshift default
+        GameLobbyDefaultPreset = CVarDef.Create("game.defaultpreset", "secret", CVar.ARCHIVE);
 
     /// <summary>
     ///     Controls if the game can force a different preset if the current preset's criteria are not met.
@@ -45,7 +45,7 @@ public sealed partial class CCVars
     ///     The preset for the game to fall back to if the selected preset could not be used, and fallback is enabled.
     /// </summary>
     public static readonly CVarDef<string>
-        GameLobbyFallbackPreset = CVarDef.Create("game.fallbackpreset", "Greenshift", CVar.ARCHIVE); // starcup: default to greenshift on fallback
+        GameLobbyFallbackPreset = CVarDef.Create("game.fallbackpreset", "Traitor,Extended", CVar.ARCHIVE);
 
     /// <summary>
     ///     Controls if people can win the game in Suspicion or Deathmatch.


### PR DESCRIPTION
a couple of small adjustments with regards to round types:

- removes ninjas, lone ops, and zombie outbreaks from the mid-round antag spawner
- removes secret as a voteable gamemode and replaces it with traitor (the only thing we're keeping in standard rotation from secret is traitor anyways)
- changes the default roundtype to greenshift, and makes it the fallback for if a roundtype fails to start for some reason

## Why / Balance
after some direction discussion, we've decided that almost all of the gamemodes encapsulated in secret are things we either want to remove from standard rotation (and keep exclusive to events) or rework before reintroducing. ninjas are also due for a massive overhaul, so they're getting taken out in the interim too.

the antag removals won't amount to any tangible difference since we aren't hitting the playercount numbers necessary for them to spawn anyways, but this ensures we don't get blindsided later.

as for the greenshift default, the default gamemodes tend to apply most to our pickup shifts between the big scheduled ones, which tend to have very small player counts that struggle to deal with extended's random events, to say nothing of survival's

**Changelog**
:cl:
- tweak: the server's default gamemode has been changed from secret to greenshift
- tweak: replaced secret with traitor in the gamemode vote
- remove: ninjas, lone ops, and zombie outbreaks no longer spawn as mid-round ghost roles