### PR TITLE
fix: upscale and pad exported character sprites

### DIFF
--- a/Content.Client/Sprite/ContentSpriteSystem.cs
+++ b/Content.Client/Sprite/ContentSpriteSystem.cs
@@ -106,7 +106,13 @@ public sealed class ContentSpriteSystem : EntitySystem
         if (size.Equals(Vector2i.Zero))
             return;
 
+        // begin DEN
+        // Add a little buffer on each side in case of height sliders making them too tall.
+        if (TryComp<HumanoidAppearanceComponent>(entity, out _))
+            size += new Vector2i(10, 10);
+
         size *= ExportScale; // DEN: upscale exported sprites
+        // end DEN
 
         var texture = _clyde.CreateRenderTarget(new Vector2i(size.X, size.Y), new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "export");
         var tcs = new TaskCompletionSource(cancelToken);

--- a/Content.Client/Sprite/ContentSpriteSystem.cs
+++ b/Content.Client/Sprite/ContentSpriteSystem.cs
@@ -30,6 +30,11 @@ public sealed class ContentSpriteSystem : EntitySystem
 
     public static readonly ResPath Exports = new ResPath("/Exports");
 
+    // begin DEN: upscale exported sprites
+    // Upscaled for better compatibility with height sliders
+    public static readonly Vector2i ExportScale = new(4, 4);
+    // end DEN
+
     public override void Initialize()
     {
         base.Initialize();
@@ -100,6 +105,8 @@ public sealed class ContentSpriteSystem : EntitySystem
         // Stop asserts
         if (size.Equals(Vector2i.Zero))
             return;
+
+        size *= ExportScale; // DEN: upscale exported sprites
 
         var texture = _clyde.CreateRenderTarget(new Vector2i(size.X, size.Y), new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "export");
         var tcs = new TaskCompletionSource(cancelToken);
@@ -179,8 +186,10 @@ public sealed class ContentSpriteSystem : EntitySystem
 
                     handle.RenderInRenderTarget(queued.Texture, () =>
                     {
-                        handle.DrawEntity(result.Entity, result.Texture.Size / 2, Vector2.One, Angle.Zero,
+                        // begin DEN: upscale exported sprites
+                        handle.DrawEntity(result.Entity, result.Texture.Size / 2, ExportScale, Angle.Zero,
                             overrideDirection: result.Direction);
+                        // end DEN
                     }, Color.Transparent);
 
                     ResPath fullFileName;


### PR DESCRIPTION
Ported from [TheDenSS14/TheDen#900](https://redirect.github.com/TheDenSS14/TheDen/pulls/900).

Fix exported character sprites where the character has a scaled height from #9. Currently, if they're smaller, they are sampled at a smaller resolution, leading to a loss of detail. If they're larger, they clip beyond the bounds of the image. This fix addresses that.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Portfiend
- fix: Sprites of characters with non-default height are now exported properly.