### PR TITLE
fix: make vox carriable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -51,6 +51,7 @@
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream
     bloodReagent: AmmoniaBlood
+  - type: Carriable # Carrying system from Nyanotrasen
   - type: MeleeWeapon
     soundHit:
       collection: AlienClaw


### PR DESCRIPTION
vox were missing the component necessary to be able to carry them. oops!

**Changelog**
:cl:
- fix: vox can now be carried like all other species