### PR TITLE
tweak: take out some lobby arts

### DIFF
--- a/Resources/Prototypes/lobbyscreens.yml
+++ b/Resources/Prototypes/lobbyscreens.yml
@@ -2,9 +2,10 @@
   id: Warden
   background: /Textures/LobbyScreens/warden.webp
 
-- type: lobbyBackground
-  id: Pharmacy
-  background: /Textures/LobbyScreens/pharmacy.webp
+# starcup: removed
+#- type: lobbyBackground
+#  id: Pharmacy
+#  background: /Textures/LobbyScreens/pharmacy.webp
 
 - type: lobbyBackground
   id: SSXIV


### PR DESCRIPTION
removes "Pharmacy", "Doomed", and "JustAWeekAway" from the lobby art rotation

## Why / Balance
these images are tonally (and in one case mechanically) inconsistent with our server. they aren't the only ones, but we'll be waiting for more starcup-exclusuve lobby art to come in before cycling those out. specific reasonings include:

- pharmacy: portrays the unhelpful stereotype of chemists shirking responsibilities in favor of making drugs and such. of all the parts of the station, the chem lab is one of the places that we expect _shouldn't_ consistently be a workplace disaster.
- doomed: just a cavalcade of unhelpful antisocial stereotypes in general
- justaweekaway: unfunny ugly clown stuff, plus there's a dwarf in it and we just don't have those

**Changelog**
:cl:
- remove: removed a few lobby art images