### PR TITLE
tweak: custom mkc hair color

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -35,9 +35,11 @@
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking
-    Hair: MobHumanoidMarkingMatchSkin
+    # begin starcup
+    Hair: MobHumanoidAnyMarking
     UndergarmentTop: MobHumanoidAnyMarking # starcup
     UndergarmentBottom: MobHumanoidAnyMarking # starcup
+    # end starcup
     Chest: MobIPCTorso
     LArm: MobIPCLArm
     RArm: MobIPCRArm


### PR DESCRIPTION
lets mkcs change their hair color to anything instead of being forced to match their skintone

## Why / Balance
there's no reason for the hair color to be locked, right? plus you can change the color of each part of the body anyways, so "skin color" kinda doesn't apply anyways

**Changelog**
:cl:
- tweak: mkc hair can now be colored independently of skintone