### PR TITLE
fix: move mkc screen markings beneath hair

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -139,9 +139,9 @@
         - map: ["belt"]
         - map: ["neck"]
         - map: ["back"]
+        - map: ["enum.HumanoidVisualLayers.HeadSide"] # starcup: moved beneath hair
         - map: ["enum.HumanoidVisualLayers.FacialHair"]
         - map: ["enum.HumanoidVisualLayers.Hair"]
-        - map: ["enum.HumanoidVisualLayers.HeadSide"]
         - map: ["enum.HumanoidVisualLayers.HeadTop"]
         - map: ["mask"]
         - map: ["head"]


### PR DESCRIPTION
makes mkc display screen markings render underneath hair and facial hair, so bangs and such work properly.

note that this change is only reflected in-game, not through the character creation screen.

## Why / Balance
it's a simple layering fix, but something to consider: this could theoretically be circumvented by doing what delta-v did and making the screens into eye markings instead of headside markings, but this would result in glasses and other eyewear rendering on top of the screen, which seems to be undesirable behavior. this can be a stop-gap to at least make things look correct in-game while other options (or a means to fix the layering in the character creation menu) are investigated further.

**Changelog**
:cl:
- fix: MKC screen markings will render beneath hair in-game. the character creation menu will unfortunately still display the wrong layering; a fix for that will hopefully be coming soon