### PR TITLE
fix: prevent useless application of healing items for mkcs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -169,7 +169,7 @@
     - HumanoidSilicon
     damage:
       groups:
-        Brute: 0 # DeltaV - prevent damage on application
+        Toxin: 0 # DeltaV - prevent RequiredFieldNotMapped error # teamstarcup/starcup#224: changed to toxin to prevent useless application
     bloodlossModifier: -20
   - type: Stack
     stackType: Plastic

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Medical/healing.yml
@@ -16,7 +16,7 @@
     - HumanoidSilicon
     damage:
       groups:
-        Burn: 0 # funny cant remove
+        Toxin: 0 # DeltaV - prevent RequiredFieldNotMapped error # teamstarcup/starcup#224: changed to toxin to prevent useless application
     modifyBloodLevel: 20 # restores a lot of blood for IPCs. # starcup: capitalization changed for action refactor
   - type: Stack
     stackType: Oilpack


### PR DESCRIPTION
oilpacks and plastic sheets now won't be consumed to no effect. this fixes #224 

**Changelog**
:cl:
- fix: using plastic or oilpacks on MKCs with brute or burn damage respectively will no longer uselessly consume the item