### PR TITLE
tweak: mkc guidebook rewrites

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/IPCs.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/IPCs.xml
@@ -3,7 +3,7 @@
   <GuideEntityEmbed Entity="MobIPCDummy" Caption="MKC"/>
   An MKC (short for Markov Knowledge Chassis) is a type of sapient robot and is considered an [color=yellow]independent individual[/color], meaning [color=red]they are not guided by any laws of robotics[/color]. MKCs cannot be hacked by emags and are not affected by ion storms because they do not have to follow any predefined directives in their system.
 
-  MKCs are silicon-based beings, and thus do not have a bloodstream, cannot ingest any food or drink, and [color=red]cannot be healed by normal means at the Medbay.[/color] Damaged MKCs are recommended to be taken to the [color=yellow]Robotics Lab[/color] for repairs, or possibly to [color=yellow]Engineering[/color] depending on crew availability.
+  MKCs are silicon-based beings, and thus do not have a bloodstream, cannot ingest any food or drink, do not need to breathe, and [color=red]cannot be healed by normal means at the Medbay.[/color] Damaged MKCs are recommended to be taken to the [color=yellow]Robotics Lab[/color] for repairs, or possibly to [color=yellow]Engineering[/color] depending on crew availability.
 
   <Box>
     <GuideEntityEmbed Entity="PositronicBrain" Caption="Positronic Brain"/>

--- a/Resources/ServerInfo/Guidebook/Mobs/IPCs.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/IPCs.xml
@@ -1,25 +1,26 @@
 <Document>
-  # I.P.C.
-  <GuideEntityEmbed Entity="MobIPCDummy" Caption="M.K.C."/>
-  An MKC (short for Markov Knowledge Chassis) is a type of sentient robot and is considered an [color=yellow]independent individual[/color], meaning [color=red]they are not guided by any laws of robotics[/color]. MKCs cannot be hacked by Emags because they do not have to follow any predefined directives in their system. [color=red]MKCs are silicon-based beings, so doctors do not have the skills to repair them.[/color]
+  # MKC
+  <GuideEntityEmbed Entity="MobIPCDummy" Caption="MKC"/>
+  An MKC (short for Markov Knowledge Chassis) is a type of sapient robot and is considered an [color=yellow]independent individual[/color], meaning [color=red]they are not guided by any laws of robotics[/color]. MKCs cannot be hacked by emags and are not affected by ion storms because they do not have to follow any predefined directives in their system.
+
+  MKCs are silicon-based beings, and thus do not have a bloodstream, cannot ingest any food or drink, and [color=red]cannot be healed by normal means at the Medbay.[/color] Damaged MKCs are recommended to be taken to the [color=yellow]Robotics Lab[/color] for repairs, or possibly to [color=yellow]Engineering[/color] depending on crew availability.
 
   <Box>
     <GuideEntityEmbed Entity="PositronicBrain" Caption="Positronic Brain"/>
   </Box>
-  Like borgs, MKCs have a positronic brain as their processing source. However, unlike them, MKCs can't be assembled. "It's cheaper to create a shell that obeys you than one that doesn't! *wink*"
+  Like borgs, MKCs have a positronic brain as their processing source. However, unlike them, MKCs can't be assembled.
   ## Recharging an MKC
    <Box>
     <GuideEntityEmbed Entity="APCBasic" Caption="APC Terminal"/>
-    <GuideEntityEmbed Entity="BorgCharger" Caption="Borg Charger"/>
     <GuideEntityEmbed Entity="PowerCellMedium" Caption="Power Cell"/>
   </Box>
-  MKCs can be recharged in three different ways:
+  Instead of food or drink, MKCs have an internal power cell that they must keep charged. This power cell constantly drains at a rate proportionate to the amount of moving around the MKC is doing.
 
-  APC Terminal: MKCs can use APC terminals to recharge. Press [color=yellow]Alt + left click[/color] on a terminal as many times as needed to fully recharge.
+  The internal battery of an MKC can be recharged in two different ways:
 
-  Borg Rechargers: MKCs can use borg rechargers to recharge. Always prioritize the ones outside of the Sci area to avoid headaches.
+  APC Terminal: An MKC can press [color=yellow]Alt + left click[/color] on a powered APC terminal to recharge themselves.
 
-  Power Cell: MKCs have an internal power cell that serves as their battery. They can simply swap it out by opening the hatch and manually replacing it.
+  Power Cell Replacement: Pressing [color=yellow]Alt + left click[/color] or using the right-click menu on an MKC will unlock (or lock) their maintenance panel, allowing their power cell to be taken out and replaced. [color=red]Note that MKCs cannot remove their own power cells![/color]
 
   ## Integrated Radio
   <Box>
@@ -32,12 +33,13 @@
   ## Repairing
   <Box HorizontalAlignment="Stretch">
     <GuideEntityEmbed Entity="WelderIndustrialAdvanced" Caption="Welder"/>
-    Welders can be used to repair [color=yellow]Brute[/color] damage and stop [color=orange]Bleeding[/color].
+    Welders can be used to repair [color=yellow]Brute[/color] damage and stop [color=orange]Bleeding[/color]. Be sure to cover your eyes!
   </Box>
   <Box HorizontalAlignment="Stretch">
     <GuideEntityEmbed Entity="CableApcStack" Caption="Cables (any type)"/>
     Cables can be used to repair [color=yellow]Burns[/color], except for caustic.
-
+  </Box>
+  <Box HorizontalAlignment="Stretch">
     <GuideEntityEmbed Entity="SheetSteel" Caption="Steel Sheets"/>
     Steel can be used to repair [color=yellow]Caustic[/color] damage.
   </Box>
@@ -54,13 +56,15 @@
     Plastic Sheets can be used to stop [color=orange]Bleeding[/color].
   </Box>
   <Box HorizontalAlignment="Stretch">
-    <GuideEntityEmbed Entity="Oilpack" Caption="Oil Packs"/>
-    MKCs have no blood, but they have Oil. Oil Packs can be used to replenish [color=red]Oil[/color].
+    <GuideEntityEmbed Entity="Lighter" Caption="Lighter"/>
+    In a pinch, cauterization via heat damage (such as from attacks by lit welders or lighters) will also heal [color=orange]Bleeding[/color].
   </Box>
   <Box HorizontalAlignment="Stretch">
-    In the event an MKC dies, after being fully repaired, it should be restarted using the [color=yellow]"Restart"[/color] button (located by right-clicking).
-
-    [color=red]NEVER ELECTROCUTE AN MKC with a defibrillator or in any other way while it is dead, as this will cause the battery to discharge energy rays outward![/color]
+    <GuideEntityEmbed Entity="Oilpack" Caption="Oil Packs"/>
+    MKCs have no blood, but instead have [color=orange]Oil[/color]. Oil packs, which replenish their oil levels, can be ordered by Logistics or printed by Robotics.
   </Box>
+  In the event that an MKC dies, after being fully repaired, they should be restarted using the [color=yellow]"Restart"[/color] button (located by right-clicking).
+
+  [color=red]NEVER ELECTROCUTE AN MKC with a defibrillator or in any other way while they're dead, as this will cause the battery to discharge energy rays outward![/color]
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -14,7 +14,7 @@
   <GuideEntityEmbed Entity="MobReptilian" Caption="Unathi"/>
   <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
-  <GuideEntityEmbed Entity="MobIPCDummy" Caption="M.K.C."/>
+  <GuideEntityEmbed Entity="MobIPCDummy" Caption="MKC"/>
   </Box>
 
   # Delta-V specific species


### PR DESCRIPTION
addresses the guidebook concerns in https://github.com/teamstarcup/starcup/issues/220 with some rewrites, and also clarifies a few additional things that were a bit ambiguous about what they're damaged and healed by

**Changelog**
:cl:
- tweak: the guidebook entry for MKCs is now clearer about what they aren't affected by and how to repair them