### PR TITLE
tweak: mkc dynamic power draw

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -22,6 +22,10 @@ using Content.Shared.Mind;
 using Content.Shared.Alert;
 using Content.Server._EinsteinEngines.Silicon.Death;
 using Content.Server._EinsteinEngines.Power.Components;
+// Begin TheDen - IPC Dynamic Power draw
+using Content.Shared.Movement.Components;
+using Robust.Shared.Physics.Components;
+// End TheDen
 
 namespace Content.Server._EinsteinEngines.Silicon.Charge;
 
@@ -36,6 +40,7 @@ public sealed class SiliconChargeSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly SharedJetpackSystem _jetpack = default!; // TheDen - IPC Dynamic Power draw
     public override void Initialize()
     {
         base.Initialize();
@@ -118,7 +123,10 @@ public sealed class SiliconChargeSystem : EntitySystem
             // Maybe use something similar to refreshmovespeedmodifiers, where it's stored in the component.
             // Maybe it doesn't matter, and stuff should just use static drain?
             if (!siliconComp.EntityType.Equals(SiliconType.Npc)) // Don't bother checking heat if it's an NPC. It's a waste of time, and it'd be delayed due to the update time.
+            {
                 drainRateFinalAddi += SiliconHeatEffects(silicon, siliconComp, frameTime) - 1; // This will need to be changed at some point if we allow external batteries, since the heat of the Silicon might not be applicable.
+                drainRateFinalAddi += SiliconMovementEffects(silicon, siliconComp); // TheDen - IPC Dynamic Power draw // Removes between 90% and 0% of the total power draw.
+            }
 
             // Ensures that the drain rate is at least 10% of normal,
             // and would allow at least 4 minutes of life with a max charge, to prevent cheese.
@@ -197,5 +205,26 @@ public sealed class SiliconChargeSystem : EntitySystem
             return 0.5f + temperComp.CurrentTemperature / thermalComp.NormalBodyTemperature * 0.5f;
 
         return 0;
+    }
+
+    // TheDen - IPC Dynamic Power draw
+    private float SiliconMovementEffects(EntityUid silicon, SiliconComponent siliconComp)
+    {
+        // Calculate dynamic power draw.
+        if (!TryComp(silicon, out MovementSpeedModifierComponent? movement) ||
+            !TryComp(silicon, out PhysicsComponent? physics) ||
+            !TryComp(silicon, out InputMoverComponent? input))
+            return 0;
+
+        if (input.HeldMoveButtons == MoveButtons.None || _jetpack.IsUserFlying(silicon)) // If nothing is being held or jet packing
+        {
+            return siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction * (-1); // Reduces draw by idle drain reduction
+        }
+
+        // LinearVelocity is relative to the parent
+        return Math.Clamp(
+            siliconComp.DrainPerSecond * ((physics.LinearVelocity.Length() / movement.CurrentSprintSpeed) - 1), // Power draw changes as a negative percentage of the movement
+            siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction * (-1), // Should be a maximum of the idle drain reduction (negative)
+            0f); // Minimum reduction is no change to power draw
     }
 }

--- a/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
@@ -69,6 +69,17 @@ public sealed partial class SiliconComponent : Component
     [DataField]
     public float DrainPerSecond = 50f;
 
+    // TheDen - Dynamic IPC Power Draw
+    /// <summary>
+    ///     How much less power is used while being idle.
+    /// </summary>
+    /// <remarks>
+    ///     Relative to the DrainPerSecond.
+    ///     0 is no reduction. 1 is 100% reduction. 0.5 is 50% reduction.
+    ///     Currently, 90% reduction is as high as we can go without changing code in C#
+    /// </remarks>
+    [DataField]
+    public float IdleDrainReduction = 0.6f;
 
     /// <summary>
     ///     The percentages at which the silicon will enter each state.

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -79,6 +79,7 @@
     entityType: enum.SiliconType.Player
     batteryPowered: true
     drainPerSecond: 1.3 # DeltaV change from 1.5
+    idleDrainReduction: 0.6 # TheDen - 60% less power usage while idling, for IPC Dynamic Power Draw
     chargeThresholdMid: 0.80
     chargeThresholdLow: 0.35
     chargeThresholdCritical: 0.10


### PR DESCRIPTION
ports ["feat: ipcs now have dynamic power draw based off movement speed"](https://github.com/DeltaV-Station/Delta-v/pull/3917) from delta-v

## Why / Balance
mkc power drain during intense roleplaying scenes is extremely annoying and doesn't benefit anyone, but their battery probably shouldn't just be increased outright. this should help smooth some things over!

**Changelog**
:cl:
- tweak: MKCs will drain their battery less quickly when idle (i.e. not moving)