### PR TITLE
tweak: mkc healing buffs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -42,7 +42,7 @@
       types: # these are all split across multiple types
         Heat: -3.22
         Shock: -3.22
-        Cold: -3,22 # DeltaV
+        Cold: -3.22 # DeltaV
   # EinsteinEngines: Change End
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -40,9 +40,9 @@
     - HumanoidSilicon # DeltaV
     damage:
       types: # these are all split across multiple types
-        Heat: -1.66
-        Shock: -1.66
-        Cold: -1.66 # DeltaV
+        Heat: -3.22
+        Shock: -3.22
+        Cold: -3,22 # DeltaV
   # EinsteinEngines: Change End
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Objects/Specific/Medical/healing.yml
@@ -51,6 +51,8 @@
       groups:
         Burn: -60 # 25 per type
         Brute: -60 # 20 per type, mostly irrelevant cause welder gaming
+      types:
+        Radiation: -20
     modifyBloodLevel: 25 # restores a lot of blood for IPCs. # starcup: capitalization changed for action refactor
     bloodlossModifier: -20 # DeltaV - IPCs bleed
   - type: Stack


### PR DESCRIPTION
includes a few features found in ["IPC Adjustments - Better cables, Modified Bloodstream"](https://github.com/DeltaV-Station/Delta-v/pull/3918) from delta-v, making cables more effective and omnipatches heal radiation

## Why / Balance
the omnipatch thing just makes sense—it's an OMNIpatch—and cables are currently way too ineffective for their availability.

**Changelog**
:cl:
- tweak: cables now heal MKCs twice as effectively
- feat: omnipatches now also heal radiation damage
