### PR TITLE
feat: give silicons mkc emotes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -154,7 +154,7 @@
     speechSounds: Borg
   - type: Vocal
     sounds:
-      Unsexed: UnisexSilicon
+      Unsexed: UnisexIPC # starcup: silicon emotes
     wilhelmProbability: 0
   - type: DamagedSiliconAccent
   - type: UnblockableSpeech

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -48,7 +48,7 @@
     proto: robot
   - type: Vocal
     sounds:
-      Unsexed: UnisexSilicon
+      Unsexed: UnisexIPC # starcup: silicon emotes
   - type: Emoting
   - type: ZombieImmune
   - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -34,9 +34,10 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-laugh"]
   chatTriggers:
     - laugh
@@ -81,9 +82,10 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-sigh"]
   chatTriggers:
     - sigh
@@ -98,9 +100,10 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-whistle"]
   chatTriggers:
     - whistle
@@ -115,9 +118,10 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-crying"]
   chatTriggers:
     - cry
@@ -207,9 +211,10 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-clap"]
   chatTriggers:
     - claps
@@ -224,9 +229,10 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: [ "chat-emote-msg-clap-single" ]
   chatTriggers:
     - clap
@@ -243,9 +249,10 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-snap"]
   chatTriggers:
     - snap
@@ -294,9 +301,10 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+# starcup: silicon emotes
+#  blacklist:
+#    tags:
+#    - SiliconEmotes
   chatMessages: ["chat-emote-msg-salute"]
   chatTriggers:
     - salute

--- a/Resources/Prototypes/_starcup/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -30,6 +30,6 @@
     - Laugh
   - type: Vocal
     sounds:
-      Unsexed: UnisexSiliconSyndicate
+      Unsexed: UnisexIPC # starcup: silicon emotes
   - type: PointLight
     color: "#dd200b"


### PR DESCRIPTION
in the process of fixing #223, I decided on a solution that also gives those same emotes to non-mkc silicons like cyborgs and player-controlled robots!

## Why / Balance
entities with the `SiliconEmotes` tag were blacklisted from various emotes, but I'm pretty sure this is only because upstream doesn't have soundclips for things like laughing, sighing, and so on. since mkcs have given us these emotes, I see no reason to not give them to all the other silicons too! they can all already talk, so why not?

**Changelog**
:cl:
- fix: MKCs have access to all their emotes again
- add: MKC emotes have also been added to all other playable silicons! now the cleanbot can laugh at you like it deserves
