### PR TITLE
fix: loadout bugfixes

### DIFF
--- a/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
@@ -58,7 +58,6 @@
 - type: loadoutGroup
   id: WardenShoes
   name: loadout-group-warden-shoes
-  minLimit: 0
   loadouts:
   - JackBoots
   - SecurityWinterBoots
@@ -69,7 +68,6 @@
 - type: loadoutGroup
   id: BartenderShoes
   name: loadout-group-bartender-shoes
-  minLimit: 0
   loadouts:
   - BlackShoes
   - WinterBoots
@@ -86,7 +84,6 @@
 - type: loadoutGroup
   id: ChaplainShoes
   name: loadout-group-chaplain-shoes
-  minLimit: 0
   loadouts:
   - BlackShoes
   - WinterBoots
@@ -132,7 +129,6 @@
 - type: loadoutGroup
   id: JanitorShoes
   name: loadout-group-janitor-shoes
-  minLimit: 0
   loadouts:
   - JanitorGaloshes
   - JanitorWinterBoots
@@ -197,7 +193,6 @@
 - type: loadoutGroup
   id: ServiceWorkerJumpsuit
   name: loadout-group-service-worker-jumpsuit
-  minLimit: 0
   loadouts:
   - BartenderJumpsuit
   - BartenderJumpskirt


### PR DESCRIPTION
some of our loadout groups had `minLimit: 0` lines erroneously applied, which allowed things like service workers spawning in with no jumpsuits, which is obviously less than ideal

**Changelog**
:cl:
- fix: loadouts have been corrected to prevent certain jobs from spawning without essential clothes