### PR TITLE
fix: network laying down changes

### DIFF
--- a/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
@@ -88,6 +88,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         }
 
         component.CurrentState = StandingState.Standing;
+        Dirty(uid, component);
     }
 
     private void OnRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, RefreshMovementSpeedModifiersEvent args)
@@ -132,6 +133,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
             return false;
 
         standingState.CurrentState = StandingState.GettingUp;
+        Dirty(uid, standingState);
         return true;
     }
 


### PR DESCRIPTION
Laying down system has prediction errors, sometimes causing players to appear to be crawling when they should be standing. This fixes that.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed players appearing to be crawling when they aren't.