### PR TITLE
tweak: assorted drink adjustments I missed

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2518,7 +2518,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.13 # starcup: decreased from 0.2
+        amount: 0.07 # starcup: decreased from 0.2
       - !type:AdjustReagent
         reagent: Copper
         amount: 0.05

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1827,7 +1827,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.06 # starcup: reduced from 0.2
 
 - type: reagent
   id: Radler

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -492,7 +492,7 @@
   reactants:
     Gin:
       amount: 1
-    JuiceLime:
+    JuiceLemon: # starcup: changed from lime juice
       amount: 1
     SodaWater:
       amount: 1
@@ -1500,11 +1500,11 @@
   - Stir
   reactants:
     Vodka:
-      amount: 4
+      amount: 2 # starcup: decreased from 4
     JuiceLime:
       amount: 1
     SolDry:
-      amount: 1
+      amount: 3 # starcup: increased from 1
   products:
     MoscowMule: 6
 

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -952,11 +952,11 @@
     JuiceLime:
       amount: 1
     Rum:
-      amount: 1
+      amount: 3 # starcup: increased from 1
     CreamOfCoconut:
-      amount: 1
+      amount: 3 # starcup: increased from 1
   products:
-    PinaColada: 6
+    PinaColada: 10 # starcup: increased from 6
 
 - type: reaction
   id: Posca


### PR DESCRIPTION
pina coladas snuck by unnoticed in #204, so I adjusted their recipe and alcohol content. I also had another look at the moscow mule and gin fizz's recipes and changed those too

## Why / Balance
not only is pina coladas being as alcoholic as rum despite barely having any rum insane, the ratios are also completely wild. no shot you're putting the same amount of lime juice as rum into a pina colada. that's batshit

I also realized the moscow mule and gin fizz's recipe was similarly insane. 4:1 vodka to ginger ale for the moscow mule!! are you kidding me!! and why the hell are you making a gin fizz with lime juice! you make those with lemon! the flavor text literally describes it as lemony!

**Changelog**
:cl:
- tweak: the moscow mule, gin fizz, and pina colada have had their recipes and ethanol content rebalanced