### PR TITLE
feat: display error on ftl failure

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -1,13 +1,13 @@
-using Content.Server.Popups;
+using Content.Server.Popups; // starcup
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
-using Content.Shared.Popups;
+using Content.Shared.Popups; // starcup
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Events;
 using Content.Shared.Shuttles.UI.MapObjects;
-using Robust.Server.Audio;
-using Robust.Shared.Audio;
+using Robust.Server.Audio; // starcup
+using Robust.Shared.Audio; // starcup
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;


### PR DESCRIPTION
The FTL user interface is incredibly flawed. Perhaps the largest of which is that attempting to FTL almost never works and there are no indicators that explain why. In lieu of a total rewrite, this change emits a buzz sound effect and displays a popup message for the reason why FTL was not initiated a mere fraction of the time.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- feat: FTL shuttle consoles now indicate why you are unable to FTL (sometimes.)