### PR TITLE
fix: set outfit now correctly gives mkcs encryption keys

### DIFF
--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -24,6 +24,7 @@ public sealed class OutfitSystem : EntitySystem
     [Dependency] private readonly HandsSystem _handSystem = default!;
     [Dependency] private readonly InventorySystem _invSystem = default!;
     [Dependency] private readonly SharedStationSpawningSystem _spawningSystem = default!;
+    [Dependency] private readonly InternalEncryptionKeySpawner _internalEncryption = default!; // starcup
 
     public bool SetOutfit(EntityUid target, string gear, Action<EntityUid, EntityUid>? onEquipped = null)
     {
@@ -109,8 +110,7 @@ public sealed class OutfitSystem : EntitySystem
         // Begin DeltaV/Goob Additions
         if (EntityManager.HasComponent<EncryptionKeyHolderComponent>(target))
         {
-            var encryption = new InternalEncryptionKeySpawner();
-            encryption.TryInsertEncryptionKey(target, startingGear);
+            _internalEncryption.TryInsertEncryptionKey(target, startingGear);  // starcup: fix null reference
         }
         // End DeltaV/Goob Additions
         return true;


### PR DESCRIPTION
`OutfitSystem.cs` was manually creating the `InternalEncryptionKeySpawner` EntitySystem, leading to the `EntityManager` dependency not being injected and ultimately generating a null reference exception. This was causing tests (the ones which spawned every kind of entity, which included random humanoid spawners) to fail.

Search tags: IPC

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: MKCs now have their encryption keys properly inserted when using the `setoutfit` command.