### PR TITLE
feat: weather & lighting improvements

### DIFF
--- a/Content.Server/Light/Components/SetRoofComponent.cs
+++ b/Content.Server/Light/Components/SetRoofComponent.cs
@@ -8,4 +8,9 @@ public sealed partial class SetRoofComponent : Component
 {
     [DataField(required: true)]
     public bool Value;
+
+    // begin starcup: selective weather occlusion for roofs
+    [DataField(required: true)]
+    public bool BlockWeather = true;
+    // end starcup
 }

--- a/Content.Server/Light/EntitySystems/RoofSystem.cs
+++ b/Content.Server/Light/EntitySystems/RoofSystem.cs
@@ -25,7 +25,7 @@ public sealed class RoofSystem : SharedRoofSystem
         if (_gridQuery.TryComp(xform.GridUid, out var grid))
         {
             var index = _maps.LocalToTile(xform.GridUid.Value, grid, xform.Coordinates);
-            SetRoof((xform.GridUid.Value, grid, null), index, ent.Comp.Value);
+            SetRoof((xform.GridUid.Value, grid, null), index, ent.Comp.Value, ent.Comp.BlockWeather);  // starcup: selective weather occlusion on roofs
         }
 
         QueueDel(ent.Owner);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -104,7 +104,14 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
-        EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+
+        // begin upstream: early merge of #38551
+        // This and RoofComponent should be mutually exclusive, so ImplicitRoof should be removed if the grid has RoofComponent
+        if (HasComp<RoofComponent>(ev.EntityUid))
+            RemComp<ImplicitRoofComponent>(ev.EntityUid);
+        else
+            EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+        // end upstream
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)

--- a/Content.Shared/Light/Components/ImplicitRoofComponent.cs
+++ b/Content.Shared/Light/Components/ImplicitRoofComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Light.Components;
 
 /// <summary>
-/// Assumes the entire attached grid is rooved.
+/// Assumes the entire attached grid is rooved. This component will get removed if the grid has RoofComponent.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ImplicitRoofComponent : Component

--- a/Content.Shared/Light/Components/RoofComponent.cs
+++ b/Content.Shared/Light/Components/RoofComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Light.Components;
 
 /// <summary>
-/// Will draw shadows over tiles flagged as roof tiles on the attached grid.
+/// Will draw shadows over tiles flagged as roof tiles on the attached grid. ImplicitRoofComponent will get removed if the grid has this component.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RoofComponent : Component

--- a/Content.Shared/Light/Components/RoofComponent.cs
+++ b/Content.Shared/Light/Components/RoofComponent.cs
@@ -18,4 +18,12 @@ public sealed partial class RoofComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public Dictionary<Vector2i, ulong> Data = new();
+
+    // begin starcup: selective weather occlusion on roofs
+    /// <summary>
+    /// Chunk origin and bitmask of weather occlusion value in chunk.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Dictionary<Vector2i, ulong> WeatherOcclusionData = new();
+    // end starcup
 }

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -113,10 +113,12 @@ namespace Content.Shared.Maps
 
         [DataField("sturdy")] public bool Sturdy { get; private set; } = true;
 
-        /// <summary>
-        /// Can weather affect this tile.
-        /// </summary>
-        [DataField("weather")] public bool Weather = false;
+        // begin upstream: early merge of #38638
+        // /// <summary>
+        // /// Can weather affect this tile.
+        // /// </summary>
+        // [DataField("weather")] public bool Weather = false;
+        // end upstream
 
         /// <summary>
         /// Is this tile immune to RCD deconstruct.

--- a/Content.Shared/Weather/SharedWeatherSystem.cs
+++ b/Content.Shared/Weather/SharedWeatherSystem.cs
@@ -46,7 +46,7 @@ public abstract class SharedWeatherSystem : EntitySystem
         if (tileRef.Tile.IsEmpty)
             return true;
 
-        if (Resolve(uid, ref roofComp, false) && _roof.IsRooved((uid, grid, roofComp), tileRef.GridIndices))
+        if (Resolve(uid, ref roofComp, false) && _roof.IsWeatherOccluding((uid, grid, roofComp), tileRef.GridIndices))  // starcup: selective weather occlusion on roofs
             return false;
 
         // begin upstream: early merge of #38638

--- a/Content.Shared/Weather/SharedWeatherSystem.cs
+++ b/Content.Shared/Weather/SharedWeatherSystem.cs
@@ -49,9 +49,12 @@ public abstract class SharedWeatherSystem : EntitySystem
         if (Resolve(uid, ref roofComp, false) && _roof.IsRooved((uid, grid, roofComp), tileRef.GridIndices))
             return false;
 
-        var tileDef = (ContentTileDefinition) _tileDefManager[tileRef.Tile.TypeId];
-
-        if (!tileDef.Weather)
+        // begin upstream: early merge of #38638
+        // var tileDef = (ContentTileDefinition) _tileDefManager[tileRef.Tile.TypeId];
+        //
+        // if (!tileDef.Weather)
+        if (HasComp<ImplicitRoofComponent>(uid))
+        // end upstream
             return false;
 
         var anchoredEntities = _mapSystem.GetAnchoredEntitiesEnumerator(uid, grid, tileRef.GridIndices);

--- a/Resources/Prototypes/Entities/Markers/tile.yml
+++ b/Resources/Prototypes/Entities/Markers/tile.yml
@@ -6,6 +6,7 @@
   components:
   - type: SetRoof
     value: true
+    blockWeather: true  # starcup: selective weather occlusion on roofs
   - type: Sprite
     layers:
     - state: green
@@ -19,6 +20,7 @@
   components:
   - type: SetRoof
     value: false
+    blockWeather: false  # starcup: selective weather occlusion on roofs
   - type: Sprite
     layers:
     - state: red

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -171,7 +171,7 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteelHerringbone
   heatCapacity: 10000
-  weather: true  # starcup - render weather over this for glacier station
+  # weather: true  # starcup: early merge of #38638  # starcup - render weather over this for glacier station
 
 - type: tile
   id: FloorSteelDiagonalMini
@@ -1458,7 +1458,7 @@
   footstepSounds:
     collection: FootstepTile
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorGrass
@@ -1470,7 +1470,7 @@
     collection: FootstepGrass
   itemDrop: FloorTileItemGrass
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorGrassJungle
@@ -1482,7 +1482,7 @@
     collection: FootstepGrass
   itemDrop: FloorTileItemGrassJungle
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorGrassDark
@@ -1499,7 +1499,7 @@
   footstepSounds:
     collection: FootstepGrass
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorGrassLight
@@ -1516,7 +1516,7 @@
   footstepSounds:
     collection: FootstepGrass
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorDirt
@@ -1533,7 +1533,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 # Asteroid
 
@@ -1561,7 +1561,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidSand
@@ -1587,7 +1587,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidSandDug
@@ -1628,7 +1628,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidSandRed
@@ -1655,7 +1655,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidIronsandBorderless
@@ -1683,7 +1683,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidIronsand
@@ -1709,7 +1709,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidSandUnvariantized
@@ -1735,7 +1735,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
 
 - type: tile
   id: FloorAsteroidIronsandUnvariantized

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -12,7 +12,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 # Desert
@@ -32,7 +32,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 - type: tile
@@ -51,7 +51,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 # Grass
@@ -81,7 +81,7 @@
     collection: FootstepGrass
   itemDrop: FloorTileItemGrass
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 # Lava
@@ -93,7 +93,7 @@
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 # Snow
@@ -126,7 +126,7 @@
   footstepSounds:
     collection: FootstepSnow
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 # Ice
@@ -137,7 +137,7 @@
   isSubfloor: true
   friction: 0.05
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   mobAcceleration: 0.1
   indestructible: true
 
@@ -156,7 +156,7 @@
   footstepSounds:
     collection: FootstepSnow
   heatCapacity: 10000
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   indestructible: true
 
 # Wasteland

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -65,7 +65,7 @@
   baseTurf: Space
   isSubfloor: true
   deconstructTools: [ Cutting ]
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   footstepSounds:
     collection: FootstepCatwalk
   friction: 1.5
@@ -81,7 +81,7 @@
   baseTurf: Space
   isSubfloor: true
   deconstructTools: [ Cutting ]
-  weather: true
+  # weather: true  # starcup: early merge of #38638
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5

--- a/Resources/Prototypes/_DeltaV/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/_DeltaV/Entities/Structures/Walls/mountain.yml
@@ -42,6 +42,7 @@
   - type: OreVein
     oreChance: 0.2
     oreRarityPrototypeId: RandomOreDistributionStandard
+  - type: IsRoof # starcup: weather and lighting enhancements
 
 - type: entity
   id: MountainRockMining
@@ -102,6 +103,7 @@
   - type: IconSmooth
     key: walls
     base: rock_
+  - type: IsRoof # starcup: weather and lighting enhancements
 
 - type: entity
   id: AsteroidAltRockMining

--- a/Resources/Prototypes/_starcup/Entities/Markers/tile.yml
+++ b/Resources/Prototypes/_starcup/Entities/Markers/tile.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: NoRoofNoWeatherMarker
+  name: Roof
+  suffix: Disabled, No Weather
+  parent: NoRoofMarker
+  components:
+  - type: SetRoof
+    value: false
+    blockWeather: true


### PR DESCRIPTION
Port of space-wizards/space-station-14#38551 and space-wizards/space-station-14#38638, plus custom additions.

## Technical Details
- Decouple weather rendering logic from tile definitions
- No longer apply `ImplicitRoof` to loaded grids with `Roof`
- Modify `SharedRoofSystem` and `SetRoofComponent` to track weather occlusion separately from map light occlusion
  - `RoofComponent` tracks a second dictionary of bitflags
  - `SharedWeatherSystem` now calls `SharedRoofSystem.IsWeatherOccluding` instead of `IsRooved`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

https://github.com/user-attachments/assets/2dc95456-26d9-4c45-9fb9-1b0bc8560cfe

https://github.com/user-attachments/assets/1503c766-6ab0-4273-be4f-17c83dd60fff

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
