### PR TITLE
fix: small traitor uplink fixes

### DIFF
--- a/Resources/Prototypes/_starcup/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_starcup/Catalog/uplink_catalog.yml
@@ -13,8 +13,6 @@
   categories:
   - UplinkWearablesNT
 
-  - UplinkWearables
-
 # Add NanoTrasen deck to traitor uplink
 - type: listing
   id: UplinkNanoTrasenDeck

--- a/Resources/Prototypes/_starcup/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_starcup/Catalog/uplink_catalog.yml
@@ -22,8 +22,7 @@
   cost:
     Telecrystal: 1
   categories:
-  - UplinkPointless
-
+  - UplinkPointlessNT
 
 # TODO: make more categories
 # Guns
@@ -1937,7 +1936,7 @@
 
 - type: listing
   id: UplinkBalloonNT
-  name: uplink-balloon-name
+  name: uplink-balloon-name-starcup
   description: uplink-balloon-desc-starcup
   productEntity: BalloonNT
   cost:


### PR DESCRIPTION
whoops, there was an extra line that was causing the thieving gloves to display twice in the uplink! I removed that, then found a couple of other small things I fixed too

**Changelog**
:cl:
- fix: thieving gloves no longer appear twice in the uplink
- fix: the nanotrasen balloon is now properly named in the uplink
- fix: the nanotrasen deck box now appears in the uplink as intended