### PR TITLE
fix: post-upstream merge mkc hotfixes

### DIFF
--- a/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
+++ b/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
@@ -5,6 +5,7 @@ using Content.Server._EE.Silicon.Charge;
 using Content.Server._EE.Power.Components;
 using Content.Server.Humanoid;
 using Content.Shared.Humanoid;
+using Content.Shared.StatusEffectNew; // starcup
 
 namespace Content.Server._EE.Silicon.Death;
 
@@ -13,6 +14,7 @@ public sealed class SiliconDeathSystem : EntitySystem
     [Dependency] private readonly SleepingSystem _sleep = default!;
     [Dependency] private readonly SiliconChargeSystem _silicon = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearanceSystem = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffect = default!; // starcup
 
     public override void Initialize()
     {
@@ -47,7 +49,7 @@ public sealed class SiliconDeathSystem : EntitySystem
             return;
 
         EntityManager.EnsureComponent<SleepingComponent>(uid);
-        EntityManager.EnsureComponent<ForcedSleepingStatusEffectComponent>(uid); // starcup: changed component after status effects refactor
+        _statusEffect.TrySetStatusEffectDuration(uid, SleepingSystem.StatusEffectForcedSleeping); // starcup: edited for status effects refactor
 
         if (TryComp(uid, out HumanoidAppearanceComponent? humanoidAppearanceComponent))
         {
@@ -62,7 +64,7 @@ public sealed class SiliconDeathSystem : EntitySystem
 
     private void SiliconUnDead(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, BatteryComponent? batteryComp, EntityUid batteryUid)
     {
-        RemComp<ForcedSleepingStatusEffectComponent>(uid); // starcup: changed component after status effects refactor
+        _statusEffect.TryRemoveStatusEffect(uid, SleepingSystem.StatusEffectForcedSleeping); // starcup: edited for status effects refactor
         _sleep.TryWaking(uid, true, null);
 
         siliconDeadComp.Dead = false;

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -168,8 +168,8 @@
     damageContainers:
     - HumanoidSilicon
     damage:
-      groups:
-        Toxin: 0 # DeltaV - prevent RequiredFieldNotMapped error # teamstarcup/starcup#224: changed to toxin to prevent useless application
+      types:
+        Caustic: 0 # DeltaV - prevent RequiredFieldNotMapped error # teamstarcup/starcup#224: changed to caustic to prevent useless application
     bloodlossModifier: -20
   - type: Stack
     stackType: Plastic

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
@@ -15,8 +15,8 @@
     damageContainers:
     - HumanoidSilicon
     damage:
-      groups:
-        Toxin: 0 # DeltaV - prevent RequiredFieldNotMapped error # teamstarcup/starcup#224: changed to toxin to prevent useless application
+      types:
+        Caustic: 0 # DeltaV - prevent RequiredFieldNotMapped error # teamstarcup/starcup#224: changed to caustic to prevent useless application
     modifyBloodLevel: 20 # restores a lot of blood for IPCs. # starcup: capitalization changed for action refactor
   - type: Stack
     stackType: Oilpack


### PR DESCRIPTION
- the event that applies forcesleep to mkcs on low-power mode needed to be refactored for the status effect changes. fixes #264 and #243
- it turns out that if you try to apply healing to a damage group a species's damage container doesn't have it'll get upset so oilpacks and plastic sheets have caustic as a dummy heal value as a stopgap. fixes #247 

**Changelog**
:cl:
- fix: MKCs will now properly be unconscious when at low-power mode
- fix: plastic and oilpacks can be applied to MKCs again. be warned, the empty application bug will still occur if the MKC has caustic damage present when using these items; a more comprehensive fix is hopefully coming soon