### PR TITLE
fix: security/prisoner telecom server fixes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -262,6 +262,7 @@
     containers:
       key_slots:
       - EncryptionKeySecurity
+      - EncryptionKeyPrison # starcup
 
 - type: entity
   parent: TelecomServer

--- a/Resources/Prototypes/_starcup/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_starcup/Roles/Jobs/Wildcards/prisoner.yml
@@ -107,7 +107,6 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyCommon
       - EncryptionKeyPrison
 
 - type: entity


### PR DESCRIPTION
Adds the prisoner key to the security telecom server and removes the common key from the prisoner telecom server.

## Why / Balance
Fixes https://github.com/teamstarcup/starcup/issues/269. 
No other specific telecom server has the common key, prisoner shouldn't either. 

**Changelog**
:cl:
- fix: Prisoner comms should now be available on all maps.
