### PR TITLE
feat: eyepatch/glasses loadouts

### DIFF
--- a/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
@@ -47,6 +47,7 @@ loadout-group-librarian-shoes = Librarian shoes
 
 loadout-group-mime-shoes = Mime shoes
 
+loadout-group-musician-glasses = Musician glasses
 loadout-group-musician-shoes = Musician shoes
 
 loadout-group-service-worker-jumpsuit = Service worker jumpsuit

--- a/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
@@ -1,3 +1,6 @@
+# Command
+loadout-group-command-glasses = Command glasses
+
 # Engineering
 loadout-group-technical-assistant-outerclothing = Technical assistant outer clothing
 
@@ -9,9 +12,12 @@ loadout-group-chemist-id-starcup = Chemist PDA
 # Science
 loadout-group-research-assistant-outerclothing = Research assistant outer clothing
 
+loadout-group-robotics-glasses = Roboticist glasses
 loadout-group-roboticist-id-starcup = Roboticist PDA
 
 # Security
+loadout-group-security-glasses = Security glasses
+
 loadout-group-security-cadet-outerclothing = Security cadet outer clothing
 
 loadout-group-warden-shoes = Warden shoes
@@ -19,6 +25,7 @@ loadout-group-warden-shoes = Warden shoes
 # Service
 loadout-group-botanist-shoes = Botanist shoes
 
+loadout-group-bartender-glasses = Bartender glasses
 loadout-group-bartender-shoes = Bartender shoes
 
 loadout-group-chaplain-shoes = Chaplain shoes

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1414,6 +1414,7 @@
   - MedicalHud
   - MedicalEyePatchHud
   - Glasses
+  - Eyepatch # starcup
   - GlassesJamjar
   - GlassesJensen
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -106,6 +106,7 @@
   minLimit: 0
   loadouts:
   - Glasses
+  - Eyepatch # starcup
   - GlassesJamjar
   - GlassesJensen
 

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -8,6 +8,7 @@
   - CaptainBackpack
   - CaptainOuterClothing
   - CaptainShoes # DeltaV
+  - CommandEyewear # starcup
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool
@@ -22,7 +23,7 @@
   - HoPBackpack
   - HoPOuterClothing
   - HoPShoes # DeltaV
-  - Glasses
+  - CommandEyewear # starcup
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool
@@ -68,6 +69,7 @@
   - CommonBackpack
   - BartenderOuterClothing
   - BartenderShoes # starcup
+  - BartenderEyewear # starcup
   - BartenderPDADelta # DeltaV
   - Glasses
   - Survival
@@ -227,7 +229,7 @@
   - CommonBackpack
   - MusicianOuterClothing
   - MusicianShoes # starcup
-  - Glasses
+  - MusicianEyewear # starcup
   - Survival
   - Trinkets
   - Instruments
@@ -394,6 +396,7 @@
   - HeadofSecurityOuterClothing
   - HeadofSecurityShoes # DeltaV - winter boots
 #  - SecurityShoes # DeltaV
+  - SecurityEyewear # starcup
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
@@ -411,6 +414,7 @@
   - SecurityBelt
   - WardenOuterClothing
   - WardenShoes # starcup, replaces SecurityShoes
+  - SecurityEyewear # starcup
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
@@ -427,6 +431,7 @@
   - SecurityBackpack
   - SecurityOuterClothing
   - SecurityShoes
+  - SecurityEyewear # starcup
   - SecurityPDA
   - SecurityBelt
   - SurvivalSecurity
@@ -445,6 +450,7 @@
   - SecurityBackpack
   - DetectiveOuterClothing
   - SecurityShoes
+  - SecurityEyewear # starcup
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
@@ -461,6 +467,7 @@
   - SecurityCadetOuterClothing # starcup
   - SecurityBackpack
   - SecurityShoes # starcup
+  - SecurityEyewear # starcup
   - SurvivalSecurity
   - Trinkets
   - GroupSpeciesBreathToolSecurity

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -304,6 +304,7 @@
   - TechnicalAssistantOuterClothing # starcup
   - StationEngineerBackpack
   - StationEngineerShoes # starcup
+  - Glasses # starcup
   - SurvivalExtended
   - Trinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -18,7 +18,7 @@
 - type: startingGear
   id: MusicianGear
   equipment:
-    eyes: ClothingEyesGlassesSunglasses
+    #eyes: ClothingEyesGlassesSunglasses # starcup: moved to loadouts
 #    shoes: ClothingShoesBootsLaceup # starcup: moved to loadouts
     id: MusicianPDA
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -38,7 +38,7 @@
   id: CaptainGear
   equipment:
     #shoes: ClothingShoesBootsLaceup # - DeltaV - Commented out for loadout options
-    eyes: ClothingEyesGlassesSunglasses
+    #eyes: ClothingEyesGlassesSunglasses # starcup: moved to loadouts
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA
     ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -26,7 +26,7 @@
 - type: startingGear
   id: DetectiveGear
   equipment:
-    eyes: ClothingEyesGlassesSecurity
+    #eyes: ClothingEyesGlassesSecurity # starcup: moved to loadouts
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltHolster # DeltaV - loadouts

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -44,7 +44,7 @@
 - type: startingGear
   id: HoSGear
   equipment:
-    eyes: ClothingEyesGlassesSecurity
+    #eyes: ClothingEyesGlassesSecurity # starcup: moved to loadouts
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
     ears: ClothingHeadsetAltSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -25,7 +25,7 @@
 - type: startingGear
   id: SecurityOfficerGear
   equipment:
-    eyes: ClothingEyesGlassesSecurity
+    #eyes: ClothingEyesGlassesSecurity # starcup: moved to loadouts
     ears: ClothingHeadsetSecurity
   #  pocket1: WeaponPistolMk58Nonlethal # DeltaV - loadouts
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -28,7 +28,7 @@
 - type: startingGear
   id: WardenGear
   equipment:
-    eyes: ClothingEyesGlassesSecurity
+    #eyes: ClothingEyesGlassesSecurity # starcup: moved to loadouts
     id: WardenPDA
     ears: ClothingHeadsetSecurity
   #  pocket1: WeaponPistolMk58Nonlethal # DeltaV - loadouts

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -56,7 +56,7 @@
   - AdminAssistantShoes
   - AdminAssistantGloves
   - CommonBackpack
-  - CommandGlasses # starcup
+  - CommandEyewear # starcup
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -10,6 +10,7 @@
   - CourierPDA
   - CourierBackpack
   - CourierShoes
+  - Glasses # starcup
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool
@@ -41,7 +42,7 @@
   - RoboticistGloves
   - RoboticistShoes
   - RoboticistPDAstarcup # starcup
-  - Glasses
+  - RoboticsEyewear # starcup
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool
@@ -55,7 +56,7 @@
   - AdminAssistantShoes
   - AdminAssistantGloves
   - CommonBackpack
-  - Glasses
+  - CommandGlasses # starcup
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
@@ -41,7 +41,7 @@
   job:  AdministrativeAssistant
   equipment:
     Head: ClothingHeadHatCommandSoft
-    Eyes: ClothingEyesHudCommand
+    #Eyes: ClothingEyesHudCommand # starcup: moved to loadouts
     Mask: ClothingMaskBreath
     Neck: ClothingNeckScarfStripedBlue
     OuterClothing: ClothingOuterVest

--- a/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
@@ -25,7 +25,7 @@
 - type: startingGear
   id: AdminAssistantGear
   equipment:
-    eyes: ClothingEyesHudCommand
+    #eyes: ClothingEyesHudCommand # starcup: moved to loadouts
     belt: ClothingBeltPaperworkFilled
     id: AdminAssistantPDA
     pocket1: RubberStampAdminAssistant
@@ -41,7 +41,7 @@
   job:  AdministrativeAssistant
   equipment:
     Head: ClothingHeadHatCommandSoft
-    #Eyes: ClothingEyesHudCommand # starcup: moved to loadouts
+    Eyes: ClothingEyesHudCommand
     Mask: ClothingMaskBreath
     Neck: ClothingNeckScarfStripedBlue
     OuterClothing: ClothingOuterVest

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Civilian/bartender.yml
@@ -26,3 +26,14 @@
     proto: SeniorBartender
   equipment:
     id: SeniorBartenderPDA
+
+#Eyewear
+- type: loadout
+  id: BeerGlasses
+  equipment:
+    eyes: ClothingEyesHudBeer
+
+- type: loadout
+  id: BeerEyePatchHud
+  equipment:
+    eyes: ClothingEyesEyepatchHudBeer

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Command/command_shared.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Command/command_shared.yml
@@ -1,0 +1,10 @@
+#Eyewear
+- type: loadout
+  id: CommandGlasses
+  equipment:
+    eyes: ClothingEyesGlassesCommand
+
+- type: loadout
+  id: CommandHud
+  equipment:
+    eyes: ClothingEyesHudCommand

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Science/roboticist.yml
@@ -1,3 +1,14 @@
+#Eyewear
+- type: loadout
+  id: DiagnosticHud
+  equipment:
+    eyes: ClothingEyesHudDiagnostic
+
+- type: loadout
+  id: DiagnosticEyePatchHud
+  equipment:
+    eyes: ClothingEyesEyepatchHudDiag
+
 # OuterClothing
 - type: loadout
   id: NeuroroboticistSuit

--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Security/security_officer.yml
@@ -1,0 +1,15 @@
+#Eyewear
+- type: loadout
+  id: SecurityGlasses
+  equipment:
+    eyes: ClothingEyesGlassesSecurity
+
+- type: loadout
+  id: SecurityHud
+  equipment:
+    eyes: ClothingEyesHudSecurity
+
+- type: loadout
+  id: SecurityEyePatchHud
+  equipment:
+    eyes: ClothingEyesEyepatchHudSecurity

--- a/Resources/Prototypes/_starcup/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Miscellaneous/glasses.yml
@@ -1,0 +1,11 @@
+# Eyepatch
+- type: loadout
+  id: Eyepatch
+  equipment:
+    eyes: ClothingEyesEyepatch
+
+# Sunglasses
+- type: loadout
+  id: Sunglasses
+  equipment:
+    eyes: ClothingEyesGlassesSunglasses

--- a/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
@@ -283,7 +283,7 @@
 
 - type: loadoutGroup
   id: MusicianEyewear
-  name: loadout-group-robotics-glasses
+  name: loadout-group-musician-glasses
   minLimit: 0
   loadouts:
   - Sunglasses

--- a/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
@@ -254,3 +254,65 @@
   - EmergencyOxygenSyndicate
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
+
+- type: loadoutGroup
+  id: BartenderEyewear
+  name: loadout-group-bartender-glasses
+  minLimit: 0
+  loadouts:
+  - BeerGlasses
+  - BeerEyePatchHud
+  - Sunglasses
+  - Glasses
+  - Eyepatch
+  - GlassesJamjar
+  - GlassesJensen
+
+- type: loadoutGroup
+  id: CommandEyewear
+  name: loadout-group-command-glasses
+  minLimit: 0
+  loadouts:
+  - CommandGlasses
+  - CommandHud
+  - Sunglasses
+  - Glasses
+  - Eyepatch
+  - GlassesJamjar
+  - GlassesJensen
+
+- type: loadoutGroup
+  id: MusicianEyewear
+  name: loadout-group-robotics-glasses
+  minLimit: 0
+  loadouts:
+  - Sunglasses
+  - Glasses
+  - Eyepatch
+  - GlassesJamjar
+  - GlassesJensen
+
+- type: loadoutGroup
+  id: RoboticsEyewear
+  name: loadout-group-robotics-glasses
+  minLimit: 0
+  loadouts:
+  - DiagnosticHud
+  - DiagnosticEyePatchHud
+  - Glasses
+  - Eyepatch
+  - GlassesJamjar
+  - GlassesJensen
+
+- type: loadoutGroup
+  id: SecurityEyewear
+  name: loadout-group-security-glasses
+  minLimit: 0
+  loadouts:
+  - SecurityGlasses
+  - SecurityHud
+  - SecurityEyePatchHud
+  - Glasses
+  - Eyepatch
+  - GlassesJamjar
+  - GlassesJensen


### PR DESCRIPTION
adds the eyepatch to the generic glasses loadout that basically everyone gets, and also adds a bunch of new departmental loadouts that allow for selection of different glasses/eyepatches!

## Why / Balance
eyepatches as a character creation option introduces fun roleplaying opportunities, and allow for more versatility than the gauze eyepatch markings might on their own. also some command/sec players might like the one-eyed visor look over the glasses look and that would be nice to support

## Media
<img width="1002" height="797" alt="image" src="https://github.com/user-attachments/assets/31f74fb2-6dae-453f-9ca7-16429016f621" />

**Changelog**
:cl:
- add: departmental glasses loadouts for security and command, plus options for bartender, roboticist, and musician
- add: standard eyepatches are now in the generic glasses loadout group