### PR TITLE
map(byoin): access levels, new items

### DIFF
--- a/Resources/Maps/_starcup/byoin.yml
+++ b/Resources/Maps/_starcup/byoin.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/20/2025 07:21:22
-  entityCount: 15866
+  time: 08/10/2025 07:53:36
+  entityCount: 15868
 maps:
 - 1
 grids:
@@ -8615,12 +8615,6 @@ entities:
     - type: Transform
       pos: -1.5,-16.5
       parent: 2
-  - uid: 388
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 47.5,-25.5
-      parent: 2
 - proto: AirlockArmoryGlassLocked
   entities:
   - uid: 389
@@ -8661,6 +8655,14 @@ entities:
       name: Bar
     - type: Transform
       pos: 2.5,-3.5
+      parent: 2
+- proto: AirlockBoxerLocked
+  entities:
+  - uid: 520
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 47.5,-25.5
       parent: 2
 - proto: AirlockCaptainLocked
   entities:
@@ -9623,11 +9625,12 @@ entities:
     - type: Transform
       pos: 19.5,40.5
       parent: 2
-- proto: AirlockMaint
+- proto: AirlockMaintBoxerLocked
   entities:
-  - uid: 520
+  - uid: 388
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 49.5,-23.5
       parent: 2
 - proto: AirlockMaintCaptainLocked
@@ -9714,6 +9717,14 @@ entities:
     components:
     - type: Transform
       pos: 7.5,3.5
+      parent: 2
+- proto: AirlockMaintLibraryocked
+  entities:
+  - uid: 568
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-15.5
       parent: 2
 - proto: AirlockMaintLocked
   entities:
@@ -9846,6 +9857,7 @@ entities:
   - uid: 558
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 19.5,-20.5
       parent: 2
 - proto: AirlockMaintRnDLocked
@@ -9904,11 +9916,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-25.5
-      parent: 2
-  - uid: 568
-    components:
-    - type: Transform
-      pos: 14.5,-15.5
       parent: 2
 - proto: AirlockMaintTheatreLocked
   entities:
@@ -10003,11 +10010,6 @@ entities:
     - type: Transform
       pos: -0.5,-29.5
       parent: 2
-  - uid: 582
-    components:
-    - type: Transform
-      pos: 6.5,-31.5
-      parent: 2
   - uid: 583
     components:
     - type: Transform
@@ -10047,6 +10049,13 @@ entities:
     - type: Transform
       pos: 11.5,-21.5
       parent: 2
+- proto: AirlockPsychologistLocked
+  entities:
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 6.5,-31.5
+      parent: 2
 - proto: AirlockQuartermasterLocked
   entities:
   - uid: 589
@@ -10060,9 +10069,8 @@ entities:
   entities:
   - uid: 590
     components:
-    - type: MetaData
-      name: Reporter's Office
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 24.5,-21.5
       parent: 2
 - proto: AirlockResearchDirectorLocked
@@ -35980,6 +35988,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 30.5,-4.5
       parent: 2
+- proto: ComputerSalvageJobBoard
+  entities:
+  - uid: 15868
+    components:
+    - type: Transform
+      pos: -21.5,-0.5
+      parent: 2
 - proto: ComputerShuttleCargo
   entities:
   - uid: 5453
@@ -36866,6 +36881,9 @@ entities:
     - type: Transform
       pos: 8.5,11.5
       parent: 2
+    - type: Door
+      secondsUntilStateChange: -1517.5536
+      state: Closing
 - proto: CurtainsBlueOpenDirectional
   entities:
   - uid: 5607
@@ -93753,6 +93771,13 @@ entities:
     - type: Transform
       pos: 10.5,-36.5
       parent: 2
+- proto: VendingMachineMNKDrobe
+  entities:
+  - uid: 15867
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
 - proto: VendingMachineNutri
   entities:
   - uid: 12952
@@ -101836,6 +101861,20 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 2
+- proto: WindoorSecureLibraryLocked
+  entities:
+  - uid: 14540
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-13.5
+      parent: 2
+  - uid: 14541
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-13.5
+      parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:
   - uid: 14531
@@ -101897,20 +101936,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,17.5
-      parent: 2
-- proto: WindoorSecureServiceLocked
-  entities:
-  - uid: 14540
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-13.5
-      parent: 2
-  - uid: 14541
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-13.5
       parent: 2
 - proto: WindoorServiceLocked
   entities:

--- a/Resources/Maps/_starcup/byoin.yml
+++ b/Resources/Maps/_starcup/byoin.yml
@@ -36881,9 +36881,6 @@ entities:
     - type: Transform
       pos: 8.5,11.5
       parent: 2
-    - type: Door
-      secondsUntilStateChange: -1517.5536
-      state: Closing
 - proto: CurtainsBlueOpenDirectional
   entities:
   - uid: 5607

--- a/Resources/Maps/_starcup/byoin.yml
+++ b/Resources/Maps/_starcup/byoin.yml
@@ -10069,8 +10069,9 @@ entities:
   entities:
   - uid: 590
     components:
+    - type: MetaData
+      name: Reporter's Office
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,-21.5
       parent: 2
 - proto: AirlockResearchDirectorLocked


### PR DESCRIPTION
adds the salvage job board, the mnk drobe, and updates all the new access levels for byoin

**Changelog**
:cl:
- tweak: the new access levels for the psychologist, librarian, and boxer have been implemented into byoin
- add: mnk drobe added to byoin
- fix: salvage job board added to byoin