### PR TITLE
tweak: omega update (access levels, missing jobs, etc)

### DIFF
--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/10/2025 10:27:19
-  entityCount: 14272
+  time: 08/10/2025 11:28:16
+  entityCount: 14270
 maps:
 - 1
 grids:
@@ -34871,13 +34871,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -38.5,-5.5
       parent: 2
-- proto: ComputerCargoOrdersSecurity
-  entities:
-  - uid: 5397
-    components:
-    - type: Transform
-      pos: -33.5,20.5
-      parent: 2
 - proto: ComputerComms
   entities:
   - uid: 5399
@@ -63091,11 +63084,6 @@ entities:
       parent: 2
 - proto: HolopadServiceKitchen
   entities:
-  - uid: 5489
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 2
   - uid: 9558
     components:
     - type: Transform

--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 260.0.0
+  engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/12/2025 22:32:21
-  entityCount: 14278
+  time: 08/10/2025 10:27:19
+  entityCount: 14272
 maps:
 - 1
 grids:
@@ -7288,6 +7288,14 @@ entities:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
+- proto: AirlockLibraryLocked
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -31.5,-20.5
+      parent: 2
 - proto: AirlockMaintAtmoLocked
   entities:
   - uid: 277
@@ -7709,6 +7717,28 @@ entities:
     - type: Transform
       pos: 13.5,-19.5
       parent: 2
+- proto: AirlockRoboticsGlassLocked
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 17.5,-24.5
+      parent: 2
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 7.5,-24.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 5.5,-22.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 10.5,-25.5
+      parent: 2
 - proto: AirlockSalvageLocked
   entities:
   - uid: 350
@@ -7718,11 +7748,6 @@ entities:
       parent: 2
 - proto: AirlockScienceGlassLocked
   entities:
-  - uid: 351
-    components:
-    - type: Transform
-      pos: 17.5,-24.5
-      parent: 2
   - uid: 352
     components:
     - type: Transform
@@ -7742,21 +7767,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-19.5
-      parent: 2
-  - uid: 356
-    components:
-    - type: Transform
-      pos: 5.5,-22.5
-      parent: 2
-  - uid: 357
-    components:
-    - type: Transform
-      pos: 7.5,-24.5
-      parent: 2
-  - uid: 358
-    components:
-    - type: Transform
-      pos: 10.5,-25.5
       parent: 2
   - uid: 359
     components:
@@ -7855,13 +7865,6 @@ entities:
     components:
     - type: Transform
       pos: -31.5,21.5
-      parent: 2
-- proto: AirlockServiceLocked
-  entities:
-  - uid: 377
-    components:
-    - type: Transform
-      pos: -31.5,-20.5
       parent: 2
 - proto: AirlockTheatreLocked
   entities:
@@ -8255,6 +8258,11 @@ entities:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 442
     components:
     - type: Transform
@@ -11920,16 +11928,12 @@ entities:
       parent: 2
 - proto: BarSign
   entities:
-  - uid: 1132
+  - uid: 16
     components:
-    - type: MetaData
-      desc: Drink till you puke and/or break the laws of reality!
-      name: The Loose Goose
     - type: Transform
-      pos: 2.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
       parent: 2
-    - type: BarSign
-      current: Goose
   - uid: 1133
     components:
     - type: MetaData
@@ -33820,15 +33824,15 @@ entities:
       parent: 2
 - proto: ClothingHandsGlovesNitrile
   entities:
-  - uid: 5232
-    components:
-    - type: Transform
-      pos: -19.480015,-25.463383
-      parent: 2
   - uid: 5233
     components:
     - type: Transform
       pos: -39.79441,-35.343323
+      parent: 2
+  - uid: 5490
+    components:
+    - type: Transform
+      pos: -22.63258,-28.237942
       parent: 2
 - proto: ClothingHandsGlovesRobohands
   entities:
@@ -34121,6 +34125,18 @@ entities:
     - type: Transform
       pos: 35.488716,-30.534061
       parent: 2
+- proto: ClothingMultipleHeadphones
+  entities:
+  - uid: 5284
+    components:
+    - type: Transform
+      pos: -22.35473,0.53885174
+      parent: 2
+  - uid: 5285
+    components:
+    - type: Transform
+      pos: -0.5106895,-15.532991
+      parent: 2
 - proto: ClothingNeckBling
   entities:
   - uid: 5282
@@ -34134,18 +34150,6 @@ entities:
     components:
     - type: Transform
       pos: 38.546867,-26.403046
-      parent: 2
-- proto: ClothingNeckHeadphones
-  entities:
-  - uid: 5284
-    components:
-    - type: Transform
-      pos: -22.35473,0.53885174
-      parent: 2
-  - uid: 5285
-    components:
-    - type: Transform
-      pos: -0.5106895,-15.532991
       parent: 2
 - proto: ClothingNeckIntersexPin
   entities:
@@ -34867,35 +34871,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -38.5,-5.5
       parent: 2
-- proto: ComputerCargoOrdersMedical
-  entities:
-  - uid: 5395
-    components:
-    - type: Transform
-      pos: -15.5,-15.5
-      parent: 2
-- proto: ComputerCargoOrdersScience
-  entities:
-  - uid: 5396
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-17.5
-      parent: 2
 - proto: ComputerCargoOrdersSecurity
   entities:
   - uid: 5397
     components:
     - type: Transform
       pos: -33.5,20.5
-      parent: 2
-- proto: ComputerCargoOrdersService
-  entities:
-  - uid: 5398
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,9.5
       parent: 2
 - proto: ComputerComms
   entities:
@@ -34997,13 +34978,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,-44.5
       parent: 2
-- proto: ComputerFundingAllocation
-  entities:
-  - uid: 5415
-    components:
-    - type: Transform
-      pos: 7.5,26.5
-      parent: 2
 - proto: ComputerId
   entities:
   - uid: 5416
@@ -35025,6 +34999,11 @@ entities:
       parent: 2
 - proto: ComputerMedicalRecords
   entities:
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -19.5,-25.5
+      parent: 2
   - uid: 5419
     components:
     - type: Transform
@@ -35065,12 +35044,6 @@ entities:
     components:
     - type: Transform
       pos: -8.5,34.5
-      parent: 2
-  - uid: 5426
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,13.5
       parent: 2
   - uid: 5427
     components:
@@ -35117,6 +35090,14 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,16.5
+      parent: 2
+- proto: ComputerSalvageJobBoard
+  entities:
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,13.5
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
@@ -35411,11 +35392,6 @@ entities:
         - 0
 - proto: CrateEmptySpawner
   entities:
-  - uid: 5476
-    components:
-    - type: Transform
-      pos: 14.5,23.5
-      parent: 2
   - uid: 5477
     components:
     - type: Transform
@@ -35625,46 +35601,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-28.5
-      parent: 2
-- proto: CrateLockBoxEngineering
-  entities:
-  - uid: 5489
-    components:
-    - type: Transform
-      pos: -35.5,-11.5
-      parent: 2
-- proto: CrateLockBoxMedical
-  entities:
-  - uid: 5490
-    components:
-    - type: Transform
-      pos: -16.5,-28.5
-      parent: 2
-- proto: CrateLockBoxScience
-  entities:
-  - uid: 5491
-    components:
-    - type: Transform
-      pos: 12.5,-23.5
-      parent: 2
-- proto: CrateLockBoxSecurity
-  entities:
-  - uid: 5492
-    components:
-    - type: Transform
-      pos: -32.5,20.5
-      parent: 2
-- proto: CrateLockBoxService
-  entities:
-  - uid: 5493
-    components:
-    - type: Transform
-      pos: -9.5,11.5
-      parent: 2
-  - uid: 5494
-    components:
-    - type: Transform
-      pos: 1.5,13.5
       parent: 2
 - proto: CrateMedicalSurgery
   entities:
@@ -40593,6 +40529,21 @@ entities:
       parent: 2
 - proto: FireAlarm
   entities:
+  - uid: 5232
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 6373
+      - 6419
+      - 6415
+      - 6417
+      - 6418
+      - 6414
+      - 6416
+      - 441
   - uid: 6322
     components:
     - type: Transform
@@ -40992,22 +40943,6 @@ entities:
       - 6418
       - 6417
       - 6415
-  - uid: 6355
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,8.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 6414
-      - 6416
-      - 6373
-      - 6419
-      - 6418
-      - 6417
-      - 6415
-      - 441
   - uid: 6356
     components:
     - type: Transform
@@ -41195,6 +41130,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6374
     components:
     - type: Transform
@@ -41458,31 +41398,61 @@ entities:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6415
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6416
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6417
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6418
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6419
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 5232
   - uid: 6420
     components:
     - type: Transform
@@ -63086,7 +63056,7 @@ entities:
       parent: 2
 - proto: HolopadServiceBar
   entities:
-  - uid: 9553
+  - uid: 5395
     components:
     - type: Transform
       pos: 3.5,6.5
@@ -63121,6 +63091,11 @@ entities:
       parent: 2
 - proto: HolopadServiceKitchen
   entities:
+  - uid: 5489
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
   - uid: 9558
     components:
     - type: Transform
@@ -63457,6 +63432,12 @@ entities:
       parent: 2
 - proto: IntercomCommon
   entities:
+  - uid: 5415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 2
   - uid: 9616
     components:
     - type: Transform
@@ -63496,6 +63477,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 10.5,8.5
       parent: 2
+  - uid: 12025
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-17.5
+      parent: 2
 - proto: IntercomEngineering
   entities:
   - uid: 9623
@@ -63509,8 +63496,20 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -43.5,-9.5
       parent: 2
+  - uid: 11560
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -32.5,-4.5
+      parent: 2
 - proto: IntercomMedical
   entities:
+  - uid: 5426
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-19.5
+      parent: 2
   - uid: 9625
     components:
     - type: Transform
@@ -63519,6 +63518,12 @@ entities:
       parent: 2
 - proto: IntercomScience
   entities:
+  - uid: 5491
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-22.5
+      parent: 2
   - uid: 9626
     components:
     - type: Transform
@@ -63533,6 +63538,11 @@ entities:
       parent: 2
 - proto: IntercomSecurity
   entities:
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -32.5,21.5
+      parent: 2
   - uid: 9628
     components:
     - type: Transform
@@ -63552,6 +63562,12 @@ entities:
       parent: 2
 - proto: IntercomService
   entities:
+  - uid: 5492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 2
   - uid: 9631
     components:
     - type: Transform
@@ -64140,6 +64156,13 @@ entities:
         11195:
         - - Pressed
           - Toggle
+- proto: LockerAdministrativeAssistantFilled
+  entities:
+  - uid: 5494
+    components:
+    - type: Transform
+      pos: 0.5,28.5
+      parent: 2
 - proto: LockerAtmosphericsFilled
   entities:
   - uid: 9687
@@ -64634,6 +64657,13 @@ entities:
     components:
     - type: Transform
       pos: -22.5,24.5
+      parent: 2
+- proto: LockerPsychologistFilled
+  entities:
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -16.5,-16.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
@@ -65568,13 +65598,6 @@ entities:
     - type: Transform
       pos: -21.5,6.5
       parent: 2
-- proto: PaintingMonkey
-  entities:
-  - uid: 9849
-    components:
-    - type: Transform
-      pos: 4.5,9.5
-      parent: 2
 - proto: PaintingNightHawks
   entities:
   - uid: 9850
@@ -65602,13 +65625,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,2.5
-      parent: 2
-- proto: PaintingSleepingGypsy
-  entities:
-  - uid: 9854
-    components:
-    - type: Transform
-      pos: -28.5,-13.5
       parent: 2
 - proto: PaladinCircuitBoard
   entities:
@@ -66478,31 +66494,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -25.5,31.5
       parent: 2
-- proto: PosterLegitCohibaRobustoAd
-  entities:
-  - uid: 10005
-    components:
-    - type: Transform
-      pos: 17.5,-14.5
-      parent: 2
-  - uid: 10006
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 2
 - proto: PosterLegitDoNotQuestion
   entities:
   - uid: 10007
     components:
     - type: Transform
       pos: -28.5,10.5
-      parent: 2
-- proto: PosterLegitEnlist
-  entities:
-  - uid: 10008
-    components:
-    - type: Transform
-      pos: -38.5,26.5
       parent: 2
 - proto: PosterLegitHereForYourSafety
   entities:
@@ -73400,6 +73397,21 @@ entities:
     - type: Transform
       pos: -47.503944,-13.422302
       parent: 2
+- proto: ShelfBar
+  entities:
+  - uid: 5396
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 2
+- proto: ShelfKitchen
+  entities:
+  - uid: 5493
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 2
 - proto: Shovel
   entities:
   - uid: 11168
@@ -75884,13 +75896,6 @@ entities:
     - type: Transform
       pos: 20.5,19.5
       parent: 2
-- proto: SpawnMobAlexander
-  entities:
-  - uid: 11560
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 2
 - proto: SpawnMobBandito
   entities:
   - uid: 11561
@@ -75994,6 +75999,13 @@ entities:
     - type: Transform
       pos: -11.5,-14.5
       parent: 2
+- proto: SpawnPointAdminAssistant
+  entities:
+  - uid: 10005
+    components:
+    - type: Transform
+      pos: -2.5,30.5
+      parent: 2
 - proto: SpawnPointAtmos
   entities:
   - uid: 11576
@@ -76043,6 +76055,13 @@ entities:
     components:
     - type: Transform
       pos: -11.5,28.5
+      parent: 2
+- proto: SpawnPointCargoAssistant
+  entities:
+  - uid: 9849
+    components:
+    - type: Transform
+      pos: 18.5,18.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
@@ -76102,6 +76121,13 @@ entities:
     components:
     - type: Transform
       pos: -9.5,1.5
+      parent: 2
+- proto: SpawnPointCourier
+  entities:
+  - uid: 9854
+    components:
+    - type: Transform
+      pos: 17.5,25.5
       parent: 2
 - proto: SpawnPointDetective
   entities:
@@ -76266,6 +76292,25 @@ entities:
     - type: Transform
       pos: -20.5,10.5
       parent: 2
+- proto: SpawnPointPrisoner
+  entities:
+  - uid: 10006
+    components:
+    - type: Transform
+      pos: -29.5,29.5
+      parent: 2
+  - uid: 10008
+    components:
+    - type: Transform
+      pos: -20.5,27.5
+      parent: 2
+- proto: SpawnPointPsychologist
+  entities:
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -16.5,-22.5
+      parent: 2
 - proto: SpawnPointQuartermaster
   entities:
   - uid: 11620
@@ -76286,6 +76331,13 @@ entities:
     components:
     - type: Transform
       pos: 27.5,-18.5
+      parent: 2
+- proto: SpawnPointRoboticist
+  entities:
+  - uid: 5476
+    components:
+    - type: Transform
+      pos: 13.5,-25.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
@@ -79076,11 +79128,6 @@ entities:
     - type: Transform
       pos: -3.5,26.5
       parent: 2
-  - uid: 12025
-    components:
-    - type: Transform
-      pos: -19.5,-25.5
-      parent: 2
   - uid: 12026
     components:
     - type: Transform
@@ -80485,23 +80532,6 @@ entities:
     - type: Transform
       pos: 10.5,26.5
       parent: 2
-- proto: VendingMachineChang
-  entities:
-  - uid: 12230
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 2
-  - uid: 12231
-    components:
-    - type: Transform
-      pos: 23.5,-6.5
-      parent: 2
-  - uid: 12232
-    components:
-    - type: Transform
-      pos: 2.5,-32.5
-      parent: 2
 - proto: VendingMachineChapel
   entities:
   - uid: 12233
@@ -80543,13 +80573,6 @@ entities:
     components:
     - type: Transform
       pos: -27.5,10.5
-      parent: 2
-  - uid: 12239
-    components:
-    - type: MetaData
-      name: cigarette machine
-    - type: Transform
-      pos: 0.5,28.5
       parent: 2
   - uid: 12240
     components:
@@ -80669,6 +80692,13 @@ entities:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
+- proto: VendingMachineCourierDrobe
+  entities:
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: 14.5,23.5
+      parent: 2
 - proto: VendingMachineCuraDrobe
   entities:
   - uid: 12258
@@ -80774,6 +80804,13 @@ entities:
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
+- proto: VendingMachineMNKDrobe
+  entities:
+  - uid: 9553
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
 - proto: VendingMachineNutri
   entities:
   - uid: 12273
@@ -80785,6 +80822,13 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-32.5
+      parent: 2
+- proto: VendingMachinePride
+  entities:
+  - uid: 5398
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
       parent: 2
 - proto: VendingMachineRoboDrobe
   entities:
@@ -80868,13 +80912,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-45.5
-      parent: 2
-- proto: VendingMachineSovietSoda
-  entities:
-  - uid: 12288
-    components:
-    - type: Transform
-      pos: 29.5,-32.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:
@@ -89993,12 +90030,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 15.5,8.5
       parent: 2
-  - uid: 14073
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -32.5,-18.5
-      parent: 2
   - uid: 14074
     components:
     - type: Transform
@@ -90175,6 +90206,14 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,23.5
+      parent: 2
+- proto: WindoorSecureLibraryLocked
+  entities:
+  - uid: 6355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -32.5,-18.5
       parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:

--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -8258,11 +8258,6 @@ entities:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 442
     components:
     - type: Transform
@@ -41123,11 +41118,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6374
     components:
     - type: Transform
@@ -41391,61 +41381,31 @@ entities:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6415
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6416
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6417
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6418
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6419
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 5232
   - uid: 6420
     components:
     - type: Transform

--- a/Resources/Prototypes/_starcup/Maps/omega.yml
+++ b/Resources/Prototypes/_starcup/Maps/omega.yml
@@ -16,8 +16,8 @@
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/_starcup/Shuttles/SYND_EvacShip.yml # starcup: emergency_omega.yml -> SYND_EvacShip.yml
         - type: StationJobs
-          availableJobs: # 48 jobs total w/o latejoins & interns, 57 jobs total w/ latejoins & interns
-            #command (7)
+          availableJobs: # 54 jobs total w/o latejoins & interns, 64 jobs total w/ latejoins & interns
+            #command (8)
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -25,6 +25,7 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
+            AdministrativeAssistant: [ 1, 1 ]
             #service (9 - 10)
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
@@ -37,23 +38,28 @@
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]
             TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (6)
+            #medical (7)
             Chemist: [ 2, 2 ]
             MedicalDoctor: [ 3, 3 ]
             Paramedic: [ 1, 1 ]
+            Psychologist: [ 1, 1 ]
             MedicalIntern: [ 2, 2 ] #intern, not counted
-            #science (4)
+            #science (5)
             Scientist: [ 4, 4 ]
+            Roboticist: [ 1, 1 ]
             ResearchAssistant: [ 2, 2 ] #intern, not counted
-            #security (7)
+            #security (9)
             Warden: [ 1, 1 ]
             SecurityOfficer: [ 4, 4 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 2, 2 ] #intern, not counted
             Lawyer: [ 1, 1 ]
-            #supply (4)
+            Prisoner: [ 2, 2 ]
+            #supply (5)
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
+            Courier: [ 1, 1 ]
+            CargoAssistant: [ 1, 1 ] # intern, not counted
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
             Clown: [ 1, 1 ]


### PR DESCRIPTION
updates omega in accordance with our current mapping standards, adding many missing jobs and resources! more comprehensive fixes will probably be in order at a later date, this just ensures everything's functional

**Changelog**
:cl:
- fix: added missing job slots/spawns to omega! all of starcup's typical jobs should be available now
- add: added the administrative assistant's locker to the bridge
- add: added the psychologist's locker to medbay (a proper office will be coming later!)
- add: the pride-o-mat and mnk drobe can now be found at omega
- add: omega now has more departmental intercoms