### PR TITLE
tweak: let assistants do crimes (antag selection fix)

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -15,7 +15,7 @@
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering
-  canBeAntag: false
+#  canBeAntag: false # starcup
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -11,7 +11,7 @@
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine
-  canBeAntag: false
+#  canBeAntag: false # starcup
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -11,7 +11,7 @@
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science
-  canBeAntag: false
+#  canBeAntag: false # starcup
   access:
   - Research
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -15,7 +15,7 @@
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security
-#  canBeAntag: true # starcup
+  canBeAntag: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -15,7 +15,7 @@
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security
-  canBeAntag: false
+#  canBeAntag: true # starcup
   access:
   - Security
   - Brig


### PR DESCRIPTION
comments out the line preventing technical assistants, medical interns, and research assistants from being selected for antagonist rolls.

## Why / Balance
lots of people play the assistant roles for roleplaying reasons over the originally intended purpose of solely being an out-of-character signifier! and we already have antag preference toggles and antag playtime requirements for this sort of thing

**Changelog**
:cl:
- tweak: research assistants, medical interns, and technical assistants are now eligible for antagonist selection
