### PR TITLE
tweak: minor playtime requirement adjustments

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -3,10 +3,10 @@
   name: job-name-serviceworker
   description: job-description-serviceworker
   playTimeTracker: JobServiceWorker
-  requirements:
-  - !type:DepartmentTimeRequirement
-    department: Civilian
-    time: 1800 #0.5 hr
+#  requirements: # starcup: remove playtime requirement
+#  - !type:DepartmentTimeRequirement
+#    department: Civilian
+#    time: 1800 #0.5 hr
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service

--- a/Resources/Prototypes/_starcup/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_starcup/Roles/Jobs/Wildcards/prisoner.yml
@@ -3,6 +3,10 @@
   name: job-name-prisoner
   description: job-description-prisoner
   playTimeTracker: JobPrisoner
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 7200 #2 hr
   startingGear: PrisonerGear
   icon: JobIconPermaPrisoner
   supervisors: job-supervisors-security


### PR DESCRIPTION
comments out the service worker playtime requirement, and requires two security hours for playing prisoner

## Why / Balance
none of the other service jobs have playtime reqs, so service worker probbly shouldn't either. and prisoners likely ought to have an at least passing familiarity with how the people on the other side of the turnstile operate!

**Changelog**
:cl:
- tweak: removed the playtime requirement for service workers
- tweak: prisoner now requires a few hours played in security