### PR TITLE
feat: admin records

### DIFF
--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
     public event Action<StationRecordFilterType, string?>? OnFiltersChanged;
 
     private bool _isPopulating;
+    private bool _filtersChanged;
     private StationRecordFilterType _filterType;
 
     private RecordConsoleType? _type;
@@ -146,6 +147,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
             if (args.Id == RecordEntryViewType.SelectedId)
                 return;
             RecordEntryViewType.SelectId(args.Id);
+            _filtersChanged = true;
             // This is a hack to get the server to send us another packet with the new entries
             OnFiltersChanged?.Invoke(_filterType, RecordFiltersValue.Text);
         };
@@ -302,11 +304,11 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         RecordContainerStatus.Visible = false;
         RecordContainer.Visible = true;
 
-        // DeltaV - that's not the case
-        // Do not needlessly reload the record if not needed. This is mainly done to prevent a bug in the admin record viewer.
-        // if (state.SelectedIndex == _openRecordKey)
-        //     return;
-        // _openRecordKey = state.SelectedIndex;
+        // Do not needlessly reload the record if not needed. This is mainly done to prevent a bug in the admin record viewer
+        // AND the admin record filter.
+        if (state.SelectedIndex == _openRecordKey && _filtersChanged == false)
+            return;
+        _openRecordKey = state.SelectedIndex;
 
         var record = state.SelectedRecord!;
         var cr = record.PRecords;
@@ -347,12 +349,15 @@ public sealed partial class CharacterRecordViewer : FancyWindow
                 {
                 case RecordConsoleType.Employment:
                     SetEntries(cr.EmploymentEntries, true);
+                    _filtersChanged = false;
                     break;
                 case RecordConsoleType.Medical:
                     SetEntries(cr.MedicalEntries, true);
+                    _filtersChanged = false;
                     break;
                 case RecordConsoleType.Security:
                     SetEntries(cr.SecurityEntries, true);
+                    _filtersChanged = false;
                     break;
                 case RecordConsoleType.Admin:
                     SetEntries(cr.AdminEntries, true);

--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -140,6 +140,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         RecordEntryViewType.AddItem(Loc.GetString("department-Security"));
         RecordEntryViewType.AddItem(Loc.GetString("department-Medical"));
         RecordEntryViewType.AddItem(Loc.GetString("humanoid-profile-editor-cd-records-employment"));
+        RecordEntryViewType.AddItem(Loc.GetString("humanoid-profile-editor-cd-records-admin"));
         RecordEntryViewType.OnItemSelected += args =>
         {
             if (args.Id == RecordEntryViewType.SelectedId)
@@ -352,6 +353,10 @@ public sealed partial class CharacterRecordViewer : FancyWindow
                     break;
                 case RecordConsoleType.Security:
                     SetEntries(cr.SecurityEntries, true);
+                    break;
+                case RecordConsoleType.Admin:
+                    SetEntries(cr.AdminEntries, true);
+                    _filtersChanged = false;
                     break;
                 }
                 break;

--- a/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
+++ b/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
@@ -61,6 +61,7 @@
                      <cdrecords:RecordEditorEntrySelector Name="EmploymentEntrySelector"/>
                      <cdrecords:RecordEditorEntrySelector Name="MedicalEntrySelector"/>
                      <cdrecords:RecordEditorEntrySelector Name="SecurityEntrySelector"/>
+                     <cdrecords:RecordEditorEntrySelector Name="AdminEntrySelector"/>
                  </TabContainer>
              </BoxContainer>
          </ScrollContainer>

--- a/Content.Client/_CD/Records/UI/RecordEditorGui.xaml.cs
+++ b/Content.Client/_CD/Records/UI/RecordEditorGui.xaml.cs
@@ -90,6 +90,7 @@ public sealed partial class RecordEditorGui : Control
         EntryEditorTabs.SetTabTitle(0, Loc.GetString("humanoid-profile-editor-cd-records-employment"));
         EntryEditorTabs.SetTabTitle(1, Loc.GetString("department-Medical"));
         EntryEditorTabs.SetTabTitle(2, Loc.GetString("department-Security"));
+        EntryEditorTabs.SetTabTitle(3, Loc.GetString("humanoid-profile-editor-cd-records-admin"));
 
         EmploymentEntrySelector.OnUpdateEntries += args =>
         {
@@ -106,6 +107,11 @@ public sealed partial class RecordEditorGui : Control
             UpdateRecords(_records.WithSecurityEntries(args.Entries));
         };
 
+        AdminEntrySelector.OnUpdateEntries += args =>
+        {
+            UpdateRecords(_records.WithAdminEntries(args.Entries));
+        };
+
         #endregion
     }
 
@@ -115,6 +121,7 @@ public sealed partial class RecordEditorGui : Control
         EmploymentEntrySelector.UpdateContents(_records.EmploymentEntries);
         MedicalEntrySelector.UpdateContents(_records.MedicalEntries);
         SecurityEntrySelector.UpdateContents(_records.SecurityEntries);
+        AdminEntrySelector.UpdateContents(_records.AdminEntries);
         UpdateWidgets();
     }
 

--- a/Content.Server.Database/CDModel.cs
+++ b/Content.Server.Database/CDModel.cs
@@ -34,7 +34,7 @@ public static class CDModel
     }
     public enum DbRecordEntryType : byte
     {
-         Medical = 0, Security = 1, Employment = 2
+         Medical = 0, Security = 1, Employment = 2, Admin = 3,
     }
 
     [Table("cd_character_record_entries"), Index(nameof(Id))]

--- a/Content.Server/_CD/Records/CharacterRecordsSystem.cs
+++ b/Content.Server/_CD/Records/CharacterRecordsSystem.cs
@@ -146,6 +146,9 @@ public sealed class CharacterRecordsSystem : EntitySystem
             case CharacterRecordType.Security:
                 cr.SecurityEntries.RemoveAt(idx);
                 break;
+            case CharacterRecordType.Admin:
+                cr.AdminEntries.RemoveAt(idx);
+                break;
         }
 
         RaiseLocalEvent(station, new CharacterRecordsModifiedEvent());

--- a/Content.Server/_CD/Records/RecordsSerialization.cs
+++ b/Content.Server/_CD/Records/RecordsSerialization.cs
@@ -73,7 +73,8 @@ public static class RecordsSerialization
             postmortemInstructions: DeserializeString(e, nameof(def.PostmortemInstructions), def.PostmortemInstructions),
             medicalEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Medical),
             securityEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Security),
-            employmentEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Employment));
+            employmentEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Employment),
+            adminEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Admin));
     }
 
     private static CDModel.CharacterRecordEntry ConvertEntry(PlayerProvidedCharacterRecords.RecordEntry entry, CDModel.DbRecordEntryType type)
@@ -88,6 +89,7 @@ public static class RecordsSerialization
         return records.MedicalEntries.Select(medical => ConvertEntry(medical, CDModel.DbRecordEntryType.Medical))
             .Concat(records.SecurityEntries.Select(security => ConvertEntry(security, CDModel.DbRecordEntryType.Security)))
             .Concat(records.EmploymentEntries.Select(employment => ConvertEntry(employment, CDModel.DbRecordEntryType.Employment)))
+            .Concat(records.AdminEntries.Select(employment => ConvertEntry(employment, CDModel.DbRecordEntryType.Admin)))
             .ToList();
     }
 }

--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -54,6 +54,8 @@ public sealed partial class PlayerProvidedCharacterRecords
     public List<RecordEntry> SecurityEntries { get; private set; }
     [DataField, JsonIgnore]
     public List<RecordEntry> EmploymentEntries { get; private set; }
+    [DataField, JsonIgnore]
+    public List<RecordEntry> AdminEntries { get; private set; }
 
     [DataDefinition]
     [Serializable, NetSerializable]
@@ -100,7 +102,10 @@ public sealed partial class PlayerProvidedCharacterRecords
         string identifyingFeatures,
         string allergies, string drugAllergies,
         string postmortemInstructions,
-        List<RecordEntry> medicalEntries, List<RecordEntry> securityEntries, List<RecordEntry> employmentEntries)
+        List<RecordEntry> medicalEntries,
+        List<RecordEntry> securityEntries,
+        List<RecordEntry> employmentEntries,
+        List<RecordEntry> adminEntries)
     {
         HasWorkAuthorization = hasWorkAuthorization;
         Height = height;
@@ -113,6 +118,7 @@ public sealed partial class PlayerProvidedCharacterRecords
         MedicalEntries = medicalEntries;
         SecurityEntries = securityEntries;
         EmploymentEntries = employmentEntries;
+        AdminEntries = adminEntries;
     }
 
     public PlayerProvidedCharacterRecords(PlayerProvidedCharacterRecords other)
@@ -128,6 +134,7 @@ public sealed partial class PlayerProvidedCharacterRecords
         MedicalEntries = other.MedicalEntries.Select(x => new RecordEntry(x)).ToList();
         SecurityEntries = other.SecurityEntries.Select(x => new RecordEntry(x)).ToList();
         EmploymentEntries = other.EmploymentEntries.Select(x => new RecordEntry(x)).ToList();
+        AdminEntries = other.AdminEntries.Select(x => new RecordEntry(x)).ToList();
     }
 
     public static PlayerProvidedCharacterRecords DefaultRecords()
@@ -142,7 +149,8 @@ public sealed partial class PlayerProvidedCharacterRecords
             postmortemInstructions: "Return home",
             medicalEntries: new List<RecordEntry>(),
             securityEntries: new List<RecordEntry>(),
-            employmentEntries: new List<RecordEntry>()
+            employmentEntries: new List<RecordEntry>(),
+            adminEntries: new List<RecordEntry>()
         );
     }
 
@@ -165,6 +173,8 @@ public sealed partial class PlayerProvidedCharacterRecords
             return false;
         if (EmploymentEntries.Count != other.EmploymentEntries.Count)
             return false;
+        if (AdminEntries.Count != other.AdminEntries.Count)
+            return false;
         if (MedicalEntries.Where((t, i) => !t.MemberwiseEquals(other.MedicalEntries[i])).Any())
         {
             return false;
@@ -174,6 +184,11 @@ public sealed partial class PlayerProvidedCharacterRecords
             return false;
         }
         if (EmploymentEntries.Where((t, i) => !t.MemberwiseEquals(other.EmploymentEntries[i])).Any())
+        {
+            return false;
+        }
+
+        if (AdminEntries.Where((t, i) => !t.MemberwiseEquals(other.AdminEntries[i])).Any())
         {
             return false;
         }
@@ -215,6 +230,7 @@ public sealed partial class PlayerProvidedCharacterRecords
         EnsureValidEntries(EmploymentEntries);
         EnsureValidEntries(MedicalEntries);
         EnsureValidEntries(SecurityEntries);
+        EnsureValidEntries(AdminEntries);
     }
     public PlayerProvidedCharacterRecords WithHeight(int height)
     {
@@ -260,9 +276,14 @@ public sealed partial class PlayerProvidedCharacterRecords
     {
         return new(this) { SecurityEntries = entries};
     }
+
+    public PlayerProvidedCharacterRecords WithAdminEntries(List<RecordEntry> entries)
+    {
+        return new (this) { AdminEntries = entries };
+    }
 }
 
 public enum CharacterRecordType : byte
 {
-    Employment, Medical, Security
+    Employment, Medical, Security, Admin,
 }

--- a/Resources/Locale/en-US/_CD/records/editor.ftl
+++ b/Resources/Locale/en-US/_CD/records/editor.ftl
@@ -18,6 +18,9 @@ humanoid-profile-editor-cd-records-allergies = Allergies:
 humanoid-profile-editor-cd-records-drug-allergies = Drug Allergies:
 humanoid-profile-editor-cd-records-postmortem = Postmortem Instructions:
 
+# Admin
+humanoid-profile-editor-cd-records-admin = Admin
+
 # Entries
 humanoid-profile-editor-cd-records-add-entry = Add Entry
 humanoid-profile-editor-cd-records-edit-entry = Edit Entry

--- a/Resources/ServerInfo/Guidebook/_CD/Records.xml
+++ b/Resources/ServerInfo/Guidebook/_CD/Records.xml
@@ -24,8 +24,16 @@ your character, major surgeries, prescriptions, and any psychological evaluation
 Security Entries should include any major arrests/incidents your character has
 had in their past or while working with the Syndicate.
 
+## Admin Entries
+
+Admin Entries should include any major information that you want to let game admins know about
+but otherwise wouldn't fit in other entry categories due to classification,
+privacy concerns, lack of relevance, or a multitude of other reasons. These entries will
+not be visible to anyone other than you and the admin team.
+
 ## Accessing Records
-You can access the records of your crewmates in game from their respective consoles.
+You can access the records of your crewmates in game from their respective consoles apart from
+admin entries.
 
 <Box>
 <GuideEntityEmbed Entity="ComputerMedicalRecords" Caption="Medical"/>


### PR DESCRIPTION
ports ["admin records"](https://github.com/cosmatic-drift-14/cosmatic-drift/pull/606) (and ["admin records console can filter by record entry type again"](https://github.com/cosmatic-drift-14/cosmatic-drift/pull/605) as a necessary prerequisite) from cosmatic drift, adding a special type of records that can only be viewed from the aghost character records action

## Why / Balance
knowing details about a character's backstory or other characterization tidbits makes for great roleplaying prompts and helps curators set up interesting events! it's also helpful for keeping track of character continuity, since that's such a priority here

**Changelog**
:cl:
- add: added a new type of character records: admin records, only available to you and server admins! give us your secret character lore!
