### PR TITLE
fix: Adds default value to AdminEntries

### DIFF
--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -55,7 +55,7 @@ public sealed partial class PlayerProvidedCharacterRecords
     [DataField, JsonIgnore]
     public List<RecordEntry> EmploymentEntries { get; private set; }
     [DataField, JsonIgnore]
-    public List<RecordEntry> AdminEntries { get; private set; }
+    public List<RecordEntry> AdminEntries { get; private set; } = [];
 
     [DataDefinition]
     [Serializable, NetSerializable]


### PR DESCRIPTION
Fixes #303

## Why / Balance
Bugfix for characters exported earlier or from servers that don't have admin records

## Technical details
Provided default value for adminrecords.

Decided to provide this as a quick fix rather than a deeper look into the CD code to ensure further safety at this time.

**Changelog**
:cl:
- fix: Characters without admin records should import now