### PR TITLE
feat: increase human limb marking limits to 6

### DIFF
--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -69,10 +69,10 @@
       points: 2
       required: false
     Legs:
-      points: 6 # starcup 2>6
+      points: 6 # starcup: 2 -> 6
       required: false
     Arms:
-      points: 6 # starcup 2>6
+      points: 6 # starcup: 2 -> 6
       required: false
 
 - type: humanoidBaseSprite


### PR DESCRIPTION
## Why / Balance
most other humanoid species already have 6-8 marking slots for arms and legs, due to ports from impstation. a minimum of 4 markings is needed to have a marking on both arms and both hands; additional slots for maximum customization.

## Technical details
two lines edited in Species/human.yml

**Changelog**
:cl:
- fix: Human limbs can now accept more markings.