### PR TITLE
tweak: make insuls engineering contraband (without the mapping changes)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -322,8 +322,8 @@
 # Insulated Gloves (Yellow Gloves)
 # Currently can not be greyscaled without looking like shit.
 - type: entity
-  parent: ClothingHandsBase
-  id: [ ClothingHandsGlovesColorYellow, BaseEngineeringContraband ] # starcup: added contraband label
+  parent: [ ClothingHandsBase, BaseEngineeringContraband ] # starcup: added contraband label
+  id: ClothingHandsGlovesColorYellow
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.
   components:

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -323,7 +323,7 @@
 # Currently can not be greyscaled without looking like shit.
 - type: entity
   parent: ClothingHandsBase
-  id: ClothingHandsGlovesColorYellow
+  id: [ ClothingHandsGlovesColorYellow, BaseEngineeringContraband ] # starcup: added contraband label
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.
   components:


### PR DESCRIPTION
puts an engineering contraband label on insulated gloves

## Why / Balance
you can view an extensive community discussion on the topic on our forum [here](https://forum.starcup.cc/t/insuls-and-doorhacking-discussion-on-the-merits-of-being-in-places-youre-not-supposed-to-be/196), but the short of it is: insulated gloves are designed to let you and encourage you to do crimes, and doorhacking needs to be taken more seriously if we want to commit to the standard of roleplaying that starcup is trying to encourage. people having insuls when they shouldn't should not be considered normal

jury's still out on budget insuls. those are in a weird spot. we'll see how this goes first

## Media
<img width="643" height="177" alt="image" src="https://github.com/user-attachments/assets/58914f0c-9d7f-4597-a41c-62654ffac8a5" />

**Changelog**
:cl:
- tweak: insulated gloves are now labeled as engineering contraband. doorhackers take caution