### PR TITLE
fix: syndicate captain hardsuit storage

### DIFF
--- a/Resources/Maps/_starcup/loop.yml
+++ b/Resources/Maps/_starcup/loop.yml
@@ -93761,7 +93761,7 @@ entities:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
-- proto: SuitStorageCaptain
+- proto: SuitStorageCaptainSyndie
   entities:
   - uid: 14569
     components:

--- a/Resources/Maps/_starcup/omega.yml
+++ b/Resources/Maps/_starcup/omega.yml
@@ -76757,7 +76757,7 @@ entities:
     - type: Transform
       pos: -30.5,5.5
       parent: 2
-- proto: SuitStorageCaptain
+- proto: SuitStorageCaptainSyndie
   entities:
   - uid: 11772
     components:

--- a/Resources/Maps/_starcup/train.yml
+++ b/Resources/Maps/_starcup/train.yml
@@ -94331,7 +94331,7 @@ entities:
     - type: Transform
       pos: -13.5,-265.5
       parent: 2
-- proto: SuitStorageCaptain
+- proto: SuitStorageCaptainSyndie
   entities:
   - uid: 14156
     components:

--- a/Resources/Migrations/syndicate-migrations.yml
+++ b/Resources/Migrations/syndicate-migrations.yml
@@ -78,6 +78,7 @@
 #LockerCaptain: LockerCaptainSyndie
 #DresserCaptainFilled: DresserCaptainFilledSyndie
 #ToyFigurineCaptain: ToyFigurineCaptainSyndie
+#SuitStorageCaptain: SuitStorageCaptainSyndie
 #
 ## job specific: command
 #ClothingEyesGlassesCommand: ClothingEyesGlassesCommandSyndie

--- a/Resources/Prototypes/_starcup/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/Lockers/suit_storage.yml
@@ -1,3 +1,16 @@
+#Captain's hardsuit
+- type: entity
+  id: SuitStorageCaptainSyndie
+  parent: SuitStorageBase
+  suffix: Captain
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCaptainHardsuitSyndie
+  - type: AccessReader
+    access: [["Captain"]]
+
 #NanoTrasen EVA
 - type: entity
   id: SuitStorageEVANanotrasen

--- a/Resources/Prototypes/_starcup/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/Lockers/suit_storage.yml
@@ -2,7 +2,7 @@
 - type: entity
   id: SuitStorageCaptainSyndie
   parent: SuitStorageBase
-  suffix: Captain
+  suffix: Captain, Syndicate
   components:
   - type: EntityTableContainerFill
     containers:


### PR DESCRIPTION
creates a new fill prototype for the new syndicate captain's hardsuit, and replaces the old versions from loop, omega, and train with it

## Why / Balance
I forgot

**Changelog**
:cl:
- fix: loop, omega, and train should now have the correct captain's hardsuit mapped