### PR TITLE
fix: treat delta-v rocks as walls

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
@@ -43,6 +43,11 @@
     oreChance: 0.2
     oreRarityPrototypeId: RandomOreDistributionStandard
   - type: IsRoof # starcup: weather and lighting enhancements
+  - type: Tag # starcup: rock walls display correctly on station maps
+    tags:
+    - Wall
+  - type: PlacementReplacement # starcup: quick replacing
+    key: walls
 
 - type: entity
   id: MountainRockMining
@@ -104,6 +109,11 @@
     key: walls
     base: rock_
   - type: IsRoof # starcup: weather and lighting enhancements
+  - type: Tag # starcup: rock walls display correctly on station maps
+    tags:
+    - Wall
+  - type: PlacementReplacement # starcup: quick replacing
+    key: walls
 
 - type: entity
   id: AsteroidAltRockMining


### PR DESCRIPTION
Needed for quick-replacing walls with the entity spawn menu, and also for correctly rendering the station map.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->
<img width="580" height="536" alt="image" src="https://github.com/user-attachments/assets/0f6e50fe-1f1a-461a-8624-d88c36fb46ee" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Glacier's rock walls now display correctly on the station map.