### PR TITLE
feat: add flipped eyepatch to loadouts

### DIFF
--- a/Resources/Prototypes/_starcup/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Miscellaneous/glasses.yml
@@ -4,6 +4,11 @@
   equipment:
     eyes: ClothingEyesEyepatch
 
+- type: loadout
+  id: EyepatchFlipped
+  equipment:
+    eyes: ClothingEyesEyepatchFlipped
+
 # Sunglasses
 - type: loadout
   id: Sunglasses

--- a/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/loadout_groups.yml
@@ -265,6 +265,7 @@
   - Sunglasses
   - Glasses
   - Eyepatch
+  - EyepatchFlipped
   - GlassesJamjar
   - GlassesJensen
 
@@ -278,6 +279,7 @@
   - Sunglasses
   - Glasses
   - Eyepatch
+  - EyepatchFlipped
   - GlassesJamjar
   - GlassesJensen
 
@@ -289,6 +291,7 @@
   - Sunglasses
   - Glasses
   - Eyepatch
+  - EyepatchFlipped
   - GlassesJamjar
   - GlassesJensen
 
@@ -301,6 +304,7 @@
   - DiagnosticEyePatchHud
   - Glasses
   - Eyepatch
+  - EyepatchFlipped
   - GlassesJamjar
   - GlassesJensen
 
@@ -314,5 +318,6 @@
   - SecurityEyePatchHud
   - Glasses
   - Eyepatch
+  - EyepatchFlipped
   - GlassesJamjar
   - GlassesJensen


### PR DESCRIPTION
The right-side patch was on there so why not the left?

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added flipped eyepatches to loadouts alongside regular eyepatches.