### PR TITLE
fix: cargo shuttle for banana

### DIFF
--- a/Resources/Prototypes/_starcup/Maps/banana.yml
+++ b/Resources/Prototypes/_starcup/Maps/banana.yml
@@ -14,9 +14,7 @@
             !type:SyndicateNameGenerator
             prefixCreator: '-IMP-KDN'
         - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency.yml
-        - type: StationCargoShuttle
-          path: /Maps/_starcup/Shuttles/SYND_EmergencyShuttle.yml
+          emergencyShuttlePath: /Maps/_starcup/Shuttles/SYND_EmergencyShuttle.yml
         - type: StationJobs
           availableJobs:
             # command


### PR DESCRIPTION
I accidentally gave Banana the evac shuttle as the cargo shuttle.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Banana now has a cargo shuttle.