### PR TITLE
tweak: meteor rebalancing pass

### DIFF
--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -4,8 +4,8 @@
   id: MeteorSwarmDustEventsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    - id: GameRuleSpaceDustMinor
-    - id: GameRuleSpaceDustMajor
+    - id: GameRuleSpaceDustMinorStarcup # starcup: uses a variant that causes spacings less frequently
+    - id: GameRuleSpaceDustMajorStarcup # starcup: uses a variant that causes spacings less frequently
 
 - type: entityTable
   id: MeteorSwarmSmallChanceEventsTable
@@ -32,12 +32,14 @@
     - id: GameRuleMeteorSwarmSmall
     - id: GameRuleMeteorSwarmMedium
     - id: GameRuleMeteorSwarmLarge
-    - id: GameRuleUristSwarm
-    - id: GameRuleClownSwarm
-    - id: GameRuleCowSwarm
-    - id: GameRulePotatoSwarm
-    - id: GameRuleFunSwarm
-    - id: ImmovableRodSpawn
+# begin starcup
+#    - id: GameRuleUristSwarm
+#    - id: GameRuleClownSwarm
+#    - id: GameRuleCowSwarm
+#    - id: GameRulePotatoSwarm
+#    - id: GameRuleFunSwarm
+#    - id: ImmovableRodSpawn
+# end starcup
 
 - type: weightedRandomEntity
   id: MeteorSpawnAsteroidWallTable

--- a/Resources/Prototypes/_starcup/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -1,0 +1,15 @@
+# starcup: deals less impact / explosion damage. Two impacts are required to break a reinforced window.
+
+- type: entity
+  parent: MeteorSpaceDust
+  id: MeteorSpaceDustStarcup
+  components:
+  - type: Explosive
+    totalIntensity: 10
+    intensitySlope: 1
+    maxIntensity: 1.5
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 25

--- a/Resources/Prototypes/_starcup/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/_starcup/GameRules/meteorswarms.yml
@@ -1,0 +1,22 @@
+# Game Rules
+
+- type: entity
+  parent: GameRuleSpaceDustMinor
+  id: GameRuleSpaceDustMinorStarcup
+  components:
+  - type: StationEvent
+    earliestStart: 10 # starcup: increased from 2 -> 10, give engineers more time to set up power
+    minimumPlayers: 10 # starcup: increased from 0 -> 10
+  - type: MeteorSwarm
+    meteors:
+      MeteorSpaceDustStarcup: 1
+
+- type: entity
+  parent: GameRuleSpaceDustMajor
+  id: GameRuleSpaceDustMajorStarcup
+  components:
+  - type: StationEvent
+    minimumPlayers: 10 # starcup: increased from 0 -> 10
+  - type: MeteorSwarm
+    meteors:
+      MeteorSpaceDustStarcup: 1


### PR DESCRIPTION
Space Dust now deals significantly less damage (both on impact and for the explosion) and won't occur within the first 10 minutes of the round starting. Additionally, the gag meteors (Urists, Clowns, Potatoes, etc) have been disabled to fit in with the tone of the server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
Space Dust events have been causing issues for a while now due to their destructive power, overwhelming engineers with structural damage and spacings and leading to player burnout. Currently, Space Dust meteors deal 100 Blunt damage on impact and then explode in a 3x3 pattern which deals 25 Blunt, 25 Pierce, and 25 Heat to the center tile. Both the initial impact and the explosion deal enough damage to shatter reinforced windows, causing significant spacing issues with relative frequency. Because some parts of the station can't be given shielding due to needing to allow movement in and out by shuttles / salvagers / etc, this leads to areas like arrivals and evac being spaced more often than is practical for our population to handle. Furthermore, it turns out there are *two* separate gamerules that can spawn Space Dust, and the "minor" version is capable of running as early as *two minutes* into the round - far earlier than any engineer could reasonably be expected to have time to deal with it.

To solve these issues, the following changes have been made:
- Space Dust and GameRuleSpaceDustMinor have been replaced with starcup variants modified for our purposes
- Space Dust now deals a quarter of its original impact damage (100 Blunt -> 25 Blunt)
- Space Dust's explosion on impact now deals a total of 15 Blunt, 15 Pierce, and 15 Heat (45 total)
- GameRuleSpaceDustMinor now cannot run before 10 minutes have passed

Additionally, the following meteors have been disabled from the BasicMeteorSwarmEventsTable due to being a little too silly for the tone we'd like to set. These meteors are:
- GameRuleUristSwarm
- GameRuleClownSwarm
- GameRuleCowSwarm
- GameRulePotatoSwarm
- GameRuleFunSwarm
- ImmovableRodSpawn

## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
MeteorSpaceDustStarcup (parented to MeteorSpaceDust) has been added, and GameRuleSpaceDustMinorStarcup / GameRuleSpaceDustMajorStarcup (parented to their respective gamerules) have been added using the new starcup prototype. Changes were made in this way to preserve them through upstream patches. Additionally, MeteorSwarmDustEventsTable was updated to use the new starcup gamerules.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: space dust deals significantly less damage
- tweak: space dust events will not occur earlier than 10 minutes
- remove: disabled some meteor events to preserve tone