### PR TITLE
fix: space dust explodes on contact

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -3,13 +3,21 @@
 - type: entity
   parent: MeteorSpaceDust
   id: MeteorSpaceDustStarcup
+  name: space dust starcup
   components:
-  - type: Explosive
-    totalIntensity: 10
-    intensitySlope: 1
-    maxIntensity: 1.5
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 25
+    - type: Explosive
+      totalIntensity: 10
+      intensitySlope: 1
+      maxIntensity: 1.5
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 25
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+            - !type:PlaySoundBehavior
+              sound:
+                collection: MetalBreak
+            - !type:ExplodeBehavior


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
My previous PR overwrote the new Space Dust prototype's Destructible component entirely rather than overwriting only the variable adjusted. This meant the new meteor would not be destroyed on contact with an entity, but would instead deal 25 Blunt continuously to it and never despawn or explode. This PR fixes that behavior.

Additionally, I've given the new prototype a name to make it easier to differentiate from the old Space Dust prototype in the Entity Spawn Menu.

## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
Added the Destruction, Play Sound, and Explode behaviors to the Destructible component's Damage Trigger. This is effectively a copy-paste of the original prototype's code, but it's necessary to make the new prototype function.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: space dust explodes on contact