### PR TITLE
tweak: main generator adjustments

### DIFF
--- a/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
+++ b/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
@@ -67,7 +67,7 @@ public sealed partial class RadiationReactiveGas
     ///     Set to zero if the reactant does not deplete
     /// </remarks>
     [DataField]
-    public float ReactantBreakdownRate = 1f;
+    public float ReactantBreakdownRate = 0.8f; // starcup: increase time to refill
 
     /// <summary>
     ///     A byproduct gas that is generated when the reactant breaks down

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -89,7 +89,7 @@
     thresholds:
       - trigger: # Excess damage, don't spawn entities
           !type:DamageTrigger
-          damage: 400
+          damage: 600 # starcup: increase time to repair, was 400
         behaviors:
           - !type:PlaySoundBehavior
             sound:
@@ -98,7 +98,7 @@
             acts: ["Destruction"]
       - trigger:
           !type:DamageTrigger
-          damage: 225
+          damage: 500 # starcup: increase time to repair, was 225
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]


### PR DESCRIPTION
Makes radiation collectors consume plasma at 0.8x the rate and gives tesla coils a little over twice as much HP. 

## Why / Balance
Generator maintenance has drastic consequences if overlooked and demands a lot of our engineers' time; we already have few engineers some shifts and they are often very busy with space debris and other engineering-related events. This pushes the time to refill/repair further back to give engineers more time to RP and relax. 

Singularities have a time to refill for most setups of around 45 minutes. I intended to make the plasma consumption rate 0.75 to push it to about an hour, but balance concerns with "demon cores" (other radiation sources) compels me to make it slightly less of a buff.

A 4-coil, 4-rod tesla setup destroys its coils in about 40 minutes; they reach half health in 20. Doubling (+ some) their health means 40 minutes becomes the time to repair, and it's nearly an hour and a half before coils are destroyed.

**Changelog**
:cl:
- tweak: Singulo/tesla generator numbers have been tweaked to give engineers more time between repairs and refills.
