### PR TITLE
perf: track all previous tiles for vapor entities

### DIFF
--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -7,11 +7,14 @@ namespace Content.Server.Chemistry.Components
     {
         public const string SolutionName = "vapor";
 
+        // begin starcup: track all previous tiles
         /// <summary>
-        /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
+        /// Stores data on the previously reacted tiles. We only want to do reaction checks once per tile.
         /// </summary>
         [DataField]
-        public TileRef? PreviousTileRef;
+        public HashSet<TileRef?> PreviousTileRefs = [];
+        // public TileRef? PreviousTileRef;
+        // end starcup
 
         /// <summary>
         /// Percentage of the reagent that is reacted with the TileReaction.

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -116,8 +116,11 @@ namespace Content.Server.Chemistry.EntitySystems
 
                     // Check if the tile is a tile we've reacted with previously. If so, skip it.
                     // If we have no previous tile reference, we don't return so we can save one.
-                    if (vaporComp.PreviousTileRef != null && tile == vaporComp.PreviousTileRef)
+                    // begin starcup: track all previous tiles
+                    // if (vaporComp.PreviousTileRef != null && tile == vaporComp.PreviousTileRef)
+                    if (vaporComp.PreviousTileRefs.Contains(tile))
                         continue;
+                    // end starcup
 
                     // Enumerate over all the reagents in the vapor entity solution
                     foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((uid, container)))
@@ -161,7 +164,10 @@ namespace Content.Server.Chemistry.EntitySystems
                     }
 
                     // Set the previous tile reference to the current tile
-                    vaporComp.PreviousTileRef = tile;
+                    // begin starcup: track all previous tiles
+                    // vaporComp.PreviousTileRef = tile;
+                    vaporComp.PreviousTileRefs.Add(tile);
+                    // end starcup
                 }
             }
         }


### PR DESCRIPTION
CleanDecalsReaction appears to be very costly. A temporary embargo has been placed on space cleaner in our live rounds over it. I have no way of gathering traces with enough granularity to figure it out exactly, but we're already attempting to cache previous tile reactions in a way that definitely does not work. This change improves that in with the hope that the performance cost becomes negligible.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Hopefully improved space cleaner-related lag.