### PR TITLE
fix: add random lockbox spawner to migrations

### DIFF
--- a/Resources/Migrations/starcup-migrations.yml
+++ b/Resources/Migrations/starcup-migrations.yml
@@ -40,3 +40,4 @@ CrateLockBoxMedical: null
 CrateLockBoxScience: null
 CrateLockBoxSecurity: null
 CrateLockBoxService: null
+LootSpawnerRandomLockbox: null


### PR DESCRIPTION
Random lockbox spawner seems to have been missed in https://github.com/teamstarcup/starcup/pull/328, this adds it; there was one mapped on Reach I noticed. 

If there's some reason to avoid using migrations on spawners/this was purposefully excluded then let me know.