### PR TITLE
fix: add warp command permission

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -92,3 +92,9 @@
 - Flags: ADMINCHAT
   Commands:
     - achatwindow
+
+# begin starcup
+- Flags: ADMIN
+  Commands:
+  - warp
+# end starcup


### PR DESCRIPTION
The `warp` command did not have a permission flag until now. You need `AdminFlags.ADMIN` to use it.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
