### PR TITLE
fix: pos command perm

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -71,6 +71,9 @@
   - print_pvs_ack
   - pvs_override_info
   - merge_grids
+  # begin starcup
+  - pos
+  # end starcup
 
 
 - Flags: MAPPING


### PR DESCRIPTION
The `pos` command was lacking a permission flag. This sets it to `DEBUG`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
