### PR TITLE
tweak: add slime metabolism clarification in guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/_starcup/SlimePersonStarcup.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/_starcup/SlimePersonStarcup.xml
@@ -16,6 +16,7 @@
   - Immune to the effects of being splashed with acid
   - Passively heal Blunt and Heat damage more effectively
   - Have a 2x3 storage grid inside of their body
+  - Metabolize ethanol 2.5x faster than most species, making them more resistant to ethanol poisoning
 
   ## Naming Traditions
   Slimes lack any strong naming tradition, typically borrowing from local cultures instead.


### PR DESCRIPTION
did you know slimes metabolize ethanol with a 0.25 rate modifier instead of the 0.1 of almost every other species? I didn't! so I included a line for it in their guidebook entry

## Why / Balance
it seems like useful information to know, and the less is made invisible about the way your character's species works the better

**Changelog**
:cl:
- tweak: the faster rate at which slime metabolisms process ethanol has been noted in their species guidebook entry