### PR TITLE
tweak: shrink decal chunk size from 32 to 8

### DIFF
--- a/Content.Shared/Decals/SharedDecalSystem.cs
+++ b/Content.Shared/Decals/SharedDecalSystem.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.Decals
 
         // Note that this constant is effectively baked into all map files, because of how they save the grid decal component.
         // So if this ever needs changing, the maps need converting.
-        public const int ChunkSize = 32;
+        public const int ChunkSize = 8;  // starcup: 32 -> 8 for performance
         public static Vector2i GetChunkIndices(Vector2 coordinates) => new ((int) Math.Floor(coordinates.X / ChunkSize), (int) Math.Floor(coordinates.Y / ChunkSize));
 
         public override void Initialize()


### PR DESCRIPTION
Decals are somewhat heavy to serialize and networking 2400 decals in 105 KB synchronously to a bunch of players across entirely exclusive potentially visible sets is fantastically infeasible.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

<img width="1046" height="742" alt="image" src="https://github.com/user-attachments/assets/7b4889b8-9b28-4fa8-a4c1-5a5e93696f17" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Hopefully mitigated decal-related lag by shrinking chunk sizes.