### PR TITLE
fix: give access configurators the new access levels

### DIFF
--- a/Resources/Locale/en-US/_starcup/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_starcup/prototypes/access/accesses.ftl
@@ -1,6 +1,6 @@
 id-card-access-level-psychologist = Psychologist
 
-id-card-access-brigmedic = Combat Medic
+id-card-access-level-brigmedic = Combat Medic
 
 id-card-access-level-boxer = Boxer
 id-card-access-level-clown = Clown

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -53,6 +53,7 @@
       - GenpopLeave
       # begin starcup additions
       - Boxer
+      - Brigmedic
       - Clown
       - Library
       - Mime
@@ -143,6 +144,19 @@
     - Xenoborg
     - GenpopEnter
     - GenpopLeave
+    # begin starcup additions
+    - Boxer
+    - Brigmedic
+    - Clown
+    - Library
+    - Mime
+    - Musician
+    - Paramedic
+    - Psychologist
+    - Reporter
+    - Robotics
+    - Zookeeper
+    # end starcup
     privilegedIdSlot:
       name: id-card-console-privileged-id
       startingItem: UniversalIDCard


### PR DESCRIPTION
quick hotfix cuz I forgot to give the base access configurator the new brigmedic access, also forgot to give the universal configurator any of them because I didn't realize you needed to do that

also fixes a typo in the ftl file that made the combat medic's access level display incorrectly oops

**Changelog**
:cl:
- fix: the access configurator has had missing access levels added
- fix: the combat medic's access level now displays its name properly