### PR TITLE
tweak: add floodlights to engivend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -9,6 +9,7 @@
     PowerCellMedium: 5
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
+    Floodlight: 2 # starcup
     ClothingHeadHatCone: 4
   contrabandInventory:
     CowToolboxFilled: 1


### PR DESCRIPTION
Adds two floodlights to the engivend. Currently they're only obtainable if mapped or salvage grabs them, but it's usually not something worth asking salvage in advance for. They're both cute to set up and helpful for working in areas without power as engi.

## Media
<img width="633" height="445" alt="safetyimportant" src="https://github.com/user-attachments/assets/3382f8ef-3e33-4182-8f8e-505eaf6c756d" />

**Changelog**
:cl:
- tweak: Engivends now contain floodlights. 
