### PR TITLE
tweak: change slime water damage type to caustic

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -82,7 +82,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Caustic: 0.15 # starcup: changed from heat
+            Caustic: 0.15 # starcup: changed damage type from heat
       - !type:PopupMessage
         type: Local
         messages: [ "slime-hurt-by-water-popup" ]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -82,7 +82,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.15
+            Caustic: 0.15 # starcup: changed from heat
       - !type:PopupMessage
         type: Local
         messages: [ "slime-hurt-by-water-popup" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -91,7 +91,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.1
+            Caustic: 0.1 # starcup: changed from heat
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -91,7 +91,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Caustic: 0.1 # starcup: changed from heat
+            Caustic: 0.1 # starcup: changed damage type from heat
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -484,7 +484,7 @@
           shouldHave: true
         damage:
           types:
-            Heat: 3
+            Caustic: 3 # starcup: changed damage type from heat
 
 - type: reagent
   id: Ice


### PR DESCRIPTION
just changes the damage type in the slime prototypes to caustic from heat

## Why / Balance
the heat damage from water is often small enough that it's nearly always fully healed thanks to slimes' increased health regen. it's also an uncommon enough interaction that I think it deserves to be a little more impactful when it does come up

**Changelog**
:cl:
- tweak: water (and water vapor) now deals caustic damage to slime people instead of heat