### PR TITLE
fix: fix loop metadata failing to parse

### DIFF
--- a/Resources/Maps/_starcup/loop.yml
+++ b/Resources/Maps/_starcup/loop.yml
@@ -55,7 +55,6 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: Map Entity
     - type: Transform
     - type: Map
       mapPaused: True


### PR DESCRIPTION
there was a name line underneath the metadata component on loop's yml that I don't think needs to be there and was making our tests unhappy. removed it int he hopes that it clears that upown. -->

**Changelog**
internal change, no cl