### PR TITLE
fix: extend wallmount interact distance

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -86,5 +86,11 @@ public enum CollisionGroup
     // FlyingMob can go past
     FullTileLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
 
-    SubfloorMask = Impassable | LowImpassable
+    SubfloorMask = Impassable | LowImpassable,
+
+    // begin starcup: wallmount layer for fixing interact distance
+    // Wallmount
+    WallmountMask = Impassable | LowImpassable,
+    WallmountLayer = Opaque | BulletImpassable
+    // end starcup
 }

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
@@ -21,7 +21,7 @@
         - WallmountMask
         layer:
         - WallmountLayer
-  # end starcupsas
+  # end starcup
   - type: Clickable
   - type: WallMount
   - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
@@ -6,8 +6,22 @@
     snap:
     - Wallmount
   components:
+  # begin starcup: extend wallmount interact range
   - type: Physics
+    bodyType: Static
     canCollide: false
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.00"
+        density: 200
+        mask:
+        - WallmountMask
+        layer:
+        - WallmountLayer
+  # end starcupsas
   - type: Clickable
   - type: WallMount
   - type: InteractionOutline


### PR DESCRIPTION
gives the base wallmount prototype a physics fixture so wallmounts can be interacted with from across tables/counters/etc. soft port of [wizden#38802](https://redirect.github.com/space-wizards/space-station-14/pull/38802)

## Why / Balance
the standard interact range should be 1.5 tiles, but there are a variety of situations as illustrated in [wizden#37741](https://redirect.github.com/space-wizards/space-station-14/issues/37741) where it gets shortened for some inexplicable reason; thus, the fact that you can't interact with wallmounts across tables and the like is fully a bug

this makes life very difficult for many reasons and creates a bunch of really finicky annoying mapping constraints for things like fire alarms, apcs, and shelves. this should allow for much, much greater flexibility in layouts and generally make things tidier

## Technical details
adds a new wallmount physics layer/mask.

## Media
<img width="254" height="184" alt="image" src="https://github.com/user-attachments/assets/ef7a97be-97f3-4e60-a72f-380c43a60cc2" />

**Changelog**
:cl:
- fix: the interact range on wallmounts has been extended, and can now cross single-tile gaps (tables, machines, etc)