### PR TITLE
feat: bar signs emit light

### DIFF
--- a/Content.Shared/BarSign/BarSignPrototype.cs
+++ b/Content.Shared/BarSign/BarSignPrototype.cs
@@ -20,4 +20,9 @@ public sealed partial class BarSignPrototype : IPrototype
 
     [DataField]
     public bool Hidden { get; private set; }
+
+    // begin starcup: bar signs emit light
+    [DataField]
+    public Color Color { get; private set; }
+    // end starcup
 }

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -39,6 +39,21 @@
   - type: Wires
     boardName: wires-board-name-barsign
     layoutId: BarSign
+  # begin starcup: bar signs emit light
+  - type: LitOnPowered
+  - type: PointLight
+#    color: "#882a55"
+    radius: 10
+    energy: 6
+    enabled: false
+    mask: /Textures/Effects/LightMasks/cone.png
+    autoRot: true
+    offset: "0, 0.3"
+    castShadows: false
+  # end starcup
+  - type: PlacementReplacement  # starcup
+    key: light
+
 
 - type: entity
   parent: BaseBarSign

--- a/Resources/Prototypes/bar_signs.yml
+++ b/Resources/Prototypes/bar_signs.yml
@@ -14,6 +14,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thesingulo
   description: barsign-prototype-description-singulo
+  color: "#b800aa" # starcup
 
 - type: barSign
   id: TheDrunkCarp
@@ -22,6 +23,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thedrunkcarp
   description: barsign-prototype-description-drunk-carp
+  color: "#660300" # starcup
 
 - type: barSign
   id: OfficerBeersky
@@ -30,6 +32,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: officerbeersky
   description: barsign-prototype-description-officer-beersky
+  color: "#660300" # starcup
 
 - type: barSign
   id: TheOuterSpess
@@ -38,6 +41,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: theouterspess
   description: barsign-prototype-description-outer-spess
+  color: "#146656" # starcup
 
 - type: barSign
   id: TheCoderbus
@@ -46,6 +50,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thecoderbus
   description: barsign-prototype-description-coderbus
+  color: "#404040" # starcup
 
 - type: barSign
   id: RobustaCafe
@@ -54,6 +59,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: robustacafe
   description: barsign-prototype-description-robusta-cafe
+  color: "#802323" # starcup
 
 - type: barSign
   id: EmergencyRumParty
@@ -62,6 +68,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: emergencyrumparty
   description: barsign-prototype-description-emergency-rum-party
+  color: "#520005" # starcup
 
 - type: barSign
   id: ComboCafe
@@ -70,6 +77,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: combocafe
   description: barsign-prototype-description-combo-cafe
+  color: "#006600" # starcup
 
 - type: barSign
   id: TheAleNath
@@ -78,6 +86,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thealenath
   description: barsign-prototype-description-ale-nath
+  color: "#660300" # starcup
 
 - type: barSign
   id: TheNet
@@ -86,6 +95,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thenet
   description: barsign-prototype-description-the-net
+  color: "#0d8a00" # starcup
 
 - type: barSign
   id: MaidCafe
@@ -94,6 +104,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: maidcafe
   description: barsign-prototype-description-maid-cafe
+  color: "#660000" # starcup
 
 - type: barSign
   id: MalteseFalcon
@@ -102,6 +113,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: maltesefalcon
   description: barsign-prototype-description-maltese-falcon
+  color: "#660000" # starcup
 
 - type: barSign
   id: TheSun
@@ -110,6 +122,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thesun
   description: barsign-prototype-description-the-sun
+  color: "#e86800" # starcup
 
 - type: barSign
   id: TheBirdCage
@@ -118,6 +131,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: birdcage
   description: barsign-prototype-description-the-birdcage
+  color: "#664b00" # starcup
 
 - type: barSign
   id: Zocalo
@@ -126,6 +140,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: zocalo
   description: barsign-prototype-description-zocalo
+  color: "#8e677a" # starcup
 
 - type: barSign
   id: LV426
@@ -134,6 +149,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: lv426
   description: barsign-prototype-description-lv426
+  color: "#0c6166" # starcup
 
 - type: barSign
   id: WiggleRoom
@@ -142,6 +158,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: thewiggleroom
   description: barsign-prototype-description-wiggle-room
+  color: "#660300" # starcup
 
 - type: barSign
   id: TheLightbulb
@@ -150,6 +167,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: the_lightbulb
   description: barsign-prototype-description-the-lightbulb
+  color: "#97994e" # starcup
 
 - type: barSign
   id: Goose
@@ -158,6 +176,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: goose
   description: barsign-prototype-description-goose
+  color: "#660000" # starcup
 
 - type: barSign
   id: EngineChange
@@ -166,6 +185,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: enginechange
   description: barsign-prototype-description-enginechange
+  color: "#b30086" # starcup
 
 - type: barSign
   id: Emprah
@@ -174,6 +194,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: emprah
   description: barsign-prototype-description-emprah
+  color: "#21660c" # starcup
 
 - type: barSign
   id: Spacebucks
@@ -182,6 +203,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: spacebucks
   description: barsign-prototype-description-spacebucks
+  color: "#296648" # starcup
 
 - type: barSign
   id: Maltroach
@@ -190,6 +212,7 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: maltroach
   description: barsign-prototype-description-maltroach
+  color: "#42665f" # starcup
 
 - type: barSign
   id: WhiskeyEchoes
@@ -198,3 +221,4 @@
     sprite: Structures/Wallmounts/barsign.rsi
     state: whiskeyechoes
   description: barsign-prototype-description-whiskeyechoes
+  color: "#660300" # starcup


### PR DESCRIPTION
Make bar signs emit light.

Since each sign variant can have different colors, the color of the emitted light is set in each BarSignPrototype instance.

Known issues:
- light color does not function well with animations that change their primary color

Complements #413 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

<img width="50%" height="50%" alt="incomplete bar sign gallery" src="https://github.com/user-attachments/assets/cfb1ef25-17ea-47e0-ad41-9f23807e4774" />

<img width="50%" height="50%" alt="emergency rum party bar sign" src="https://github.com/user-attachments/assets/ed9f05f5-72d1-481d-8988-637bfbf3d546" />


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Bar signs now emit light.