### PR TITLE
feat: re-adds the bioluminescence plant mutation

### DIFF
--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -1,7 +1,8 @@
 - type: RandomPlantMutationList
   id: RandomPlantMutations
   mutations:
-    # disabled until 50 morbillion point lights don't cause the renderer to die # starcup: reenabled since it doesn't seem to kill the renderer anymore
+    # disabled until 50 morbillion point lights don't cause the renderer to die
+    # starcup: reenabled since it doesn't seem to kill the renderer anymore
     - name: Bioluminescent
       description: mutation-plant-bioluminescent
       baseOdds: 1


### PR DESCRIPTION
the mutation was disabled due to issues with the lighting renderer (see [wizden#32561](https://redirect.github.com/space-wizards/space-station-14/pull/32561)) about a year ago, but it seems like changes to the lighting renderer have remedied these problems.

## Why / Balance
glowy plants are nice, and the content is already in the game anyways. no reason to not put it back in if it works now!

## Media
<img width="262" height="359" alt="image" src="https://github.com/user-attachments/assets/0bc63279-43c8-41c8-b953-22eb692719e6" />

**Changelog**
:cl:
- add: re-added the bioluminescent mutation for plants