### PR TITLE
tweak: move bartender's combat gear to cabinet (and rename it)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -6,7 +6,7 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillLockerBooze
+        tableId: FillLockerBartender # starcup: new fill
 
 - type: entityTable
   id: FillLockerBooze

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -14,9 +14,9 @@
     ClothingUniformNightclubSuitSkirt: 2 #imp
     ClothingUniformJumpsuitBartenderPurple: 2
     ClothingShoesColorBlack: 2
-    ClothingOuterArmorBasicSlim: 2
+    # ClothingOuterArmorBasicSlim: 2 # starcup: remove combat gear
     ClothingOuterVest: 2
-    ClothingBeltBandolier: 2
+    # ClothingBeltBandolier: 2 # starcup: remove combat gear
     ClothingEyesGlassesSunglasses: 2
   contrabandInventory:
     ToyFigurineBartender: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -2,13 +2,11 @@
   id: BoozeOMatInventory
   startingInventory:
     DrinkGlass: 10 #Kept glasses at top for ease to differentiate from booze. # starcup: reduced number
+    DrinkGlassHighball: 10 # starcup
+    DrinkGlassOldFashioned: 10 # starcup
+    DrinkGlassCocktail: 10 # starcup
     DrinkShotGlass: 10
     DrinkGlassCoupeShaped: 10
-    # begin starcup additions
-    DrinkGlassHighball: 10
-    DrinkGlassOldFashioned: 10
-    DrinkGlassCocktail: 10
-    # end starcup additions
     DrinkVacuumFlask: 5
     DrinkFlaskBar: 5
     DrinkShaker: 5
@@ -16,6 +14,8 @@
     DrinkIceBucket: 2
     Skimmer: 2 # DeltaV - adds skimmer
     BarSpoon: 3
+    RagItem: 2 # starcup
+    HandLabeler: 2 # starcup
     CustomDrinkJug: 2 #to allow for custom drinks in the soda/booze dispensers
     DrinkAbsintheBottleFull: 2
     DrinkAleBottleFull: 5

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -2,7 +2,7 @@
   id: LockerBooze
   parent: LockerBase
   name: bartender's cabinet # starcup: renamed for clarity
-  description: This is where the bartender keeps their personal equipment. # starcup: renamed for clarity
+  description: This is where the bartender keeps their personal equipment. # starcup: rewritten for clarity
   components:
   - type: Appearance
   - type: EntityStorageVisuals

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -1,8 +1,8 @@
 - type: entity
   id: LockerBooze
   parent: LockerBase
-  name: booze storage
-  description: This is where the bartender keeps the booze.
+  name: bartender's cabinet # starcup: renamed for clarity
+  description: This is where the bartender keeps their personal equipment. # starcup: renamed for clarity
   components:
   - type: Appearance
   - type: EntityStorageVisuals

--- a/Resources/Prototypes/_starcup/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/Lockers/service.yml
@@ -1,0 +1,26 @@
+- type: entity
+  id: LockerBoozeFilledNoGun
+  suffix: Filled, No Gun
+  parent: LockerBooze
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillLockerBartenderNoGun # starcup: new fill
+
+- type: entityTable
+  id: FillLockerBartenderNoGun
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterArmorBasicSlim
+    - id: BoxBeanbag
+      amount: 2
+    - id: ClothingBeltBandolier
+
+- type: entityTable
+  id: FillLockerBartender
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: FillLockerBartenderNoGun
+    - id: WeaponShotgunDoubleBarreledRubber


### PR DESCRIPTION
renames the "booze storage" cabinet to "bartender's cabinet" and rewrites its description, relocates the armor vest and bandolier from the bardrobe into it, removes everything else, and places the damp rag and hand labeler into the booze-o-mat

also adds a new filled prototype without the gun in it, in case mappers want to use the filled version of the bartender shotgun cabinet I made a little while back

## Why / Balance
first off, it's not _booze_ storage! there's no booze in it! the beer bottles don't even have beer in them!!!

also it has confusingly redundant contents, with most of it being available from the booze-o-mat or bardrobe, which are usually pretty much right next to the cabinet. I think it makes most sense for it, being an id-locked storage unit, to be where the bartender's specialized combat gear is, and I've thus also removed the armor vest and bandolier from the drobe. you get one each, and if you lose them somehow, that's between you and security

**Changelog**
:cl:
- tweak: the booze storage cabinet has had its name and description changed to not be an outright lie
- tweak: some of the bartender's equipment has been relocated between various storage areas