### PR TITLE
fix: test failures from mail teleports

### DIFF
--- a/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
+++ b/Content.Server/_DV/Mail/EntitySystems/MailSystem.cs
@@ -660,7 +660,7 @@ namespace Content.Server._DV.Mail.EntitySystems
 
             if (candidateList.Count <= 0)
             {
-                _sawmill.Error("List of mail candidates was empty!");
+                // _sawmill.Error("List of mail candidates was empty!"); // starcup
                 return;
             }
 


### PR DESCRIPTION
Nyano code no longer generates test failures from `_log.Error` when attempting to create mail when nobody is around.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
snore