### PR TITLE
fix: all mimes now start with a survival box

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -82,6 +82,13 @@
     - Dwarf
     - Human
     - Reptilian
+    # begin starcup changes
+    - Felinid
+    - Harpy
+    - Oni
+    - Vulpkanin
+    - Rodentia
+    # end starcup changes
 
 - type: loadoutEffectGroup
   id: OxygenBreatherMimeMoth


### PR DESCRIPTION
Survival box loadouts are split by species due to some having unique needs, such as nitrogen instead of oxygen or cotton-based food instead of a standard PSB. Notably, the Mime job has its own species list due to mime survival boxes having a croissant by default upstream, and it seems we didn't update this list properly to include new species.

Whoops.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
Currently, half our species start with a survival box as a mime and half don't. That's obviously not intended and needs to be fixed.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: all mimes now start with a survival box