### PR TITLE
fix: re-remove bioluminescent mutation

### DIFF
--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -2,12 +2,11 @@
   id: RandomPlantMutations
   mutations:
     # disabled until 50 morbillion point lights don't cause the renderer to die
-    # starcup: reenabled since it doesn't seem to kill the renderer anymore
-    - name: Bioluminescent
-      description: mutation-plant-bioluminescent
-      baseOdds: 1
-      appliesToPlant: false
-      effect: !type:Glow
+    #- name: Bioluminescent
+    #  description: mutation-plant-bioluminescent
+    #  baseOdds: 0.036
+    #  appliesToPlant: false
+    #  effect: !type:Glow
     - name: Sentient
       description: mutation-plant-sentient
       baseOdds: 0.0072


### PR DESCRIPTION
it turned out I was not rigorous enough in my testing when speedmerging #450 and it still caused unpleasant bugs. my bad!!

**Changelog**
:cl:
- remove: the bioluminescent botany trait has been removed again after it was revealed to still cause lighting errors