### PR TITLE
tweak: remove tc drop from renault, let her become sentient

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -616,6 +616,10 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalRenault
+  # begin starcup: add sentience target
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-organic
+  # end starcup
 
 - type: entity
   name: Hamlet

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -602,8 +602,10 @@
     spawned:
     - id: FoodMeat
       amount: 3
-    - id: Telecrystal5
-      amount: 1
+    # begin starcup: remove tc
+    # - id: Telecrystal5
+    #   amount: 1
+    # end starcup
   - type: Grammar
     attributes:
       proper: true


### PR DESCRIPTION
removes the telecrystal drop from butchering renault, and also adds the `SentienceTarget` component so she can be targeted by sentience events.

## Why / Balance
in addition to just kinda being a gigantic tone-lurching bummer that you're incentivized to carve up the cute fox, the telecrystal thing feels very inside baseball in a way that I'm not a fan of; there shouldn't be a secret bonus objectives every traitor basically has but that no one gets told about. that's not fun

the sentience thing is because foxcurl asked me to very nicely

**Changelog**
:cl:
- remove: butchering renault no longer gives additional telecrystals
- feat: renault can now be targeted by random sentience events