### PR TITLE
fix: assorted writing fixes

### DIFF
--- a/Resources/Locale/en-US/_starcup/advertisements/vending/sectech.ftl
+++ b/Resources/Locale/en-US/_starcup/advertisements/vending/sectech.ftl
@@ -1,6 +1,6 @@
 advertisement-sectech-starcup-1 = Remember, if SyndComm tells you to shoot the Captain, you can. And must.
 advertisement-sectech-starcup-2 = Just because the China Lake has a Syndie label doesn't make it okay for the cadet to have it.
 advertisement-sectech-starcup-3 = Think of yourself as a Service employee. With a stun baton.
-advertisement-sectech-starcup-4 = Remember the Tunnel Uprisings of Year 54 ANC. Remember that you lost.
+advertisement-sectech-starcup-4 = Remember the Security Uprisings of Year 54 ANC. Remember that you lost.
 thankyou-sectech-starcup-1 = Good luck, and stay sharp!
 thankyou-sectech-starcup-2 = Remember, you can't arrest the felinid Janitor for saying 'nyaa'. Not in Syndicate systems.

--- a/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
+++ b/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
@@ -1,6 +1,7 @@
 cargo-gifts-event-announcement = Congratulations! { $sender } has decided to send { $description } to the station { $dest }. Look for it in your next cargo shipment.
 cargo-gift-default-description = A bundle of gifts
-cargo-gift-default-sender = NanoTrasen
+# starcup: changed default sender from NanoTrasen to SyndComm
+cargo-gift-default-sender = SyndComm
 cargo-gift-default-dest = Logistics Dept.
 
 cargo-gift-dest-bar = bar

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -295,7 +295,7 @@
   name: filet migrawr
   parent: FoodMealBase
   id: FoodMealBearsteak
-  description: Because eating bear wasn't manly enough.
+  description: The only steak capable of causing forest fires. # starcup: rewritten for tone
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -76,8 +76,8 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: StationRecordsComputerCircuitboard
-  name: station records computer board
-  description: A computer printed circuit board for a station records computer.
+  name: employee records computer board # starcup: renamed for clarity
+  description: A computer printed circuit board for an employee records computer. # starcup: renamed for clarity
   components:
     - type: Sprite
       sprite: _starcup/Objects/Misc/module.rsi # starcup: command recolors

--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -286,7 +286,7 @@
 - type: entity
   id: BedsheetBrigmedic
   parent: BedsheetBase
-  name: cobmat medic's bedsheet # starcup: rename brigmedic to combat medic
+  name: combat medic's bedsheet # starcup: rename brigmedic to combat medic
   description: Not worse than cotton.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -413,8 +413,8 @@
 - type: entity
   parent: BaseComputerAiAccess
   id: ComputerStationRecords
-  name: station records computer
-  description: This can be used to check station records.
+  name: employee records computer # starcup: renamed for clarity
+  description: This can be used to check employee records. # starcup: renamed for clarity
   components:
   - type: GeneralStationRecordConsole
   - type: UserInterface


### PR DESCRIPTION
fixed a typo, renamed the station records computer to employee records computer, rewrote the bear steak description to a slightly less cringy joke, and fixed the default cargo gifts sender still being nanotrasen

## Why / Balance
mostly just housekeeping; the station records computer thing is to help make it clear that you view employee records on it and not the other two types

**Changelog**
:cl:
- fix: handled some assorted typos and other writing mishaps (no more pizza parties from nanotrasen!)
- tweak: renamed the station records computer to the employee records computer for clarity