### PR TITLE
tweak: nudge up ethanol contents of absinthe cocktails

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1682,7 +1682,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.13 # increased from 0.06
+        amount: 0.14 # increased from 0.06
   # end starcup
 
 - type: reagent
@@ -2622,7 +2622,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.22 # starcup: decreased from 0.3
+        amount: 0.25 # starcup: decreased from 0.3
 
 - type: reagent
   id: Empress75
@@ -2719,7 +2719,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.16 # starcup: decreased from 0.3
+        amount: 0.17 # starcup: decreased from 0.3
 
 - type: reagent
   id: WhiskeySour


### PR DESCRIPTION
very slightly increases the ethanol numbers on cocktails that use absinthe as an ingredient (except for bacchus's, whose ethanol content is nonsensical on purpose). this specifically affects monkey business, death in the afternoon, and the sun always rises

## Why / Balance
[wizden#34371](https://redirect.github.com/space-wizards/space-station-14/pull/34371) effectively gave absinthe an extra 0.05 ethanol content, and so this ensures cocktails' proportionality with their component ingredients' ethanol contents as per #204! these might be very small numbers-wise, but with ethanol, very slight nudges can possibly come up!

**Changelog**
:cl:
- tweak: cocktails with absinthe (except bacchus's) have had their ethanol content very, very slightly increased to match absinthe's slight bump in ethanol