### PR TITLE
feat: add ammonia bottle

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/chemistry-bottles.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: ChemistryBottleAmmonia # just for prisoners and similar limited scenarios
+  suffix: ammonia
+  parent: BaseChemistryBottleFilled
+  components:
+  - type: Label
+    currentLabel: reagent-name-ammonia
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Ammonia
+          Quantity: 30


### PR DESCRIPTION
Added an autofill 30u bottle of ammonia, so ammonia bottles can be mapped to areas.

## Why / Balance
It is advantageous to allow prisoners to access ammonia, as it and ethanol can give them access to some largely harmless chemistry, but the ingredients to make ammonia are too volatile to offer them.

**Changelog**
:cl:
- tweak: added ammonia bottle