### PR TITLE
tweak: borgs are opened with screwdrivers again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -113,7 +113,7 @@
       - BorgChassis
       - RoboticsConsole
   - type: WiresPanel
-    openingTool: Prying
+    #openingTool: Prying # starcup: use screwdriver for borgs
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier
     group: Silicon


### PR DESCRIPTION
Cyborgs are opened with the screwdriver after being unlocked. 

## Why / Balance
This is the muscle memory of most of our roboticists, and the vast majority of other panels in the game use screwdrivers. 
Upstream introduced the change in https://github.com/space-wizards/space-station-14/pull/32796, and as far as I can tell the only rationale here is "thing ss13 does" (not a good reason) and "eventually we might add another hacking panel," except it makes more sense to use the screwdriver for the legal panel and a crowbar to access the hacking panel.

**Changelog**
:cl:
- tweak: Cyborg panels are opened with screwdrivers again.
