### PR TITLE
tweak: increase time for players to rot

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -269,7 +269,7 @@
     normalBodyTemperature: 310.15
     thermalRegulationTemperatureThreshold: 2
   - type: Perishable
-    rotAfter: 1800 # starcup: increase time to rot from 10 minutes to 30
+    rotAfter: 1200 # starcup: increase time to rot from 10 minutes to 20
   # begin starcup: people are not food
   # - type: Butcherable
   #   butcheringType: Spike # TODO human.

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -92,7 +92,7 @@
         Blunt: 2
         Slash: 3
   - type: Perishable
-    rotAfter: 1800 # starcup: increase time to rot from 10 minutes to 30
+    rotAfter: 1200 # starcup: increase time to rot from 10 minutes to 20
   - type: Damageable
     damageModifierSet: Vulpkanin
   - type: Vocal


### PR DESCRIPTION
Changes the time it takes for players to start rotting to be twice the old time; 10 minutes to 20 minutes.

## Why / Balance
This is somewhat of a band-aid fix to larger salvage balance concerns; very very frequently in our rounds a salvager comes in rotted, and quite often they are only minutes from being saved. This gives the crew a little more leeway in rescuing salvagers. 

It was pointed out that this reduces the frequency that medical will have to do something more complex/interesting than just injecting chems into patients or using topicals. However, this is already a huge issue with current medical and while we would love to see the gameplay options for medical expanded, it simply is the case that rotting happens too often. It may need further tweaks, twenty minutes feels very short to me still, but discussion was generally in the 1.5-2x range.

## Technical details
why do vulps have a copy of the perishable component..? seems out of scope to remove, we can clean up the file when we do the upstream vulp merge

**Changelog**
:cl:
- tweak: Player species will take twice as long to rot.
