### PR TITLE
fix: add brigmedic access to security remote

### DIFF
--- a/Resources/Prototypes/Access/security.yml
+++ b/Resources/Prototypes/Access/security.yml
@@ -35,6 +35,7 @@
   - Brig
   - Detective
   - Cryogenics
+  - Brigmedic # starcup
 
 - type: accessGroup
   id: Armory


### PR DESCRIPTION
Fixes the head of security's door remote being unable to access Brigmedic doors. The armory remote still lacks this ability; it may be nice to add it if we add brigmedic access to the warden, but that would be a separate PR if we go for it.

I don't think adding this to the security group will change much else, and if it does it's probably a desirable change.

**Changelog**
:cl:
- fix: The Security door remote can now access Brigmedic doors.
