### PR TITLE
tweak: remove unused poster prototypes, bring back the anime poster

### DIFF
--- a/Resources/Migrations/starcup-migrations.yml
+++ b/Resources/Migrations/starcup-migrations.yml
@@ -5,7 +5,6 @@ PosterContrabandSmoke: null
 PosterContrabandHaveaPuff: null
 PosterContrabandDDayPromo: null
 PosterContrabandSyndicatePistol: null
-PosterContrabandBeachStarYamamoto: null
 PosterContrabandRise: null
 PosterContrabandCybersun600: null
 PosterLegitSpaceCops: null

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -80,6 +80,7 @@
       - PosterContrabandTheBigGasTruth
       - PosterContrabandWehWatches
       - PosterContrabandVoteWeh
+      - PosterContrabandBeachStarYamamoto
       - PosterContrabandHighEffectEngineering
       - PosterContrabandNuclearDeviceInformational
       - PosterContrabandRevolt

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -80,7 +80,6 @@
       - PosterContrabandTheBigGasTruth
       - PosterContrabandWehWatches
       - PosterContrabandVoteWeh
-      #- PosterContrabandBeachStarYamamoto # starcup: removed for tone
       - PosterContrabandHighEffectEngineering
       - PosterContrabandNuclearDeviceInformational
       - PosterContrabandRevolt

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -501,7 +501,7 @@
   parent: PosterBase
   id: PosterContrabandBeachStarYamamoto
   name: "Beach Star Yamamoto!"
-  description: "A wall scroll depicting an old swimming anime with girls in small swim suits. You feel more weebish the longer you look at it."
+  description: A poster depicting characters from an animated series about young women playing volleyball on the beach, legendary for somehow managing to spin this premise into six seasons and two feature-length films. # starcup: rewritten for tone
   components:
   - type: Sprite
     state: poster52_contraband

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -109,14 +109,16 @@
   - type: Sprite
     state: poster6_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandSmoke
-  name: "Smoke"
-  description: "A poster advertising a rival corporate brand of cigarettes."
-  components:
-  - type: Sprite
-    state: poster7_contraband
+# begin starcup: removed for tone
+# - type: entity
+#   parent: PosterBase
+#   id: PosterContrabandSmoke
+#   name: "Smoke"
+#   description: "A poster advertising a rival corporate brand of cigarettes."
+#   components:
+#   - type: Sprite
+#     state: poster7_contraband
+# end starcup
 
 - type: entity
   parent: PosterBase
@@ -271,14 +273,16 @@
   - type: Sprite
     state: poster24_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandHaveaPuff
-  name: "Have a Puff"
-  description: "Who cares about lung cancer when you're high as a kite?"
-  components:
-  - type: Sprite
-    state: poster25_contraband
+# begin starcup: removed for tone
+# - type: entity
+#   parent: PosterBase
+#   id: PosterContrabandHaveaPuff
+#   name: "Have a Puff"
+#   description: "Who cares about lung cancer when you're high as a kite?"
+#   components:
+#   - type: Sprite
+#     state: poster25_contraband
+# end starcup
 
 - type: entity
   parent: PosterBase
@@ -289,23 +293,25 @@
   - type: Sprite
     state: poster26_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandDDayPromo
-  name: "D-Day Promo"
-  description: "A promotional poster for some rapper."
-  components:
-  - type: Sprite
-    state: poster27_contraband
+# begin starcup: removed for tone
+# - type: entity
+#   parent: PosterBase
+#   id: PosterContrabandDDayPromo
+#   name: "D-Day Promo"
+#   description: "A promotional poster for some rapper."
+#   components:
+#   - type: Sprite
+#     state: poster27_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandSyndicatePistol
-  name: "Syndicate Pistol"
-  description: "A poster advertising syndicate pistols as being 'classy as fuck'. It's covered in faded gang tags."
-  components:
-  - type: Sprite
-    state: poster28_contraband
+# - type: entity
+#   parent: PosterBase
+#   id: PosterContrabandSyndicatePistol
+#   name: "Syndicate Pistol"
+#   description: "A poster advertising syndicate pistols as being 'classy as fuck'. It's covered in faded gang tags."
+#   components:
+#   - type: Sprite
+#     state: poster28_contraband
+# end starcup
 
 - type: entity
   parent: PosterBase
@@ -524,14 +530,16 @@
   - type: Sprite
     state: poster54_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandRise
-  name: "Rise Up"
-  description: "A poster depicting a grey shirted man holding a crowbar with the word Rise written below it."
-  components:
-  - type: Sprite
-    state: poster55_contraband
+# begin starcup: removed for tone
+# - type: entity
+#   parent: PosterBase
+#   id: PosterContrabandRise
+#   name: "Rise Up"
+#   description: "A poster depicting a grey shirted man holding a crowbar with the word Rise written below it."
+#   components:
+#   - type: Sprite
+#     state: poster55_contraband
+# end starcup
 
 - type: entity
   parent: PosterBase
@@ -551,14 +559,16 @@
     - type: Sprite
       state: poster57_contraband
 
-- type: entity
-  parent: PosterBase
-  id: PosterContrabandCybersun600
-  name: "Cybersun: 600 Years Commemorative Poster"
-  description: "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
-  components:
-    - type: Sprite
-      state: poster58_contraband
+# begin starcup: removed for tone
+# - type: entity
+#   parent: PosterBase
+#   id: PosterContrabandCybersun600
+#   name: "Cybersun: 600 Years Commemorative Poster"
+#   description: "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
+#   components:
+#     - type: Sprite
+#       state: poster58_contraband
+# end starcup
 
 - type: entity
   parent: PosterBase


### PR DESCRIPTION
removes prototypes for posters that have been migrated out, and also brings back the beach star yamamoto poster with a rewritten description

## Why / Balance
keeping the map prototypes around despite being removed via migrations risks mapper confusion, so I just commented them out so they won't show in the spawn menu at all

also people keep wanting to use the silly anime poster so I brought back the silly anime poster

**Changelog**
not player facing, no cl