### PR TITLE
fix: give cyborgs mkc emotes

### DIFF
--- a/Resources/Prototypes/_EE/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_EE/Voice/speech_emotes.yml
@@ -10,11 +10,13 @@
   icon: _DV/Interface/Emotes/ecg.png # DeltaV - Added icon
   category: Vocal
   whitelist:
+  # begin starcup: allow cyborgs to use mkc emotes
     requireAll: true
     components:
     - Vocal
     tags:
     - SiliconEmotes
+  # end starcup
   chatMessages: [ boops ]
   chatTriggers:
     - boops
@@ -22,11 +24,13 @@
 - type: emote
   id: Whirr # uncategorized as it is generic
   whitelist:
+  # begin starcup: allow cyborgs to use mkc emotes
     requireAll: true
     components:
     - Vocal
     tags:
     - SiliconEmotes
+  # end starcup
   name: chat-emote-name-whirr
   chatMessages: [ whirrs ]
   chatTriggers:


### PR DESCRIPTION
fixed the whitelist conditions for the `boop` and `whirr` emotes so that cyborgs can have them too

**Changelog**
:cl:
- fix: cyborgs now have access to the boop and whirr emotes