### PR TITLE
tweak: change "admin" records to "ooc" records

### DIFF
--- a/Resources/Locale/en-US/_CD/records/editor.ftl
+++ b/Resources/Locale/en-US/_CD/records/editor.ftl
@@ -19,7 +19,8 @@ humanoid-profile-editor-cd-records-drug-allergies = Drug Allergies:
 humanoid-profile-editor-cd-records-postmortem = Postmortem Instructions:
 
 # Admin
-humanoid-profile-editor-cd-records-admin = Admin
+# starcup: change name from admin to ooc
+humanoid-profile-editor-cd-records-admin = OOC
 
 # Entries
 humanoid-profile-editor-cd-records-add-entry = Add Entry


### PR DESCRIPTION
just rewrites the ftl string of admin records to rename them to "OOC" instead. no internal changes, so there shouldn't be any problems with profile imports

## Why / Balance
makes their intended use a little clearer; some players have expressed confusion on what these are intended to be used for!

**Changelog**
:cl:
- tweak: admin records have been renamed to OOC records, to make their intended use clearer