### PR TITLE
fix: client crash related to compressing tile textures

### DIFF
--- a/Resources/Textures/_starcup/Tiles/Interior/arcade_carpet.rsi/meta.json
+++ b/Resources/Textures/_starcup/Tiles/Interior/arcade_carpet.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 32,
         "y": 32
     },
+    "rsic": false,
     "states": [
         {
             "name": "arcade"

--- a/Resources/Textures/_starcup/Tiles/Interior/piiixl.rsi/meta.json
+++ b/Resources/Textures/_starcup/Tiles/Interior/piiixl.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 32,
         "y": 32
     },
+    "rsic": false,
     "states": [
         {
             "name": "carpet26"

--- a/Resources/Textures/_starcup/Tiles/Planet/mute_water.rsi/meta.json
+++ b/Resources/Textures/_starcup/Tiles/Planet/mute_water.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 32,
         "y": 32
     },
+    "rsic": false,
     "states": [
         {
             "name": "full"

--- a/Resources/Textures/_starcup/Tiles/Stone/piiixl.rsi/meta.json
+++ b/Resources/Textures/_starcup/Tiles/Stone/piiixl.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 32,
         "y": 32
     },
+    "rsic": false,
     "states": [
         {
             "name": "blackstone01"


### PR DESCRIPTION
RobustToolbox v266.0.0 enabled compressing rsi textures into single files. Tile rendering does not properly support rsi yet, so this needs to be disabled or it will cause an instant launch crash for the client. This crash is only triggered when running from a release package (presumably rsi compression takes place in the Content.Packaging step.)

Related to #131, #496

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Hopefully fixed a launch crash caused by compressed tile textures.