### PR TITLE
map(saltern): last Brig buff + minor fixes

### DIFF
--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -75607,10 +75607,6 @@ entities:
     - type: Transform
       pos: -15.5,12.5
       parent: 2
-    - type: UserInterface
-      actors:
-        enum.StorageUiKey.Key:
-        - invalid
     - type: Storage
       storedItems:
         6929:


### PR DESCRIPTION
Gave the Brig a botanical belt (complete with robust harvest!), a freezer with meat/bacon/carp fillets/mayo/eggs, two more beakers, a scrubber brush, some cutlery, a garbage bag, and took away a plant bag.

Fixed Warden's door to require the correct access level, fixed the Evac beacon not being configured properly.

## Why / Balance
Prisoner play was a little vexing without any eggs, meat, or robust harvest. With such a small space, I think it's fine to be a little generous. Now prisoners can make somewhat fancier meals like bisques and cakes, as well as actually being able to mix their powdered milk, and their gardening becomes a little bit more robust.

**Changelog**
:cl:
- tweak: Made more minor Saltern fixes