### PR TITLE
fix: hop no longer spawns with an admin hud on the floor

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -81,7 +81,7 @@
     gloves: ClothingHandsGlovesHop
     ears: ClothingHeadsetAltCommandSyndie # starcup: command recolors
     belt: BoxFolderClipboardThreePapers
-    eyes: ClothingEyesHudCommand
+    # eyes: ClothingEyesHudCommand # starcup: moved to loadouts
   storage:
     back:
     - Flash


### PR DESCRIPTION
HoP has a glasses loadout, but still spawned with an admin HUD; this fixes that by commenting the admin HUD. They still have one in their locker.

**Changelog**
:cl:
- fix: The Head of Personnel no longer drops their administration HUD at the start of every shift.
