### PR TITLE
fix: cryopods can rotate now

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -116,6 +116,10 @@
   - type: GuideHelp
     guides:
     - Cryogenics
+  # begin starcup: QoL fixes
+  - type: Anchorable
+  - type: Rotatable
+  # end starcup
 
 - type: entity
   parent: BaseMachine


### PR DESCRIPTION
Cryopods were not able to be rotated before this. Now they can.

I'm not sure why this was the case. The prototype has a comment indicating that omitting AnchorableComponent was purposeful, but doesn't state why.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cryopods can be rotated now.