### PR TITLE
feat: give real mouse godmode

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -135,6 +135,7 @@
     attributes:
       proper: true
       gender: female
+  - type: Godmode # starcup
 
 - type: entity
   name: Puppy Ian


### PR DESCRIPTION
just gives the godmode component onto the real mouse that spawns in the dev environment

## Why / Balance
I have had enough of real mouse wandering into space and dying every single time I boot up the dev station. she deserves better

**Changelog**
not player facing, no cl