### PR TITLE
fix: add PointLight to PoweredlightExterior

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -204,6 +204,11 @@
       types:
         Heat: 4 # brighter light gets hotter
     popupText: powered-light-component-burn-hand
+  - type: PointLight # starcup: add PointLight component
+    radius: 12
+    energy: 4.5
+    softness: 0.5
+    color: "#B4FCF0"
 
 - type: entity
   parent: AlwaysPoweredWallLight


### PR DESCRIPTION
The PointLight component is added to light prototypes so that when mapping on an uninitialized map, they have the proper lighting. The prototype for the powered exterior light does not have this, meaning it has the lighting of a regular light tube on an uninitialized map. This isn't good for mappers; there's workarounds, but they're inconvenient.

My main concern is that it's too small of a change to bother modifying an upstream file for.

**Changelog**
Not player-facing.
