### PR TITLE
fix: Fixes uncharged MKCs sometimes fully draining replacement batteries

### DIFF
--- a/Content.Server/_EE/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EE/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -218,7 +218,7 @@ public sealed class SiliconChargeSystem : EntitySystem
             !TryComp(silicon, out InputMoverComponent? input))
             return 0;
 
-        if (input.HeldMoveButtons == MoveButtons.None || _jetpack.IsUserFlying(silicon)) // If nothing is being held or jet packing
+        if (input.HeldMoveButtons == MoveButtons.None || _jetpack.IsUserFlying(silicon) || movement.CurrentSprintSpeed == 0) // If nothing is being held or jet packing. starcup: Or speed is 0, which will cause a NaN and instantly drain the battery
         {
             return siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction * (-1); // Reduces draw by idle drain reduction
         }


### PR DESCRIPTION
## Why / Balance
Bugfix

## Technical details
NaN was eating the batteries when players were downed with a held movement key stuck on. 

**Changelog**
:cl:
- fix: MKCs will no longer instantly drain replacement batteries to 0% in certain situations.
