### PR TITLE
feat: hairstyle combination & markings menu accessible hair

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -142,7 +142,7 @@
                 <BoxContainer Name="MarkingsTab" Orientation="Vertical" Margin="10">
                     <!-- Markings -->
                     <ScrollContainer VerticalExpand="True">
-                        <humanoid:MarkingPicker Name="Markings" IgnoreCategories="Hair,FacialHair" />
+                        <humanoid:MarkingPicker Name="Markings" /> <!-- starcup : tweak -->
                     </ScrollContainer>
                 </BoxContainer>
             </TabContainer>

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -45,7 +45,7 @@
 #      points: 0
 #      required: false
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -37,7 +37,7 @@
   id: MobSlimeMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -48,7 +48,7 @@
   onlyWhitelisted: true
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -40,7 +40,7 @@
   id: MobVulpkaninMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/_DV/Species/Oni.yml
+++ b/Resources/Prototypes/_DV/Species/Oni.yml
@@ -19,7 +19,7 @@
   id: MobOniMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/_DV/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Species/felinid.yml
@@ -14,7 +14,7 @@
   id: MobFelinidMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -37,7 +37,7 @@
   id: MobHarpyMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -46,7 +46,7 @@
   id: MobRodentiaMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 2 # starcup 1<2
       required: false
     FacialHair:
       points: 1

--- a/Resources/Prototypes/_EE/Species/ipc.yml
+++ b/Resources/Prototypes/_EE/Species/ipc.yml
@@ -56,7 +56,7 @@
   id: MobIPCMarkingLimits
   points:
     Hair:
-      points: 1 # starcup: changed from 0
+      points: 2 # starcup: changed from 0
       required: false
     FacialHair:
       points: 1 # starcup: changed from 0


### PR DESCRIPTION

## Why / Balance
creativity and fun

## Technical details
allows the hair and facial hair markings to be accessible from the markings menu & allows for a second hairstyle to be selected through that menu. the standard hair selection menu is unchanged, limited to one style, and will be overridden if you hit the markings point cap.

there are probably better ways to do this but anne and i agreed it was outside of our field of competence. it's not ideal but i doubt it'll cause many issues.

## Media
<img width="1491" height="488" alt="image" src="https://github.com/user-attachments/assets/2f1dabf5-549e-46b7-99f0-3b42782abb5d" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: up to two hairstyles may now be selected from the markings menu, simultaneously
