### PR TITLE
fix: DockingConsoleWindow state consistency

### DIFF
--- a/Content.Client/_DV/Shuttles/UI/DockingConsoleWindow.xaml.cs
+++ b/Content.Client/_DV/Shuttles/UI/DockingConsoleWindow.xaml.cs
@@ -50,7 +50,6 @@ public sealed partial class DockingConsoleWindow : FancyWindow
         {
             MapFTLState.Text = Loc.GetString("docking-console-no-shuttle");
             _ftlStyle.BackgroundColor = Color.FromHex("#B02E26");
-            return;
         }
 
         Destinations.OnItemSelected += args => _selected = args.ItemIndex;


### PR DESCRIPTION
Port of deltav-station/delta-v#4227. You will no longer have to close the mining shuttle console window after opening it the first time.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: You no longer need to close the mining shuttle console window after opening it for the first time.