### PR TITLE
feat: changeable records font

### DIFF
--- a/Content.Client/_CD/Records/UI/RecordEntryViewPopup.xaml.cs
+++ b/Content.Client/_CD/Records/UI/RecordEntryViewPopup.xaml.cs
@@ -23,6 +23,7 @@ public sealed partial class RecordEntryViewPopup : FancyWindow
         typeof(HeadingTag),
         typeof(ItalicTag),
         typeof(MonoTag), // starcup
+        typeof(SizeTag), // starcup
         typeof(FontTag), // starcup
         typeof(EmojiTag), // starcup
     ];


### PR DESCRIPTION
## Why / Balance
Tag parity with paper
#523 Added font and emoji tags to paper
#522 Added the size tag to paper
The mono tag was missing

**Changelog**
:cl:
- add: You can now use the `[mono]`, `[font]`, and `[emoji]` rich text tags to spice up your character records.
