### PR TITLE
fix: Avoid constantly alerting MKC players that their panel is being touched

### DIFF
--- a/Content.Server/_EE/Silicon/BatteryLocking/BatterySlotRequiresLockSystem.cs
+++ b/Content.Server/_EE/Silicon/BatteryLocking/BatterySlotRequiresLockSystem.cs
@@ -32,7 +32,7 @@ public sealed class BatterySlotRequiresLockSystem : EntitySystem
 
     private void LockToggleAttempted(EntityUid uid, BatterySlotRequiresLockComponent component, LockToggleAttemptEvent args)
     {
-        if (args.User == uid || !HasComp<SiliconComponent>(uid))
+        if (args.User == uid || !HasComp<SiliconComponent>(uid) || args.Silent) // starcup: don't pop up on silent checks
             return;
 
         _popupSystem.PopupEntity(Loc.GetString("batteryslotrequireslock-component-alert-owner", ("user", Identity.Entity(args.User, EntityManager))), uid, uid, PopupType.Large);


### PR DESCRIPTION
## Why / Balance
Bugfix

## Technical details
Silent on this event is used when seeing if unlock can go into the verb menu. No reason to alert players at that point, no action has been taken yet.

**Changelog**
:cl:
- fix: MKC players should no longer be constantly alerted that people are touching their maintenance panels when they aren't. 