### PR TITLE
feat: mute oil tile now deals caustic on step

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Tiles/mute_water.yml
+++ b/Resources/Prototypes/_starcup/Entities/Tiles/mute_water.yml
@@ -77,3 +77,9 @@
       collection: FootstepWater
       params:
         volume: 8
+  - type: TriggerOnStepTrigger
+  - type: DamageOnTrigger
+    targetUser: true
+    damage:
+      types:
+        Caustic: 5


### PR DESCRIPTION
add a damage on step trigger for mute oil that inflicts a decent amount of caustic damage when you walk over it

## Why / Balance
we figured it probably ought to be a little more hazardous!

## Media
https://github.com/user-attachments/assets/8c584d49-f00a-425a-b070-254be124cd2a

**Changelog**
not player-facing (yet), no cl