### PR TITLE
fix: air alarm autolink now considers grid rotation

### DIFF
--- a/Content.Server/_Wizden/DeviceLinking/Systems/AlarmAutoLinkSystem.cs
+++ b/Content.Server/_Wizden/DeviceLinking/Systems/AlarmAutoLinkSystem.cs
@@ -66,9 +66,7 @@ public sealed class AlarmAutoLinkSystem : EntitySystem
                 continue;
 
             var blockedDirections = AtmosDirection.Invalid;
-            var worldCoord = _mapSystem.LocalToWorld(grid.Owner, grid.Comp, tileRef.GridIndices);
-            var worldAABB = new Box2(worldCoord, worldCoord + grid.Comp.TileSizeVector).Enlarged(-0.05f);
-            var entities = _entityLookupSystem.GetEntitiesIntersecting(gridUid, worldAABB, LookupFlags.StaticSundries);
+            var entities = _entityLookupSystem.GetLocalEntitiesIntersecting(tileRef);
 
             foreach (var entity in entities)
             {


### PR DESCRIPTION
This code was not compensating for the rotation of the grid. It would sometimes consider solid walls in the first node and abort the flood fill search.

See: https://github.com/space-wizards/space-station-14/pull/35617#discussion_r2462613330

Before:

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/85ce3183-93a8-4555-9f8a-2543b48fdd62" />

After:

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/381fafa0-316d-4447-aceb-4ba4ee33034d" />


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Auto-link air alarms now account for grid rotation when linking.