### PR TITLE
build: content.packaging run configuration

### DIFF
--- a/.run/Content.Packaging.run.xml
+++ b/.run/Content.Packaging.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Content.Packaging" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/Content.Packaging/bin/Debug/net9.0/Content.Packaging.exe" />
+    <option name="PROGRAM_PARAMETERS" value="server --hybrid-acz --platform linux-x64 --platform win-x64" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/Content.Packaging/Content.Packaging.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="0" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value="net9.0" />
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
Corrects the Content.Packaging run configuration. It can be used from your IDE to package a standalone server with hybrid-acz, right out of the box.