### PR TITLE
feat: Adds new scrubbing component to clean decals on tiles

### DIFF
--- a/Content.Client/_starcup/Tools/Systems/ScrubTileToolSystem.cs
+++ b/Content.Client/_starcup/Tools/Systems/ScrubTileToolSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._starcup.Tools.Systems;
+
+namespace Content.Client._starcup.Tools.Systems;
+
+public sealed class ScrubTileToolSystem : SharedScrubTileToolSystem;

--- a/Content.Server/_starcup/Tools/Systems/ScrubTileToolSystem.cs
+++ b/Content.Server/_starcup/Tools/Systems/ScrubTileToolSystem.cs
@@ -1,0 +1,27 @@
+using System.Numerics;
+using Content.Server.Decals;
+using Content.Shared._starcup.Tools.Systems;
+using Content.Shared.Decals;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server._starcup.Tools.Systems;
+
+public sealed class ScrubTileToolSystem : SharedScrubTileToolSystem
+{
+    [Dependency] private readonly DecalSystem _decalSystem = default!;
+    [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
+
+    public override bool TryDoScrub(TileRef tileRef, MapGridComponent grid, DecalGridComponent decalGrid)
+    {
+        var bounds = _lookupSystem.GetLocalBounds(tileRef, grid.TileSize).Translated(new Vector2(-0.5f, -0.5f));
+        var decals = _decalSystem.GetDecalsIntersecting(tileRef.GridUid, bounds);
+
+        foreach (var decal in decals)
+        {
+            if (decal.Decal.Cleanable)
+                _decalSystem.RemoveDecal(tileRef.GridUid, decal.Index, decalGrid);
+        }
+        return true;
+    }
+}

--- a/Content.Shared/_starcup/Tools/Components/ScrubbingToolComponent.cs
+++ b/Content.Shared/_starcup/Tools/Components/ScrubbingToolComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._starcup.Tools.Components;
+
+/// <summary>
+/// This is used for entities with <see cref="ToolComponent"/> that are also able
+/// to remove decals.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ScrubbingToolComponent : Component
+{
+    /// <summary>
+    /// The time it takes to scrub away the decals
+    /// </summary>
+    [DataField]
+    public TimeSpan Delay = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// Whether or not the tile being scrubbed must be unobstructed
+    /// </summary>
+    [DataField]
+    public bool RequiresUnobstructed = true;
+}

--- a/Content.Shared/_starcup/Tools/Systems/SharedScrubTileToolSystem.cs
+++ b/Content.Shared/_starcup/Tools/Systems/SharedScrubTileToolSystem.cs
@@ -1,0 +1,106 @@
+using Content.Shared._starcup.Tools.Components;
+using Content.Shared.Decals;
+using Content.Shared.Fluids.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Maps;
+using Content.Shared.Physics;
+using Content.Shared.Tools.Components;
+using Content.Shared.Tools.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Shared._starcup.Tools.Systems;
+
+public abstract class SharedScrubTileToolSystem : EntitySystem
+{
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly SharedMapSystem _maps = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly TurfSystem _turfs = default!;
+    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly SharedToolSystem _toolSystem = default!;
+
+    private const string ScrubQuality = "Brushing";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ScrubbingToolComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<ScrubbingToolComponent, TileToolDoAfterEvent>(OnScrubbingComplete);
+    }
+
+    private void OnAfterInteract(Entity<ScrubbingToolComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || args.Target != null && !HasComp<PuddleComponent>(args.Target))
+            return;
+
+        args.Handled = TryStartScrubbing(ent, args.User, args.ClickLocation);
+    }
+
+    private bool TryStartScrubbing(Entity<ScrubbingToolComponent> ent, EntityUid user, EntityCoordinates clickedCoords)
+    {
+        if (!TryComp<ToolComponent>(ent, out var tool))
+            return false;
+
+        if (!HasScrubQuality(tool))
+            return false;
+
+        if (!_mapManager.TryFindGridAt(_transformSystem.ToMapCoordinates(clickedCoords), out var gridUid, out var mapGrid))
+            return false;
+
+        var tileRef = _maps.GetTileRef(gridUid, mapGrid, clickedCoords);
+
+        if (ent.Comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask))
+            return false;
+
+        var coordinates = _maps.GridTileToLocal(gridUid, mapGrid, tileRef.GridIndices);
+        if (!_interactionSystem.InRangeUnobstructed(user, coordinates, popup: false))
+            return false;
+
+        var args = new TileToolDoAfterEvent(GetNetEntity(gridUid), tileRef.GridIndices);
+        _toolSystem.UseTool(ent, user, ent, ent.Comp.Delay, tool.Qualities, args, out _, toolComponent: tool);
+        return true;
+    }
+
+    private void OnScrubbingComplete(Entity<ScrubbingToolComponent> ent, ref TileToolDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled)
+            return;
+
+        if (!TryComp<ToolComponent>(ent, out var tool))
+            return;
+
+        if (!HasScrubQuality(tool))
+            return;
+
+        var gridUid = GetEntity(args.Grid);
+        if (!TryComp<MapGridComponent>(gridUid, out var grid))
+        {
+            Log.Error("Attempted to scrub a tile on a non-existant grid?");
+            return;
+        }
+        if (!TryComp<DecalGridComponent>(gridUid, out var decalGrid))
+            return;
+
+        var tileRef = _maps.GetTileRef(gridUid, grid, args.GridTile);
+
+        if (!TryDoScrub(tileRef, grid, decalGrid))
+            return;
+
+        args.Handled = true;
+    }
+
+    private static bool HasScrubQuality(ToolComponent tool)
+    {
+        // Using qualities directly gives an access error
+        // But assigning it to a variable first works
+        var qualities = tool.Qualities;
+        return qualities.Contains(ScrubQuality);
+    }
+
+    public virtual bool TryDoScrub(TileRef tileRef, MapGridComponent grid, DecalGridComponent decalGrid)
+    {
+        // Don't bother on the client, decals only remove on the server
+        return true;
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -386,6 +386,7 @@
     materialComposition:
       Steel: 50
       Plastic: 50
+  - type: ScrubbingTool # starcup
   - type: Tool
     qualities:
     - Brushing


### PR DESCRIPTION
## Why / Balance
Limiting cleaning decals to space cleaner doesn't feel great. Giving the option to slowly clean them manually with the wire brush gives more options to janitors. No longer do you need to constantly run back and forth to refill your spray bottles during your quest to make the station spotless! Unless you want to, of course.

## Technical details
New component to avoid messing around in upstream code. 

## Media
https://github.com/user-attachments/assets/139b0551-f8e8-4b21-a403-fa177c3e34fc


**Changelog**
:cl:
- add: The wire brush can now be used to scrub the dirt off tiles. This has caused the space cleaner stocks to plummet.