### PR TITLE
tweak: add parcel wrap and envelope boxes to courierdrobe

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/courierdrobe.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/courierdrobe.yml
@@ -12,5 +12,9 @@
     ClothingHeadMailCarrier: 2 # Nyanotrasen - Mail Carrier old gear
     MailBag: 2 # Nyanotrasen - Mail Carrier old gear
     ClothingOuterWinterCoatMail: 2 # Nyanotrasen - Mail Carrier old gear
+    # begin starcup: add letters, parcel wrap
+    BoxEnvelope: 2
+    ParcelWrap: 1
+    # end starcup
     WeaponMailLake: 2 # Frontier Mail Port
     BoxMailCapsulePrimed: 4 # Frontier Mail Port


### PR DESCRIPTION
Adds two envelope boxes and a parcel wrap with 30 charges to the courierdrobe. 

## Why / Balance
Courier should be able to deliver letters! Courier should be able to deliver packages! There's two neat little items that don't see use. The HoP has envelopes too, and I think it's fine to leave this (they can still seal the envelope then ask the courier to deliver it).

As a note, parcel wrap does behave strangely in some cases. It's functional and nothing seems to be game-breaking, but it may be worth waiting for it to be improved, or just improving it.

**Changelog**
:cl:
- tweak: Envelopes and parcel wrap are now available in the CourierDrobe.
