### PR TITLE
tweak: buff tape recorders

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -16,7 +16,7 @@
   - type: TapeRecorder
     rewindSpeed: 10 # starcup
   - type: ActiveListener
-    range: 4
+    range: 6 # starcup: was 4
   - type: UseDelay
     delay: 1
   - type: Speech


### PR DESCRIPTION
Increases the time length of cassette tapes from 3 minutes to 10 minutes, and accordingly changes the tape recorder rewind time from 3 to 10. Also slightly increases the range of detection from 4 to 6.

## Why / Balance
We have a lot more focus on long conversations on starcup, and often we want to record these, IC. People take a while to type, and having to pause the conversation so that you can rewind the tape every 3 minutes is rough. 10 minutes is still somewhat short in comparison. The range of detection is increased too, since I've heard people complain that it cuts off voices that are still close to the recorder, and to allow conversations between larger groups of people to be recorded. 

A setting for this might be nice? I dunno; recording a conversation in a busy bar isn't good practice. It'd also be nice to be able to rewind tapes when they aren't in the recorder, if that isn't already possible.

**Changelog**
:cl:
- tweak: Changed fun!
