### PR TITLE
feat: event grids for charon-epsilon

### DIFF
--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml
@@ -29,7 +29,6 @@ entities:
       name: Automated Trade Outpost
     - type: Transform
       pos: 8,0
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-mime-tree-4x4.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-mime-tree-4x4.yml
@@ -26,7 +26,6 @@ entities:
       name: hollow tree mime
     - type: Transform
       pos: 1,3
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-piano-6x5.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-piano-6x5.yml
@@ -27,7 +27,6 @@ entities:
       name: grid
     - type: Transform
       pos: 0,4
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-power-station-13x14.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-power-station-13x14.yml
@@ -29,7 +29,6 @@ entities:
       name: power station
     - type: Transform
       pos: 5,12
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-reactor-casing-7x10.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-reactor-casing-7x10.yml
@@ -26,7 +26,6 @@ entities:
       name: reactor casing
     - type: Transform
       pos: 6,8
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-ritual-circle-8x8.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-ritual-circle-8x8.yml
@@ -27,7 +27,6 @@ entities:
       name: rune circle
     - type: Transform
       pos: 3,0
-      parent: invalid
     - type: MapGrid
       chunks:
         -1,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-tanks-6x6.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-tanks-6x6.yml
@@ -24,7 +24,6 @@ entities:
     - type: MetaData
       name: tanks
     - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-turbine-7x4.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-turbine-7x4.yml
@@ -24,7 +24,6 @@ entities:
       name: turbine
     - type: Transform
       pos: 0,3
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-electrolyzer-14x14.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-electrolyzer-14x14.yml
@@ -26,7 +26,6 @@ entities:
       name: electrolyzer
     - type: Transform
       pos: 0,11
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-farmhouse-17x20.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-farmhouse-17x20.yml
@@ -29,7 +29,6 @@ entities:
       name: Acid Enterprise Farmhouse
     - type: Transform
       pos: 21,16
-      parent: invalid
     - type: MapGrid
       chunks:
         -1,0:
@@ -756,11 +755,6 @@ entities:
           - 5
           - 10
           - 6
-    - type: UserInterface
-      actors:
-        enum.StorageUiKey.Key:
-        - invalid
-    - type: ActiveUserInterface
 - proto: FenceWoodHighCorner
   entities:
   - uid: 104

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-hatch-11x10.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-hatch-11x10.yml
@@ -27,7 +27,6 @@ entities:
       name: hatch
     - type: Transform
       pos: 9,9
-      parent: invalid
     - type: MapGrid
       chunks:
         -1,0:
@@ -161,48 +160,6 @@ entities:
     - type: Transform
       pos: -5.12072,-3.1488917
       parent: 1
-    - type: Physics
-      bodyStatus: InAir
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape: !type:PolygonShape
-            radius: 0.01
-            vertices:
-            - -0.25,-0.25
-            - 0.25,-0.25
-            - 0.25,0.25
-            - -0.25,0.25
-          mask:
-          - Impassable
-          - HighImpassable
-          layer: []
-          density: 20
-          hard: True
-          restitution: 0.3
-          friction: 0.2
-        throw-fixture:
-          shape: !type:PolygonShape
-            radius: 0.01
-            vertices:
-            - -0.25,-0.25
-            - 0.25,-0.25
-            - 0.25,0.25
-            - -0.25,0.25
-          mask:
-          - Impassable
-          - HighImpassable
-          - BulletImpassable
-          layer: []
-          density: 1
-          hard: False
-          restitution: 0
-          friction: 0.4
-    - type: ThrownItem
-      playLandSound: True
-      landTime: 77348.9691025
-      thrownTime: 77348.922651
-      thrower: invalid
 - proto: ScrapFireExtinguisher
   entities:
   - uid: 9

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-med-outpost-14x11.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T2-med-outpost-14x11.yml
@@ -27,7 +27,6 @@ entities:
       name: Medical Outpost
     - type: Transform
       pos: 3,7
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -379,11 +378,6 @@ entities:
       parent: 1
     - type: Paper
       content: savegrid 2021561 /silent-moon-foxcul-med-outpost
-    - type: UserInterface
-      actors:
-        enum.PaperUiKey.Key:
-        - invalid
-    - type: ActiveUserInterface
 - proto: PaperDyedRed
   entities:
   - uid: 42

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-chromium-cave-14x17.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-chromium-cave-14x17.yml
@@ -25,7 +25,6 @@ entities:
       name: chromium cave
     - type: Transform
       pos: 11,2
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-shadow-valley-13x12.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-shadow-valley-13x12.yml
@@ -27,7 +27,6 @@ entities:
       name: shadow valley
     - type: Transform
       pos: 6,8
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-virology-lake-48x52.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-virology-lake-48x52.yml
@@ -29,7 +29,6 @@ entities:
       name: grid
     - type: Transform
       pos: 32,14
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:


### PR DESCRIPTION
Adds the grids made for the Charon-Epsilon event. They're organized by their intended "ring," then name, then their grid size. All grids are offset such that the chosen position for their spawn will be the lower left corner of the smallest box they fit inside. I also ran `fixgridatmos`. Note that some papers used on the maps for documentation/curator use are still there and need to be removed during the event.

