### PR TITLE
tweak: catwalks can be built on subfloor tiles

### DIFF
--- a/Content.Shared/_starcup/Construction/Conditions/TileSubfloorCondition.cs
+++ b/Content.Shared/_starcup/Construction/Conditions/TileSubfloorCondition.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Construction;
+using Content.Shared.Construction.Conditions;
+using Content.Shared.Maps;
+using Robust.Shared.Map;
+
+namespace Content.Shared._starcup.Construction.Conditions;
+
+/// <summary>
+/// starcup: Requires that the construction must be placed on a subfloor tile.
+/// </summary>
+[DataDefinition]
+public sealed partial class TileSubfloorCondition : IConstructionCondition
+{
+    public ConstructionGuideEntry GenerateGuideEntry()
+    {
+        return new ConstructionGuideEntry
+        {
+            Localization = "construction-step-condition-tile-is-subfloor",
+        };
+    }
+
+    public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
+    {
+        if (!IoCManager.Resolve<IEntityManager>().TrySystem<TurfSystem>(out var turfSystem))
+            return false;
+
+        if (!turfSystem.TryGetTileRef(location, out var tileRef))
+            return false;
+
+        var tileDef = turfSystem.GetContentTileDefinition(tileRef.Value);
+        return tileDef.IsSubFloor;
+    }
+}

--- a/Resources/Locale/en-US/_starcup/construction/Conditions/tile-subfloor.ftl
+++ b/Resources/Locale/en-US/_starcup/construction/Conditions/tile-subfloor.ftl
@@ -1,0 +1,1 @@
+construction-step-condition-tile-is-subfloor = The tile must be a subfloor.

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -659,11 +659,7 @@
   conditions:
     - !type:TileNotBlocked
       failIfSpace: false
-    - !type:TileType
-      targets:
-        - Lattice
-        - Plating
-        - FloorBasalt  # starcup: build catwalks over lava
+    - !type:TileSubfloorCondition  # starcup: replaced TileType condition with TileSubfloorCondition
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false


### PR DESCRIPTION
Catwalk construction was previously checking the ID of the tile it was attempting to be built on in order to check that it's being used like a top-layer tile. This prevented players from building catwalks across lava and similar things. Those entities were being generated on tiles with `isSubfloor: true`, so now we use that as our frame of reference instead.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Catwalks can now be built over lava, water, and any 'subfloor' tile.