### PR TITLE
feat: APC power and access wires

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -66,6 +66,13 @@ namespace Content.Client.Power.APC.UI
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
+                // Begin DeltaV Additions - set it to Disabled when power wire is snipped
+                if (!castState.PowerEnabled)
+                {
+                    ExternalPowerStateLabel.Text = Loc.GetString("apc-menu-power-state-disabled");
+                    ExternalPowerStateLabel.SetOnlyStyleClass(StyleNano.StyleClassPowerStateNone);
+                }
+                // End DeltaV Additions
             }
 
             if (ChargeBar != null)

--- a/Content.Server/Power/Components/PowerNetworkBatteryComponent.cs
+++ b/Content.Server/Power/Components/PowerNetworkBatteryComponent.cs
@@ -112,6 +112,16 @@ namespace Content.Server.Power.Components
             set => NetworkBattery.Efficiency = value;
         }
 
+        /// <summary>
+        /// DeltaV - Disables power I/O, controlled by <c>PowerBatteryWireAction</c>.
+        /// </summary>
+        [DataField]
+        public bool PowerEnabled
+        {
+            get => NetworkBattery.Enabled;
+            set => NetworkBattery.Enabled = value;
+        }
+
         [ViewVariables]
         public PowerState.Battery NetworkBattery { get; } = new();
     }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -169,7 +169,7 @@ public sealed class ApcSystem : EntitySystem
 
         var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled,
             (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
-            charge);
+            charge, battery.Enabled); // DeltaV
 
         _ui.SetUiState((uid, ui), ApcUiKey.Key, state);
     }

--- a/Content.Server/Wires/BaseWireAction.cs
+++ b/Content.Server/Wires/BaseWireAction.cs
@@ -86,6 +86,6 @@ public abstract partial class BaseWireAction : IWireAction
     /// <returns>true if powered, false otherwise</returns>
     protected bool IsPowered(EntityUid uid)
     {
-        return WiresSystem.IsPowered(uid, EntityManager);
+        return WiresSystem.HasPower(uid); // DeltaV - support APC power checks
     }
 }

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -21,7 +21,7 @@ using Robust.Shared.Random;
 
 namespace Content.Server.Wires;
 
-public sealed class WiresSystem : SharedWiresSystem
+public sealed partial class WiresSystem : SharedWiresSystem // DeltaV - made partial
 {
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;

--- a/Content.Server/_DV/Wires/WiresSystem.Power.cs
+++ b/Content.Server/_DV/Wires/WiresSystem.Power.cs
@@ -1,0 +1,17 @@
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+
+namespace Content.Server.Wires;
+
+public sealed partial class WiresSystem
+{
+    public bool HasPower(EntityUid uid)
+    {
+        // for APCs check if the power wire isn't snipped/pulsed
+        if (TryComp<PowerNetworkBatteryComponent>(uid, out var comp))
+            return comp.PowerEnabled;
+
+        // for other devices check for APCPowerReceiver
+        return this.IsPowered(uid, EntityManager);
+    }
+}

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -181,13 +181,15 @@ namespace Content.Shared.APC
         public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
+        public readonly bool PowerEnabled; // DeltaV
 
-        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, bool powerEnabled) // DeltaV - add powerEnabled
         {
             MainBreaker = mainBreaker;
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
+            PowerEnabled = powerEnabled; // DeltaV
         }
 
         public bool Equals(ApcBoundInterfaceState? other)
@@ -197,7 +199,8 @@ namespace Content.Shared.APC
             return MainBreaker == other.MainBreaker &&
                    Power == other.Power &&
                    ApcExternalPower == other.ApcExternalPower &&
-                   MathHelper.CloseTo(Charge, other.Charge);
+                   MathHelper.CloseTo(Charge, other.Charge) &&
+                   PowerEnabled == other.PowerEnabled; // DeltaV
         }
 
         public override bool Equals(object? obj)

--- a/Resources/Locale/en-US/_DV/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/_DV/ui/power-apc.ftl
@@ -1,0 +1,1 @@
+apc-menu-power-state-disabled = Disabled

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
@@ -41,6 +41,7 @@
           conditions:
             - !type:WirePanel
               open: true
+            - !type:AllWiresCut # DeltaV - APC wires
           steps:
             - tool: Prying
               doAfter: 4

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -228,7 +228,13 @@
 
 - type: wireLayout
   id: APC
-  dummyWires: 3
+  # begin DeltaV: add APC power wires
+  # dummyWires: 3
   wires:
-  - !type:AccessWireAction
+  - !type:PowerWireAction
+    pulseTimeout: 60 # double the times of airlock wires so it's more useful
+  - !type:PowerWireAction
+    pulseTimeout: 30
   - !type:AiInteractWireAction
+  - !type:AccessWireAction
+  # end DeltaV


### PR DESCRIPTION
Cherry-pick of https://github.com/DeltaV-Station/Delta-v/pull/3372. I realized that upstream already added an AI wire and wire panel to the APC, but this adds a few more for a more complete experience. All I changed from the original DeltaV PR is the wire panel layout, since I moved it to be an adjustment to upstream's instead of renaming the DeltaV prototype. 

If upstream's APC breaker popping gets merged, it might be nice to do a tweak to make it so that if one power wire is snipped, it can only support half as much of a load.

It might also be feasible to apply this to substations and SMESs. In this case we could also make their UI engi-locked and deconstruction require insuls. It's trivially easy to deconstruct or shut off a substation, once you get to it.

## Why / Balance
The power wires are useful, since they can be pulsed to give a window of time to do something before it automatically turns back on. They also serve to give an insuls requirement to deconstructing the APC, which makes it harder to do so; no more screwdriver + crowbar trick to reset them. However, to offset this, the access wire is added. Cutting this doesn't shock you and lets you toggle the APC. I don't think I've ever seen a breaker flip more than once on starcup, especially not on lowpop, but 
if there is an instance where engineers are unable to respond then this is a nice alternative. I think it's a nice balance of allowing and enabling antagonism while not being completely trivial.

**Changelog**
:cl: deltanedas
- feat: APCs now have power wires, which can be pulsed to temporarily deactivate power to an area.
- feat: APCs now have access wires, which can be safely cut without insuls.
