### PR TITLE
fix: add crux to the default map pool

### DIFF
--- a/Resources/Prototypes/_starcup/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_starcup/Maps/Pools/default.yml
@@ -23,3 +23,4 @@
   - Train
   - Banana
   - Shoukou
+  - Crux


### PR DESCRIPTION
it was supposed to be there but I didn't realize it was a file in the repo and not in the toml file!

**Changelog**
:cl:
- fix: crux is now part of the standard map pool and appears in map votes!