### PR TITLE
fix: don't show StandardTerrestrialStation in spawn menu

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
+++ b/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
@@ -25,3 +25,4 @@
   parent:
   - StandardTerrestrialStationNoEvac
   - BaseStationEvacuation
+  categories: [ HideSpawnMenu ]


### PR DESCRIPTION
Adds the `HideSpawnMenu` to `StandardTerrestrialStation`; this shouldn't be able to be spawned and shouldn't be in the menu, yet it is. It must not parent it from `StandardTerrestrialStationNoEvac`. It showed up as one of the first things in the list, though.