### PR TITLE
fix: rodentia can no longer be butchered with knives

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -92,10 +92,10 @@
         Slash: 3
   - type: Damageable
     damageModifierSet: Rodentia
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatRat
-      amount: 5
+  #- type: Butcherable # starcup: no butchering rodentia
+  #  spawned:
+  #  - id: FoodMeatRat
+  #    amount: 5
   - type: TypingIndicator
     proto: rodentia
   - type: Vocal


### PR DESCRIPTION
Comments out the `Butcherable` component on Rodentia, which was missed because it does not require a spike. A little confused that this wasn't noticed earlier, since from what I can tell this has been in DeltaV since Rodentia were added. 

## Why / Balance
Even if we allowed other humanoids to be butchered on a spike, Rodentia shouldn't be an exception..! It doesn't even drop the brain, from what I can tell!

**Changelog**
:cl:
- fix: Rodentia can no longer be butchered by sharp objects.
