### PR TITLE
config: disable pushing metrics

### DIFF
--- a/Resources/ConfigPresets/starcup/starcup.toml
+++ b/Resources/ConfigPresets/starcup/starcup.toml
@@ -81,8 +81,3 @@ auto_record = true
 auto_record_temp_dir = "replays_tmp/"
 max_compressed_size = 999999999999
 max_uncompressed_size = 999999999999
-
-[metrics]
-enabled = true
-host = "0.0.0.0"
-port = 44880


### PR DESCRIPTION
We want this to be suitable for development environments, which generally don't have Prometheus set up.