### PR TITLE
fix: more crux hotfixes

### DIFF
--- a/Resources/Maps/_starcup/crux.yml
+++ b/Resources/Maps/_starcup/crux.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 11/14/2025 10:26:33
+  time: 11/15/2025 21:28:22
   entityCount: 14164
 maps:
 - 1
@@ -4750,25 +4750,6 @@ entities:
       parent: 2
 - proto: AirlockAtmospherics
   entities:
-  - uid: 125
-    components:
-    - type: Transform
-      pos: -31.5,-9.5
-      parent: 2
-  - uid: 126
-    components:
-    - type: MetaData
-      name: Atmospherics
-    - type: Transform
-      pos: -33.5,-8.5
-      parent: 2
-  - uid: 127
-    components:
-    - type: MetaData
-      name: Atmospherics
-    - type: Transform
-      pos: -32.5,-8.5
-      parent: 2
   - uid: 128
     components:
     - type: MetaData
@@ -4791,6 +4772,23 @@ entities:
       name: Atmos Storage
     - type: Transform
       pos: -31.5,-6.5
+      parent: 2
+- proto: AirlockAtmosphericsLocked
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -31.5,-9.5
+      parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -33.5,-8.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -32.5,-8.5
       parent: 2
 - proto: AirlockBarLocked
   entities:


### PR DESCRIPTION
more stuff I forgot:

- drain in disposals
- tweaked armory contents (replaced the riot suits with a portable flasher, replaced the enforcer safe with a kammerer safe, replaced the lecter safe with an mk58 safe)
- wrong door name for the warden's office
- gave engineering a youtool
- removed the grilles from the burn chamber doors
- unlocked atmos doors replaced with locked ones

**Changelog**
:cl:
- fix: more crux hotfixes! some missing fixtures have been added, the armory's contents have been tweaked, and the burn chamber is finally completely unobstructed