### PR TITLE
tweak: reduce EMP mail chance

### DIFF
--- a/Resources/Prototypes/_DV/Mail/mailDeliveries.yml
+++ b/Resources/Prototypes/_DV/Mail/mailDeliveries.yml
@@ -27,7 +27,7 @@
     #MailCosplaySchoolgirl: 0.5  # starcup: disabled
     #MailNFCosplayNurse: 0.4  # starcup: disabled
     MailNFDonkPockets: 0.5
-    MailNFEMP: 0.3
+    MailNFEMP: 0.03 # starcup: 0.3 -> 0.03
     MailNFFigurineBulk: 1
     MailFishingCap: 0.5
     MailFlashlight: 1


### PR DESCRIPTION
Reduces the weighting of EMP mail by a factor of about a tenth.

## Why / Balance
It loses a lot of its impact and just becomes annoying when it happens 1-2 times a shift. It's also a bit of a silly thing to have happen so often IC.

**Changelog**
:cl:
- tweak: EMPs now appear in the mail less often.
