### PR TITLE
fix: mail/robotics windoors

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Windoors/windoor.yml
@@ -1,21 +1,23 @@
 - type: entity
-  parent: Windoor
+  parent: WindoorCargoLocked
   id: WindoorMailLocked
   suffix: Mail, Locked
   components:
-  - type: AccessReader
-    access: [["Mail"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMail ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureCargoLocked
   id: WindoorSecureMailLocked
   suffix: Mail, Locked
   components:
-  - type: AccessReader
-    access: [["Mail"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMail ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureScienceLocked
   id: WindoorSecureRoboticsLocked
   suffix: Robotics, Locked
   components:


### PR DESCRIPTION
per [delta-v#3499](https://redirect.github.com/DeltaV-Station/Delta-v/pull/3499), windoors needed to be re-parented and weren't, so their access restrictions weren't working! this fixes that

**Changelog**
:cl:
- fix: access restrictions for mailroom and robotics windoors now work