### PR TITLE
fix: mud, water, and magma entities not spawning

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Tiles/magma.yml
+++ b/Resources/Prototypes/_starcup/Entities/Tiles/magma.yml
@@ -17,7 +17,7 @@
       - Catwalk
   - type: TileEntityEffect
     effects:
-    - !type:FlammableReaction
+    - !type:Flammable
       multiplier: 3.75
       multiplierOnExisting: 0.75
     - !type:Ignite

--- a/Resources/Prototypes/_starcup/Entities/Tiles/mud.yml
+++ b/Resources/Prototypes/_starcup/Entities/Tiles/mud.yml
@@ -15,7 +15,7 @@
       - Catwalk
   - type: TileEntityEffect
     effects:
-    - !type:ExtinguishReaction
+    - !type:Extinguish
   - type: SyncSprite
   - type: Clickable
   - type: Sprite

--- a/Resources/Prototypes/_starcup/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/_starcup/Entities/Tiles/water.yml
@@ -17,7 +17,7 @@
       - Catwalk
   - type: TileEntityEffect
     effects:
-    - !type:ExtinguishReaction
+    - !type:Extinguish
   - type: SolutionContainerManager
     solutions:
       pool:


### PR DESCRIPTION
## Technical details
The tile effects were incorrectly labeled "ExtinguishReaction" and "FlammableReaction" when they should've just been Extinguish and Flammable. I copied these form the water and lava prototypes originally, so I figure it was some upstream change that was made between me first making these and the PR getting merged.
