### PR TITLE
tweak: remove undocumented reduced stamina threshold for felinids

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/felinid.yml
@@ -52,8 +52,10 @@
     damage:
       types:
         Blunt: 1
-  - type: Stamina
-    critThreshold: 85
+# begin starcup: remove undocumented reduced stamina threshold
+#  - type: Stamina
+#    critThreshold: 85
+# end starcup
   - type: TypingIndicator
     proto: felinid
   - type: PseudoItem


### PR DESCRIPTION
felinids had an undocumented feature of their species prototype that made their critical threshold for stamina damage 85. this removes that, bringing their threshold back up to 100.

## Why / Balance
did you know that felinids had this? I didn't know felinids had this, because it's completely undocumented. I also can't think of any reason why felinids *should* have this—they already take increased damage from the most common type in the game, I don't know why they also ought to take increased damage from the second most common type in the game. that just feels mean!

**Changelog**
:cl:
- tweak: felinids no longer have a lower stamina crit threshold than all other species