### PR TITLE
feat: dusk to dawn powered lighting

### DIFF
--- a/Content.Server/_starcup/Light/AmbientSensingLightComponent.cs
+++ b/Content.Server/_starcup/Light/AmbientSensingLightComponent.cs
@@ -1,0 +1,28 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._starcup.Light;
+
+/// <summary>
+/// Causes a PoweredLight to toggle based on the map's ambient light level. Used for dusk-to-dawn light fixtures.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AmbientSensingLightComponent : Component
+{
+    /// <summary>
+    /// Below this ambient (map) light level, the entity's PointLight will become enabled. It will be disabled above it.
+    /// </summary>
+    /// <remarks>
+    /// Compare this against LightCycleComponent's MinLightLevel and MaxLightLevel.
+    /// </remarks>
+    [DataField]
+    public float LightLevelThreshold = 0.8f;
+
+    /// <summary>
+    /// The game time after which this entity will toggle state. This is non-zero when the fixture is pending a state change.
+    /// </summary>
+    /// <remarks>
+    /// Used to stagger light fixture state changes, simulates realism.
+    /// </remarks>
+    [ViewVariables]
+    public TimeSpan StateChangeOffset;
+}

--- a/Content.Server/_starcup/Light/AmbientSensingLightSystem.cs
+++ b/Content.Server/_starcup/Light/AmbientSensingLightSystem.cs
@@ -1,0 +1,62 @@
+using Content.Server.GameTicking;
+using Content.Server.Light.EntitySystems;
+using Content.Shared._starcup.Light;
+using Content.Shared.Light.Components;
+using Content.Shared.Light.EntitySystems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._starcup.Light;
+
+/// <summary>
+/// Simulates dusk-to-dawn light fixtures.
+/// </summary>
+public sealed class AmbientSensingLightSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly PoweredLightSystem _poweredLight = default!;
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    private EntityQuery<LightCycleComponent> _lightCycleQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _lightCycleQuery = GetEntityQuery<LightCycleComponent>();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<AmbientSensingLightComponent, PoweredLightComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var ambientSensingLight, out var poweredLight, out var transform))
+        {
+            if (!_lightCycleQuery.TryComp(transform.MapUid, out var lightCycle))
+                continue;
+
+            var time = _timing.CurTime.Add(lightCycle.Offset).Subtract(_gameTicker.RoundStartTimeSpan).TotalSeconds;
+            var ambientLightLevel = SharedLightCycleSystem.CalculateLightLevel(lightCycle, (float) time);
+            var shouldBeEnabled = ambientLightLevel < ambientSensingLight.LightLevelThreshold;
+            var shouldToggle = poweredLight.On ^ shouldBeEnabled;
+
+            if (!shouldToggle)
+            {
+                ambientSensingLight.StateChangeOffset = TimeSpan.Zero;
+                continue;
+            }
+
+            if (ambientSensingLight.StateChangeOffset == TimeSpan.Zero)
+            {
+                ambientSensingLight.StateChangeOffset = _timing.CurTime + _robustRandom.Next(TimeSpan.FromSeconds(5));
+            }
+            else if (_timing.CurTime >= ambientSensingLight.StateChangeOffset)
+            {
+                _poweredLight.SetState(uid, shouldBeEnabled, poweredLight);
+                ambientSensingLight.StateChangeOffset = TimeSpan.Zero;
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/_starcup/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Lighting/ground_lighting.yml
@@ -89,6 +89,14 @@
     softness: 2
     color: "#FF8A0C"
 
+- type: entity
+  id: PoweredLightPostSmallAmbientSensingWarm
+  parent: PoweredLightPostSmallWarm
+  suffix: "Warm, Ambient Sensing"
+  components:
+  - type: AmbientSensingLight
+    lightLevelThreshold: 0.8
+
 # cold
 - type: entity
   id: PoweredLightPostSmallCold


### PR DESCRIPTION
Add ambient-sensing powered lights, which become active when the map's ambient light level (LightCycleComponent) drops below a configured value.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

https://github.com/user-attachments/assets/4228172c-197f-4231-a38f-6b790b8abf6a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->