### PR TITLE
feat: dynamic weather scheduling

### DIFF
--- a/Content.Server/_starcup/Weather/DynamicWeatherComponent.cs
+++ b/Content.Server/_starcup/Weather/DynamicWeatherComponent.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Weather;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._starcup.Weather;
+
+/// <summary>
+/// Add this to a *map entity* to enable randomized weather.
+///
+/// Example:
+/// <code>
+///    - type: DynamicWeather
+///      states:
+///        Clear:
+///          Clear: 162
+///          SnowfallLight: 1
+///          SnowfallHeavy: 0.05
+///        SnowfallLight:
+///          Clear: 1
+///          SnowfallLight: 100
+///          SnowfallMedium: 2
+///        SnowfallMedium:
+///          SnowfallLight: 3
+///          SnowfallMedium: 150
+///          SnowfallHeavy: 1
+///        SnowfallHeavy:
+///          SnowfallLight: 1
+///          SnowfallMedium: 3
+///          SnowfallHeavy: 36
+/// </code>
+///
+/// Each state is a weather prototype ID, and lists the next possible weather states and their weighted chance.
+/// </summary>
+[RegisterComponent]
+public sealed partial class DynamicWeatherComponent : Component
+{
+    [DataField(required: true)]
+    public Dictionary<ProtoId<WeatherPrototype>, Dictionary<ProtoId<WeatherPrototype>, float>> States;
+
+    /// <summary>
+    /// Wait this long before determining the next (random) weather state.
+    /// </summary>
+    /// <remarks>
+    /// It's best to keep this above 15 seconds to match <see cref="Content.Shared.Weather.WeatherComponent.ShutdownTime"/>.
+    /// </remarks>
+    [DataField]
+    public TimeSpan StepFrequency = TimeSpan.FromMinutes(1);
+
+    [DataField]
+    public bool RandomInitialState = true;
+
+    [ViewVariables]
+    public ProtoId<WeatherPrototype>? CurrentState;
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextUpdate;
+}

--- a/Content.Server/_starcup/Weather/DynamicWeatherSystem.cs
+++ b/Content.Server/_starcup/Weather/DynamicWeatherSystem.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using Content.Shared.Random.Helpers;
+using Content.Shared.Weather;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._starcup.Weather;
+
+public sealed class DynamicWeatherSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly SharedWeatherSystem _weather = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DynamicWeatherComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid entity, DynamicWeatherComponent dynamicWeather, MapInitEvent args)
+    {
+        ProtoId<WeatherPrototype>? initialStateProtoId = dynamicWeather.States.First().Key;
+        if (dynamicWeather.RandomInitialState)
+        {
+            var states = dynamicWeather.States.Keys.ToArray();
+            initialStateProtoId = states[_robustRandom.Next(states.Length)];
+        }
+
+        if (initialStateProtoId == "Clear")
+            initialStateProtoId = null;
+
+        WeatherPrototype? initialState = null;
+        if (initialStateProtoId != null && !_proto.Resolve(initialStateProtoId, out initialState))
+            return;
+
+        var mapId = Transform(entity).MapID;
+        _weather.SetWeather(mapId, initialState, dynamicWeather.NextUpdate + WeatherComponent.ShutdownTime);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _gameTiming.CurTime;
+        var query = EntityQueryEnumerator<DynamicWeatherComponent, MapComponent>();
+        while (query.MoveNext(out var entity, out var dynamicWeather, out var map))
+        {
+            if (now < dynamicWeather.NextUpdate)
+                continue;
+
+            dynamicWeather.NextUpdate = now + dynamicWeather.StepFrequency;
+
+            var previousStateProtoId = dynamicWeather.CurrentState;
+            NextState(dynamicWeather);
+
+            WeatherPrototype? nextState = null;
+            if (dynamicWeather.CurrentState != null && !_proto.Resolve(dynamicWeather.CurrentState, out nextState))
+                return;
+
+            WeatherPrototype? previousState = null;
+            if (previousStateProtoId != null)
+            {
+                _proto.Resolve(previousStateProtoId, out previousState);
+            }
+
+            var ev = new DynamicWeatherUpdateEvent(entity, previousState, nextState);
+            RaiseLocalEvent(entity, ref ev, true);
+
+            _weather.SetWeather(map.MapId, nextState, dynamicWeather.NextUpdate + WeatherComponent.ShutdownTime);
+        }
+    }
+
+    private void NextState(DynamicWeatherComponent dynamicWeather)
+    {
+        var previousState = dynamicWeather.CurrentState ?? dynamicWeather.States.First().Key;
+        var pick = SharedRandomExtensions.Pick(dynamicWeather.States[previousState], _robustRandom.GetRandom());
+
+        dynamicWeather.CurrentState = pick != "Clear" ? pick : (ProtoId<WeatherPrototype>?) null;
+    }
+}
+
+/// <summary>
+/// Raised when a map with dynamic weather switches from one weather state to another.
+/// </summary>
+[ByRefEvent]
+public readonly record struct DynamicWeatherUpdateEvent(EntityUid DynamicWeather, WeatherPrototype? PreviousState, WeatherPrototype? NextState);

--- a/Resources/Prototypes/_starcup/weather.yml
+++ b/Resources/Prototypes/_starcup/weather.yml
@@ -24,3 +24,10 @@
       volume: -25 # should be barely audible, if that, this will be playing constantly
   statusEffect: StatusEffectHushed
   refresh: true
+
+# NOTE: This isn't intended to be used directly! DynamicWeatherSystem secretly swaps this for `null`.
+- type: weather
+  id: Clear
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: storm


### PR DESCRIPTION
Add a dynamic weather scheduling system. Maps that opt in to this will define their own Markov chain of weather prototypes to switch between as well as the weighted chance of each being selected.

Complements #252.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
not player facing yet