### PR TITLE
fix: make aacs printable

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -48,7 +48,7 @@
   - WhiteCane
   - OffsetCane
   - OffsetCaneWood
-  - MedicalStaticDeltaV # DeltaV
+  - AACTablet # DeltaV
 
 - type: latheRecipePack
   id: RollerBedsStatic

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/medical.yml
@@ -1,6 +1,0 @@
-## Static
-
-- type: latheRecipePack
-  id: MedicalStaticDeltaV
-  recipes:
-  - AACTablet


### PR DESCRIPTION
lets aac tablets be printed at medfabs for 3 steel and 1 glass. labeled as a fix because this was supposed to be available when aacs were very first ported, but got lost in the shuffle

**Changelog**
:cl:
- add: aac tablets can now be printed at medfabs