### PR TITLE
fix: pain suppression effect

### DIFF
--- a/Content.Client/_DV/Pain/PainSystem.cs
+++ b/Content.Client/_DV/Pain/PainSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._DV.Pain;
+
+namespace Content.Client._DV.Pain;
+
+public sealed class PainSystem : SharedPainSystem {}

--- a/Content.Server/_DV/Pain/PainSystem.cs
+++ b/Content.Server/_DV/Pain/PainSystem.cs
@@ -25,7 +25,7 @@ public sealed class PainSystem : SharedPainSystem
         ent.Comp.NextPopupTime = _timing.CurTime;
     }
 
-    protected void UpdatePainSuppression(Entity<PainComponent> ent, float duration, PainSuppressionLevel level)
+    protected override void UpdatePainSuppression(Entity<PainComponent> ent, float duration, PainSuppressionLevel level)
     {
         var curTime = _timing.CurTime;
         var newEndTime = curTime + TimeSpan.FromSeconds(duration);

--- a/Content.Shared/_DV/Pain/SharedPainSystem.cs
+++ b/Content.Shared/_DV/Pain/SharedPainSystem.cs
@@ -3,13 +3,13 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._DV.Pain;
 
-public class SharedPainSystem : EntitySystem
+public abstract class SharedPainSystem : EntitySystem // starcup: make abstract
 {
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
 
     public ProtoId<StatusEffectPrototype> StatusEffectKey = "InPain";
 
-    protected void UpdatePainSuppression(Entity<PainComponent> ent, float duration, PainSuppressionLevel level)
+    protected virtual void UpdatePainSuppression(Entity<PainComponent> ent, float duration, PainSuppressionLevel level) // starcup: make virtual
     {
     }
 


### PR DESCRIPTION
Fixes #581

## Why / Balance
Bugfix

## Technical details
Overridden method was not being called.

Additionally, the InPain effect doesn't currently do anything and can be removed if there are no plans to have a non-trait pain effect. Left out of this PR.

**Changelog**
:cl:
- fix: Painkillers now function correctly again. Please remember to thank your local Interdyne representative for access to the non-placebo versions of their medications.
