### PR TITLE
Revert "tweak: remove undocumented reduced stamina threshold for felinids (#588)"

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/felinid.yml
@@ -52,10 +52,8 @@
     damage:
       types:
         Blunt: 1
-# begin starcup: remove undocumented reduced stamina threshold
-#  - type: Stamina
-#    critThreshold: 85
-# end starcup
+  - type: Stamina
+    critThreshold: 85
   - type: TypingIndicator
     proto: felinid
   - type: PseudoItem


### PR DESCRIPTION
## Why / Balance
needed more direction review as to whether to remove the nerf or just keep the change with documentation

**Changelog**
:cl:
- tweak: felinids' reduced stamina threshold has been re-introduced pending further discussion