### PR TITLE
tweak: remove cut wires from roundstart variation

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -504,7 +504,7 @@
     - id: BasicTrashVariationPass
     - id: SolidWallRustingVariationPass
     - id: ReinforcedWallRustingVariationPass
-    - id: CutWireVariationPass
+    # - id: CutWireVariationPass # starcup: removed
     - id: BasicPuddleMessVariationPass
       prob: 0.99
       orGroup: puddleMess


### PR DESCRIPTION
[wizden#41191](https://redirect.github.com/space-wizards/space-station-14/pull/41191) added the unused `CutWireVariationPass` to the basic roundstart variation set. this comments that back out

## Why / Balance
random airlocks being electrified at roundstart is annoying and saddles an already harried engineering department with even more stressful obligations. the lack of feedback on wires being cut also means it's either nearly or outright impossible to tell that a wire has been cut until you suffer its consequences. nobody liked this once they learned about it

**Changelog**
:cl:
- remove: wires on the station will no longer randomly be cut at roundstart