### PR TITLE
feat: add an option for ore boxes to dump contents (from delta)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -8,6 +8,7 @@
     price: 500
   - type: Anchorable
   - type: InteractionOutline
+  - type: Dumpable #DeltaV
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood


### PR DESCRIPTION
port of [deltav#4786](https://github.com/DeltaV-Station/Delta-v/pull/4786) that just gives ore boxes the `Dumpable` component so they can have their contents dumped onto the ground via verb or alt-click. very handy!

**Changelog**
:cl:
- add: ore boxes can now dump out ores!