### PR TITLE
fix: put the energy shotgun into the warden locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -46,6 +46,7 @@
       amount: 2
     - id: NetworkConfigurator
     - id: Binoculars
+    - id: WeaponEnergyShotgun # starcup: give the warden the energy shotgun
 
 - type: entityTable
   id: FillLockerWardenHarduit


### PR DESCRIPTION
adds the energy shotgun to the warden's locker fill, so it'll always be there at roundstart

## Why / Balance
upstream moved this to a mapped spawner for reasons I can't quite figure out, and this way matches the distribution of the hos's energy magnum

**Changelog**
:cl:
- fix: the energy shotgun should now spawn in the warden's locker as intended