### PR TITLE
tweak: adjust prisoner wardrobe inventories

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -23,13 +23,13 @@
   id: FillWardrobePrison
   table: !type:AllSelector
     children:
-    # begin starcup changes
     - !type:AllSelector
       rolls: 2
       children:
       - id: ClothingUniformJumpsuitPrisoner
       - id: ClothingUniformJumpskirtPrisoner
       - id: ClothingShoesColorBlack
+    # begin starcup changes
     - id: ClothingHeadsetPrisoner
     #- id: ClothingMaskMuzzle
     # end starcup changes


### PR DESCRIPTION
Makes prisoner headsets guaranteed to spawn in a wardrobe and makes muzzles only have a chance to appear.

## Why / Balance
Prisoner headsets/encryption keys are currently only available through roundstart prisoners, a box in the warden office, and the HoP. This is a large barrier for secoffs sentencing people to permanent confinement; they can not easily get any sort of replacement headset. Since this is one of the few means prisoners have to interact with the environment outside of the brig, it's not worth risking a forgetful secoff being given the duty of handing out the headset.

The muzzle was previously the only item guaranteed to be in a prisoner locker. This is weird for many reasons; I moved it to the rare item list. Everything else in that list seems fine to me.

**Changelog**
:cl:
- tweak: Prisoner wardrobes now contain prisoner headsets.
