### PR TITLE
map(byoin): Byoin Will Be Clean

### DIFF
--- a/Resources/Maps/_starcup/byoin.yml
+++ b/Resources/Maps/_starcup/byoin.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 10/21/2025 02:08:52
-  entityCount: 15874
+  time: 12/03/2025 06:22:18
+  entityCount: 15914
 maps:
 - 1
 grids:
@@ -3900,7 +3900,8 @@ entities:
           1,4:
             0: 65419
           2,0:
-            0: 48043
+            0: 47787
+            1: 256
           2,1:
             0: 65339
           2,2:
@@ -3914,7 +3915,8 @@ entities:
           3,0:
             0: 30576
           3,1:
-            0: 63255
+            0: 62231
+            1: 1024
           3,2:
             0: 54612
           3,-1:
@@ -3936,7 +3938,8 @@ entities:
           0,-5:
             0: 40944
           0,-3:
-            0: 62685
+            0: 58589
+            1: 4096
           -1,-4:
             0: 62566
           0,-2:
@@ -3965,19 +3968,19 @@ entities:
             0: 65524
           3,-3:
             0: 28735
-            1: 34816
+            2: 34816
           3,-2:
             0: 62259
-            1: 136
+            2: 136
           3,-5:
             0: 65293
           4,-4:
             0: 62122
           4,-3:
-            1: 13056
+            2: 13056
             0: 51342
           4,-2:
-            1: 51
+            2: 51
             0: 63624
           4,-1:
             0: 65339
@@ -4003,17 +4006,19 @@ entities:
             0: 65358
           -3,-4:
             0: 14131
-            2: 34952
+            3: 34952
           -3,-3:
-            0: 43938
+            0: 43936
+            1: 2
           -3,-2:
             0: 4082
           -3,-5:
-            0: 7633
+            1: 1
+            0: 7632
           -3,-1:
             0: 61166
           -2,-4:
-            2: 4369
+            3: 4369
             0: 52940
           -2,-3:
             0: 57308
@@ -4046,7 +4051,8 @@ entities:
           -4,4:
             0: 2047
           -3,0:
-            0: 8160
+            0: 7136
+            1: 1024
           -3,1:
             0: 65485
           -3,2:
@@ -4073,7 +4079,7 @@ entities:
             0: 8191
           0,8:
             0: 4369
-            3: 50252
+            4: 50252
           1,5:
             0: 15289
           1,6:
@@ -4081,39 +4087,39 @@ entities:
           1,7:
             0: 36863
           1,8:
-            3: 12835
+            4: 12835
             0: 34952
           2,5:
             0: 61439
           2,6:
             0: 238
-            3: 57344
+            4: 57344
           2,7:
-            3: 8928
+            4: 8928
           2,8:
-            3: 11810
+            4: 11810
           3,5:
             0: 65535
           3,6:
             0: 255
-            3: 61440
+            4: 61440
           3,7:
-            3: 244
+            4: 244
           4,4:
             0: 4064
           4,5:
             0: 65535
           4,6:
             0: 255
-            3: 53248
+            4: 53248
           4,7:
-            3: 156
+            4: 156
           5,5:
             0: 4078
           5,7:
-            3: 4080
+            4: 4080
           4,8:
-            3: 3976
+            4: 3976
           5,4:
             0: 20206
           5,6:
@@ -4121,9 +4127,10 @@ entities:
           5,3:
             0: 61156
           6,4:
-            0: 3824
+            0: 2800
+            1: 1024
           6,7:
-            3: 4080
+            4: 4080
           6,3:
             0: 63347
           6,5:
@@ -4131,24 +4138,24 @@ entities:
           6,6:
             0: 61152
           7,7:
-            3: 310
+            4: 310
           7,3:
             0: 61559
           7,4:
             0: 3822
           7,5:
-            3: 26214
+            4: 26214
           7,6:
-            3: 26214
+            4: 26214
           7,8:
-            3: 4002
+            4: 4002
           8,4:
             0: 25207
           8,5:
             0: 255
-            3: 61440
+            4: 61440
           8,6:
-            3: 19457
+            4: 19457
           5,0:
             0: 10099
           5,1:
@@ -4186,7 +4193,8 @@ entities:
           5,-4:
             0: 61951
           5,-3:
-            0: 30479
+            0: 30471
+            1: 8
           5,-2:
             0: 63351
           5,-5:
@@ -4218,53 +4226,53 @@ entities:
           -5,4:
             0: 3839
           -4,5:
-            4: 30583
+            5: 30583
           -5,5:
-            4: 61166
+            5: 61166
             0: 4096
           -4,6:
-            4: 50288
-            3: 13056
+            5: 50288
+            4: 13056
           -5,6:
-            4: 240
-            3: 65280
+            5: 240
+            4: 65280
           -4,7:
-            3: 140
+            4: 140
           -3,5:
             0: 65535
           -3,6:
             0: 255
-            4: 61440
+            5: 61440
           -3,7:
-            3: 56785
-            4: 8750
+            4: 56785
+            5: 8750
           -3,8:
-            3: 3857
-            4: 14
+            4: 3857
+            5: 14
           -2,5:
             0: 65535
           -2,6:
             0: 255
-            4: 61440
+            5: 61440
           -2,7:
-            4: 15
-            3: 65520
+            5: 15
+            4: 65520
           -2,8:
-            4: 15
-            3: 3840
+            5: 15
+            4: 3840
           -1,4:
             0: 30576
           -1,5:
             0: 30583
           -1,6:
             0: 119
-            4: 28672
+            5: 28672
           -1,7:
-            4: 8739
-            3: 21844
+            5: 8739
+            4: 21844
           -1,8:
-            4: 3
-            3: 18244
+            5: 3
+            4: 18244
           9,0:
             0: 29615
           9,1:
@@ -4287,7 +4295,7 @@ entities:
             0: 65522
           10,-1:
             0: 65280
-            3: 2
+            4: 2
           10,4:
             0: 26495
           11,0:
@@ -4300,19 +4308,19 @@ entities:
             0: 63078
           11,-1:
             0: 40192
-            3: 128
+            4: 128
           11,4:
             0: 65510
           12,0:
             0: 273
-            4: 52428
+            5: 52428
           12,1:
             0: 4369
-            4: 12
-            3: 52352
+            5: 12
+            4: 52352
           12,2:
             0: 13057
-            3: 132
+            4: 132
           12,3:
             0: 30467
           8,-5:
@@ -4329,18 +4337,18 @@ entities:
             0: 40189
           10,-3:
             0: 6331
-            3: 16384
-            4: 32768
+            4: 16384
+            5: 32768
           10,-2:
             0: 17
-            3: 11460
-            4: 8
+            4: 11460
+            5: 8
           10,-5:
             0: 53745
           11,-4:
             0: 61423
           11,-2:
-            3: 1808
+            4: 1808
             0: 2060
           11,-3:
             0: 61160
@@ -4352,12 +4360,12 @@ entities:
             0: 48056
           12,-2:
             0: 9
-            3: 43776
-            4: 17408
+            4: 43776
+            5: 17408
           12,-1:
-            3: 16570
+            4: 16570
             0: 768
-            4: 35908
+            5: 35908
           4,-8:
             0: 65520
           4,-7:
@@ -4365,22 +4373,22 @@ entities:
           4,-6:
             0: 63287
           4,-9:
-            3: 19524
+            4: 19524
           5,-8:
             0: 61712
-            3: 192
+            4: 192
           5,-7:
             0: 65295
           5,-6:
             0: 65295
           5,-9:
-            3: 12032
+            4: 12032
           6,-7:
             0: 65252
           6,-6:
             0: 28518
           6,-9:
-            3: 7936
+            4: 7936
           6,-8:
             0: 61152
           7,-8:
@@ -4391,26 +4399,27 @@ entities:
             0: 4080
           7,-9:
             0: 50176
-            3: 256
+            4: 256
           8,-8:
             0: 61713
-            3: 196
+            4: 196
           8,-7:
             0: 65535
           8,-6:
             0: 3846
           8,-9:
             0: 4352
-            3: 19456
+            4: 19456
           9,-8:
-            3: 17
+            4: 17
             0: 62668
           9,-7:
             0: 65535
           9,-6:
-            0: 8184
+            0: 8152
+            1: 32
           9,-9:
-            3: 4352
+            4: 4352
             0: 50176
           10,-8:
             0: 56785
@@ -4420,7 +4429,7 @@ entities:
             0: 57308
           10,-9:
             0: 4352
-            3: 19456
+            4: 19456
           11,-8:
             0: 30576
           11,-7:
@@ -4428,10 +4437,10 @@ entities:
           11,-6:
             0: 32759
           11,-9:
-            3: 36608
+            4: 36608
           12,-7:
             0: 13104
-            3: 128
+            4: 128
           12,-5:
             0: 14515
           -4,-8:
@@ -4455,7 +4464,7 @@ entities:
           -3,-6:
             0: 48113
           -3,-9:
-            3: 34560
+            4: 34560
           -2,-8:
             0: 65534
           -2,-7:
@@ -4464,7 +4473,7 @@ entities:
             0: 30578
           -2,-9:
             0: 57344
-            3: 81
+            4: 81
           -1,-8:
             0: 32631
           -1,-7:
@@ -4473,7 +4482,7 @@ entities:
             0: 49147
           -1,-9:
             0: 28672
-            3: 84
+            4: 84
           0,-8:
             0: 32767
           0,-7:
@@ -4481,39 +4490,39 @@ entities:
           0,-6:
             0: 48059
           -8,0:
-            3: 24379
-            4: 196
+            4: 24379
+            5: 196
           -8,-1:
-            4: 65484
-            3: 51
+            5: 65484
+            4: 51
           -9,0:
-            3: 255
+            4: 255
           -8,1:
-            3: 4437
+            4: 4437
           -8,2:
-            3: 4369
+            4: 4369
           -8,3:
-            3: 39313
+            4: 39313
           -8,4:
-            3: 8089
+            4: 8089
           -7,0:
-            4: 13104
+            5: 13104
             0: 34944
           -7,-1:
             0: 65518
           -7,1:
-            4: 3
-            5: 1536
+            5: 3
+            6: 1536
             0: 8
           -7,2:
-            6: 6
-            7: 1536
+            7: 6
+            8: 1536
           -7,3:
-            4: 6
+            5: 6
             0: 60928
           -7,4:
             0: 238
-            3: 28672
+            4: 28672
           -6,0:
             0: 65520
           -6,1:
@@ -4527,10 +4536,10 @@ entities:
           -6,4:
             0: 62719
           -8,-2:
-            3: 61440
+            4: 61440
           -9,-1:
-            3: 255
-            4: 65280
+            4: 255
+            5: 65280
           -6,-4:
             0: 3838
           -6,-5:
@@ -4540,133 +4549,133 @@ entities:
           -6,-2:
             0: 3820
           -8,5:
-            3: 4369
+            4: 4369
           -8,6:
-            3: 4369
+            4: 4369
           -8,7:
-            3: 4369
-            4: 32768
+            4: 4369
+            5: 32768
           -8,8:
-            3: 4375
-            4: 32904
+            4: 4375
+            5: 32904
           -7,7:
-            4: 61440
-            3: 546
+            5: 61440
+            4: 546
           -7,5:
-            3: 26487
+            4: 26487
           -7,8:
-            4: 61663
-            3: 512
+            5: 61663
+            4: 512
           -7,6:
-            3: 11878
-            4: 128
+            4: 11878
+            5: 128
           -6,5:
             0: 62719
           -6,6:
             0: 1
-            4: 8944
-            3: 3328
+            5: 8944
+            4: 3328
           -6,7:
-            4: 41506
+            5: 41506
           -6,8:
-            4: 41646
+            5: 41646
           -5,7:
-            4: 28672
-            3: 546
+            5: 28672
+            4: 546
           -5,8:
-            4: 61691
-            3: 512
+            5: 61691
+            4: 512
           -12,-1:
-            3: 4607
-            4: 60928
+            4: 4607
+            5: 60928
           -12,0:
-            3: 17663
+            4: 17663
           -11,-1:
-            4: 65530
+            5: 65530
           -11,0:
-            4: 255
+            5: 255
           -10,-1:
-            4: 65296
-            3: 238
+            5: 65296
+            4: 238
           -10,0:
-            4: 17
-            3: 17646
+            5: 17
+            4: 17646
           13,-4:
             0: 65531
           13,-3:
             0: 65535
           13,-2:
             0: 15
-            3: 3840
+            4: 3840
           13,-1:
-            3: 240
-            4: 36608
+            4: 240
+            5: 36608
           14,-4:
             0: 14199
           14,-3:
             0: 13107
-            3: 32768
+            4: 32768
           14,-2:
             0: 3
-            3: 3976
+            4: 3976
           14,-1:
-            3: 112
-            4: 36736
+            4: 112
+            5: 36736
           13,0:
-            4: 56797
-            3: 512
+            5: 56797
+            4: 512
           15,-4:
             0: 63351
           15,-3:
-            3: 61440
+            4: 61440
             0: 14
           15,-1:
-            3: 240
-            4: 36608
+            4: 240
+            5: 36608
           14,0:
-            4: 56797
-            3: 512
+            5: 56797
+            4: 512
           15,-5:
             0: 65024
           15,-2:
-            3: 3072
+            4: 3072
           16,-4:
             0: 32382
           16,-3:
             0: 3
-            3: 61440
+            4: 61440
           16,-2:
-            3: 3976
+            4: 3976
           16,-1:
-            3: 35224
+            4: 35224
           15,0:
-            4: 56797
-            3: 512
+            5: 56797
+            4: 512
           12,-6:
             0: 60066
           12,-8:
-            3: 8
+            4: 8
           12,-9:
-            3: 50944
+            4: 50944
           13,-8:
-            3: 8753
+            4: 8753
           13,-7:
-            3: 8946
+            4: 8946
           13,-6:
             0: 13104
-            3: 32776
+            4: 32776
           13,-5:
             0: 4016
           14,-7:
-            3: 17520
+            4: 17520
           14,-6:
-            3: 62543
+            4: 62543
           14,-5:
             0: 816
           15,-6:
-            3: 61455
+            4: 61455
           16,-6:
-            3: 63631
+            4: 63631
           16,-5:
             0: 29440
           0,-9:
@@ -4695,26 +4704,26 @@ entities:
             0: 1911
           3,-9:
             0: 4369
-            3: 50176
+            4: 50176
           8,7:
-            3: 25668
+            4: 25668
           8,8:
-            3: 19
+            4: 19
           9,5:
-            3: 63624
+            4: 63624
             0: 546
           9,6:
-            3: 32767
+            4: 32767
           9,7:
-            3: 2
+            4: 2
           10,6:
-            3: 44800
+            4: 44800
           10,5:
-            3: 96
+            4: 96
           10,7:
-            3: 8746
+            4: 8746
           10,8:
-            3: 8930
+            4: 8930
           11,5:
             0: 65535
           11,6:
@@ -4723,7 +4732,7 @@ entities:
             0: 57582
           11,8:
             0: 6
-            3: 1024
+            4: 1024
           12,4:
             0: 24694
           12,5:
@@ -4733,30 +4742,30 @@ entities:
           12,7:
             0: 65535
           -12,1:
-            3: 50244
+            4: 50244
           -11,1:
-            3: 61440
+            4: 61440
           -10,1:
-            3: 29764
+            4: 29764
           -8,-7:
-            3: 34947
+            4: 34947
           -9,-7:
-            3: 34952
+            4: 34952
           -8,-6:
-            3: 15
+            4: 15
           -9,-6:
-            3: 8
+            4: 8
           -8,-8:
-            3: 514
+            4: 514
             0: 34952
           -8,-9:
             0: 34952
-            3: 770
+            4: 770
           -7,-8:
             0: 65535
           -7,-9:
             0: 62003
-            3: 136
+            4: 136
           -7,-7:
             0: 61152
           -6,-8:
@@ -4765,114 +4774,114 @@ entities:
             0: 49144
           -6,-9:
             0: 63624
-            3: 50
+            4: 50
           -5,-9:
             0: 12851
-            3: 2048
+            4: 2048
           0,-11:
-            3: 61440
+            4: 61440
           -1,-11:
-            3: 57344
+            4: 57344
           0,-10:
-            3: 112
+            4: 112
             0: 28672
           -1,-10:
-            3: 18331
+            4: 18331
           1,-11:
-            3: 61440
+            4: 61440
           1,-10:
             0: 61440
-            3: 192
+            4: 192
           2,-11:
-            3: 61440
+            4: 61440
           2,-10:
-            3: 242
+            4: 242
             0: 53248
           3,-11:
-            3: 61440
+            4: 61440
           3,-10:
-            3: 58
+            4: 58
             0: 4096
           4,-10:
-            3: 17969
+            4: 17969
           -4,-10:
-            3: 3840
+            4: 3840
           -5,-10:
-            3: 2048
+            4: 2048
             0: 12800
           -4,-9:
-            3: 3840
+            4: 3840
           -3,-10:
-            3: 3840
+            4: 3840
           -2,-10:
-            3: 7936
+            4: 7936
           13,1:
-            4: 13
-            3: 63616
+            5: 13
+            4: 63616
           13,2:
-            3: 17520
+            4: 17520
           13,3:
-            3: 21572
+            4: 21572
           13,4:
-            3: 9117
+            4: 9117
           14,1:
-            4: 13
-            3: 63616
+            5: 13
+            4: 63616
           15,1:
-            4: 13
-            3: 63616
+            5: 13
+            4: 63616
           16,0:
-            4: 4369
-            3: 36488
+            5: 4369
+            4: 36488
           16,1:
-            4: 1
-            3: 31880
+            5: 1
+            4: 31880
           -8,9:
-            3: 25367
-            4: 136
+            4: 25367
+            5: 136
           -8,10:
-            3: 12
+            4: 12
           -7,9:
-            4: 255
-            3: 8704
+            5: 255
+            4: 8704
           -7,10:
-            3: 15
+            4: 15
           -6,9:
-            4: 175
-            3: 8704
+            5: 175
+            4: 8704
           -6,10:
-            3: 15
+            4: 15
           -5,9:
-            4: 255
-            3: 8704
+            5: 255
+            4: 8704
           -5,10:
-            3: 15
+            4: 15
           -4,9:
-            3: 17479
+            4: 17479
           -4,10:
-            3: 19535
+            4: 19535
           -4,8:
-            3: 51200
+            4: 51200
           -4,11:
-            3: 35908
+            4: 35908
           -3,10:
-            3: 257
+            4: 257
             0: 60620
           -3,11:
-            3: 4096
+            4: 4096
             0: 140
           -3,12:
-            3: 227
+            4: 227
           -3,9:
             0: 60544
           -2,9:
             0: 48000
-            3: 3
+            4: 3
           -2,10:
             0: 48955
           -2,11:
             0: 139
-            3: 768
+            4: 768
           -1,9:
             0: 64432
           -1,10:
@@ -4886,36 +4895,36 @@ entities:
           0,11:
             0: 511
           -8,-10:
-            3: 768
+            4: 768
             0: 34816
           -9,-10:
-            3: 34816
+            4: 34816
           -9,-9:
-            3: 34952
+            4: 34952
           -7,-10:
             0: 12800
-            3: 34816
+            4: 34816
           -6,-10:
-            3: 8960
+            4: 8960
             0: 34816
           -9,-8:
-            3: 34952
+            4: 34952
           12,8:
             0: 65535
           13,7:
             0: 61422
           13,5:
-            3: 14
+            4: 14
             0: 26112
           13,6:
             0: 36580
           13,8:
             0: 238
-            3: 49152
+            4: 49152
           14,4:
-            3: 3856
+            4: 3856
           14,5:
-            3: 15
+            4: 15
             0: 47872
           14,6:
             0: 36850
@@ -4923,24 +4932,24 @@ entities:
             0: 15283
           14,8:
             0: 51
-            3: 20488
+            4: 20488
           15,4:
-            3: 12032
+            4: 12032
           15,5:
-            3: 3
+            4: 3
             0: 4352
           15,6:
             0: 13105
-            3: 34952
+            4: 34952
           15,7:
             0: 817
-            3: 32768
+            4: 32768
           16,4:
-            3: 12544
+            4: 12544
           16,6:
-            3: 8739
+            4: 8739
           16,7:
-            3: 12834
+            4: 12834
           1,9:
             0: 65528
           1,10:
@@ -4954,7 +4963,7 @@ entities:
           2,11:
             0: 255
           3,8:
-            3: 3840
+            4: 3840
           3,9:
             0: 56784
           3,10:
@@ -4963,104 +4972,109 @@ entities:
             0: 255
           4,9:
             0: 53504
-            3: 2
+            4: 2
           4,10:
             0: 57289
           4,11:
             0: 1
-            3: 4608
+            4: 4608
           4,12:
-            3: 241
+            4: 241
           5,8:
-            3: 3840
+            4: 3840
           5,9:
             0: 4096
-            3: 17408
+            4: 17408
           5,10:
             0: 4400
-            3: 18440
+            4: 18440
           5,11:
-            3: 32772
+            4: 32772
           6,8:
-            3: 12032
+            4: 12032
           6,10:
-            3: 8995
+            4: 8995
           5,12:
-            3: 124
+            4: 124
           6,11:
-            3: 4898
+            4: 4898
           6,9:
-            3: 8738
+            4: 8738
           3,12:
-            3: 128
+            4: 128
           -2,12:
-            3: 16
+            4: 16
           17,-6:
-            3: 6343
+            4: 6343
           17,-5:
-            3: 17955
+            4: 17955
           17,-4:
-            3: 17604
+            4: 17604
           18,-6:
-            3: 12544
+            4: 12544
           18,-5:
-            3: 57890
+            4: 57890
           18,-4:
-            3: 57906
+            4: 57906
           19,-5:
-            3: 12808
-            4: 34816
+            4: 12808
+            5: 34816
           19,-4:
-            3: 12290
-            4: 35976
+            4: 12290
+            5: 35976
           20,-5:
-            3: 1
-            4: 30496
+            4: 1
+            5: 30496
           17,-3:
-            3: 4902
+            4: 4902
           17,-2:
-            3: 1992
+            4: 1992
           18,-2:
-            3: 1
+            4: 1
           18,-3:
-            3: 12834
+            4: 12834
           19,-3:
-            3: 546
-            4: 3080
+            4: 546
+            5: 3080
           20,-4:
-            4: 30527
+            5: 30527
           20,-3:
-            4: 4375
+            5: 4375
           19,-2:
-            3: 8
+            4: 8
           20,-2:
-            3: 1
+            4: 1
           21,-4:
-            3: 4368
+            4: 4368
           12,9:
-            3: 61680
+            4: 61680
           11,9:
-            3: 63872
+            4: 63872
           13,9:
-            3: 61712
+            4: 61712
           14,9:
-            3: 13900
+            4: 13900
           15,9:
-            3: 15
+            4: 15
           15,8:
-            3: 32768
+            4: 32768
           16,8:
-            3: 4898
+            4: 4898
           10,9:
-            3: 2246
+            4: 2246
           16,5:
-            3: 8738
+            4: 8738
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
             Oxygen: 21.824879
             Nitrogen: 82.10312
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         - volume: 2500
           temperature: 235
           moles:
@@ -15386,6 +15400,73 @@ entities:
     components:
     - type: Transform
       pos: 45.655445,31.67928
+      parent: 2
+  - uid: 15875
+    components:
+    - type: Transform
+      parent: 5233
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15878
+    components:
+    - type: Transform
+      parent: 5234
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15881
+    components:
+    - type: Transform
+      parent: 5272
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15884
+    components:
+    - type: Transform
+      pos: 12.806155,-32.188396
+      parent: 2
+  - uid: 15886
+    components:
+    - type: Transform
+      rot: -6.283185307179586 rad
+      pos: 10.683707,-21.741764
+      parent: 2
+  - uid: 15887
+    components:
+    - type: Transform
+      pos: -11.148347,4.2877216
+      parent: 2
+  - uid: 15892
+    components:
+    - type: Transform
+      pos: 15.804019,-16.5309
+      parent: 2
+  - uid: 15894
+    components:
+    - type: Transform
+      pos: -2.6718347,-11.069378
+      parent: 2
+  - uid: 15897
+    components:
+    - type: Transform
+      pos: 23.196728,-11.071844
+      parent: 2
+  - uid: 15898
+    components:
+    - type: Transform
+      pos: 36.94413,-22.671928
+      parent: 2
+  - uid: 15899
+    components:
+    - type: Transform
+      pos: 38.98566,-1.6614022
+      parent: 2
+  - uid: 15901
+    components:
+    - type: Transform
+      pos: -10.2039385,-22.669157
       parent: 2
 - proto: BurnAutoInjector
   entities:
@@ -25973,11 +26054,6 @@ entities:
     - type: Transform
       pos: 9.5,-21.5
       parent: 2
-  - uid: 3561
-    components:
-    - type: Transform
-      pos: 23.5,29.5
-      parent: 2
   - uid: 3562
     components:
     - type: Transform
@@ -27521,7 +27597,7 @@ entities:
   - uid: 3870
     components:
     - type: Transform
-      pos: 21.5,29.5
+      pos: 23.5,29.5
       parent: 2
   - uid: 3871
     components:
@@ -29567,6 +29643,11 @@ entities:
     components:
     - type: Transform
       pos: 49.5,4.5
+      parent: 2
+  - uid: 10651
+    components:
+    - type: Transform
+      pos: 21.5,29.5
       parent: 2
 - proto: CableMVStack
   entities:
@@ -34657,16 +34738,65 @@ entities:
     - type: Transform
       pos: 14.5,6.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 5233
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15875
+          - 15876
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
   - uid: 5234
     components:
     - type: Transform
       pos: 37.5,-22.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15879
+          - 15877
+          - 15878
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
   - uid: 5235
     components:
     - type: Transform
@@ -34956,6 +35086,14 @@ entities:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: Fixtures
       fixtures: {}
   - uid: 5271
@@ -34972,6 +35110,22 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -11.5,-11.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15881
+          - 15880
     - type: Fixtures
       fixtures: {}
   - uid: 5273
@@ -34996,6 +35150,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -10.5,-19.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: Fixtures
       fixtures: {}
   - uid: 5276
@@ -35011,6 +35173,21 @@ entities:
     - type: Transform
       pos: 23.5,-10.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15882
     - type: Fixtures
       fixtures: {}
   - uid: 5278
@@ -47548,13 +47725,6 @@ entities:
     - type: Transform
       pos: 44.771873,-30.461567
       parent: 2
-- proto: DrinkKiraSpecial
-  entities:
-  - uid: 7582
-    components:
-    - type: Transform
-      pos: 3.2471948,10.517842
-      parent: 2
 - proto: DrinkManlyDorfGlass
   entities:
   - uid: 7583
@@ -47645,6 +47815,13 @@ entities:
     components:
     - type: Transform
       pos: 13.560448,20.559834
+      parent: 2
+- proto: DrinkOrangeLimeSodaGlass
+  entities:
+  - uid: 7582
+    components:
+    - type: Transform
+      pos: 3.2471948,10.517842
       parent: 2
 - proto: DrinkPinkDrinkGlass
   entities:
@@ -72508,11 +72685,6 @@ entities:
     - type: Transform
       pos: 4.5,-16.5
       parent: 2
-  - uid: 10651
-    components:
-    - type: Transform
-      pos: 22.5,29.5
-      parent: 2
   - uid: 10652
     components:
     - type: Transform
@@ -73078,20 +73250,10 @@ entities:
     - type: Transform
       pos: -29.5,-31.5
       parent: 2
-  - uid: 10765
-    components:
-    - type: Transform
-      pos: 21.5,29.5
-      parent: 2
   - uid: 10766
     components:
     - type: Transform
       pos: 26.5,29.5
-      parent: 2
-  - uid: 10767
-    components:
-    - type: Transform
-      pos: 23.5,29.5
       parent: 2
   - uid: 10768
     components:
@@ -74972,6 +75134,21 @@ entities:
     components:
     - type: Transform
       pos: 43.5,22.5
+      parent: 2
+  - uid: 15910
+    components:
+    - type: Transform
+      pos: 22.5,29.5
+      parent: 2
+  - uid: 15913
+    components:
+    - type: Transform
+      pos: 21.5,29.5
+      parent: 2
+  - uid: 15914
+    components:
+    - type: Transform
+      pos: 23.5,29.5
       parent: 2
 - proto: GrilleBroken
   entities:
@@ -78065,6 +78242,25 @@ entities:
     - type: Transform
       pos: 0.5,-8.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15066
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: LockerBotanistFilled
   entities:
   - uid: 11573
@@ -78492,6 +78688,25 @@ entities:
     - type: Transform
       pos: 26.5,18.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15903
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: LogicGateAnd
   entities:
   - uid: 1393
@@ -79231,6 +79446,79 @@ entities:
     components:
     - type: Transform
       pos: 46.45232,32.55114
+      parent: 2
+  - uid: 15876
+    components:
+    - type: Transform
+      parent: 5233
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15877
+    components:
+    - type: Transform
+      parent: 5234
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15879
+    components:
+    - type: Transform
+      parent: 5234
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15880
+    components:
+    - type: Transform
+      parent: 5272
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15882
+    components:
+    - type: Transform
+      parent: 5277
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15883
+    components:
+    - type: Transform
+      pos: 12.743588,-32.011192
+      parent: 2
+  - uid: 15885
+    components:
+    - type: Transform
+      rot: -6.283185307179586 rad
+      pos: 10.759127,-21.383228
+      parent: 2
+  - uid: 15888
+    components:
+    - type: Transform
+      pos: -11.282884,4.397874
+      parent: 2
+  - uid: 15891
+    components:
+    - type: Transform
+      pos: 15.538918,-16.279346
+      parent: 2
+  - uid: 15893
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.0848305,-11.8878765
+      parent: 2
+  - uid: 15900
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.96438,-1.6374836
+      parent: 2
+  - uid: 15902
+    components:
+    - type: Transform
+      pos: -10.405901,-22.572403
       parent: 2
 - proto: Morgue
   entities:
@@ -80453,8 +80741,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 55.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: PlasmaWindoorSecureCommandLocked
   entities:
   - uid: 11902
@@ -80463,40 +80749,30 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 45.5,-10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 11903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 11904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 11905
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 11906
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 11907
@@ -80610,7 +80886,7 @@ entities:
   - uid: 11925
     components:
     - type: Transform
-      pos: 22.294851,27.696293
+      pos: 23.365757,27.734373
       parent: 2
 - proto: PlushieSharkBlue
   entities:
@@ -83380,6 +83656,18 @@ entities:
     - type: Transform
       pos: 42.546482,4.636961
       parent: 2
+  - uid: 15895
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.124253,2.2319138
+      parent: 2
+  - uid: 15896
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.729968,-8.98913
+      parent: 2
 - proto: Railing
   entities:
   - uid: 12402
@@ -84346,197 +84634,141 @@ entities:
     - type: Transform
       pos: 37.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12583
     components:
     - type: Transform
       pos: 53.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12584
     components:
     - type: Transform
       pos: 57.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12585
     components:
     - type: Transform
       pos: 55.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12586
     components:
     - type: Transform
       pos: 51.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12587
     components:
     - type: Transform
       pos: -12.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12588
     components:
     - type: Transform
       pos: -12.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12589
     components:
     - type: Transform
       pos: -24.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12590
     components:
     - type: Transform
       pos: -12.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12591
     components:
     - type: Transform
       pos: -24.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12592
     components:
     - type: Transform
       pos: 24.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12593
     components:
     - type: Transform
       pos: -12.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12594
     components:
     - type: Transform
       pos: -24.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12595
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12596
     components:
     - type: Transform
       pos: 56.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12597
     components:
     - type: Transform
       pos: -17.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12598
     components:
     - type: Transform
       pos: -16.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12599
     components:
     - type: Transform
       pos: -15.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12600
     components:
     - type: Transform
       pos: -14.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12601
     components:
     - type: Transform
       pos: 38.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12602
     components:
     - type: Transform
       pos: 39.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12603
     components:
     - type: Transform
       pos: 21.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12604
     components:
     - type: Transform
       pos: 20.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12605
     components:
     - type: Transform
       pos: 20.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12606
     components:
     - type: Transform
       pos: 11.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12607
     components:
     - type: Transform
       pos: 12.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12608
     components:
     - type: Transform
       pos: 13.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12609
     components:
     - type: Transform
       pos: 14.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ReinforcedWindow
   entities:
   - uid: 12610
@@ -84544,1492 +84776,1066 @@ entities:
     - type: Transform
       pos: 43.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12611
     components:
     - type: Transform
       pos: 49.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12612
     components:
     - type: Transform
       pos: 49.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12613
     components:
     - type: Transform
       pos: 49.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12614
     components:
     - type: Transform
       pos: 49.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12615
     components:
     - type: Transform
       pos: 49.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12616
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12617
     components:
     - type: Transform
       pos: 35.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12618
     components:
     - type: Transform
       pos: 32.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12619
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12620
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12621
     components:
     - type: Transform
       pos: 38.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12622
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12623
     components:
     - type: Transform
       pos: 32.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12624
     components:
     - type: Transform
       pos: 36.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12625
     components:
     - type: Transform
       pos: 19.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12626
     components:
     - type: Transform
       pos: 22.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12627
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12628
     components:
     - type: Transform
       pos: 18.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12629
     components:
     - type: Transform
       pos: 24.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12630
     components:
     - type: Transform
       pos: 25.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12631
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12632
     components:
     - type: Transform
       pos: 26.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12633
     components:
     - type: Transform
       pos: -24.5,-33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12634
     components:
     - type: Transform
       pos: -17.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12635
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12636
     components:
     - type: Transform
       pos: -4.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12637
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12638
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12639
     components:
     - type: Transform
       pos: -24.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12640
     components:
     - type: Transform
       pos: -20.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12641
     components:
     - type: Transform
       pos: -21.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12642
     components:
     - type: Transform
       pos: -22.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12643
     components:
     - type: Transform
       pos: -23.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12644
     components:
     - type: Transform
       pos: -24.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12645
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12646
     components:
     - type: Transform
       pos: 8.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12647
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12648
     components:
     - type: Transform
       pos: -25.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12649
     components:
     - type: Transform
       pos: -25.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12650
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12651
     components:
     - type: Transform
       pos: 30.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12652
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12653
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12654
     components:
     - type: Transform
       pos: 6.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12655
     components:
     - type: Transform
       pos: 7.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12656
     components:
     - type: Transform
       pos: -5.5,-33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12657
     components:
     - type: Transform
       pos: -3.5,-33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12658
     components:
     - type: Transform
       pos: -1.5,-33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12659
     components:
     - type: Transform
       pos: 35.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12660
     components:
     - type: Transform
       pos: 37.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12661
     components:
     - type: Transform
       pos: 28.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12662
     components:
     - type: Transform
       pos: 48.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12663
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12664
     components:
     - type: Transform
       pos: 54.5,-22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12665
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12666
     components:
     - type: Transform
       pos: 27.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12667
     components:
     - type: Transform
       pos: 4.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12668
     components:
     - type: Transform
       pos: -27.5,-26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12669
     components:
     - type: Transform
       pos: -27.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12670
     components:
     - type: Transform
       pos: -23.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12671
     components:
     - type: Transform
       pos: -23.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12672
     components:
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12673
     components:
     - type: Transform
       pos: 1.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12674
     components:
     - type: Transform
       pos: 0.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12675
     components:
     - type: Transform
       pos: -0.5,-36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12676
     components:
     - type: Transform
       pos: 6.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12677
     components:
     - type: Transform
       pos: -29.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12678
     components:
     - type: Transform
       pos: -0.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12679
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12680
     components:
     - type: Transform
       pos: -29.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12681
     components:
     - type: Transform
       pos: -21.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12682
     components:
     - type: Transform
       pos: -23.5,-33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12683
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12684
     components:
     - type: Transform
       pos: -25.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12685
     components:
     - type: Transform
       pos: -8.5,-23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12686
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12687
     components:
     - type: Transform
       pos: 46.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12688
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12689
     components:
     - type: Transform
       pos: 3.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12690
     components:
     - type: Transform
       pos: -27.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12691
     components:
     - type: Transform
       pos: -27.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12692
     components:
     - type: Transform
       pos: 20.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12693
     components:
     - type: Transform
       pos: 20.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12694
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12695
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12696
     components:
     - type: Transform
       pos: 54.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12697
     components:
     - type: Transform
       pos: -29.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12698
     components:
     - type: Transform
       pos: -9.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12699
     components:
     - type: Transform
       pos: 33.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12700
     components:
     - type: Transform
       pos: 41.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12701
     components:
     - type: Transform
       pos: 38.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12702
     components:
     - type: Transform
       pos: 47.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12703
     components:
     - type: Transform
       pos: 46.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12704
     components:
     - type: Transform
       pos: 48.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12705
     components:
     - type: Transform
       pos: -16.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12706
     components:
     - type: Transform
       pos: -14.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12707
     components:
     - type: Transform
       pos: 38.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12708
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12709
     components:
     - type: Transform
       pos: 27.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12710
     components:
     - type: Transform
       pos: -27.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12711
     components:
     - type: Transform
       pos: -15.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12712
     components:
     - type: Transform
       pos: 48.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12713
     components:
     - type: Transform
       pos: -8.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12714
     components:
     - type: Transform
       pos: 34.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12715
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12716
     components:
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12717
     components:
     - type: Transform
       pos: -14.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12718
     components:
     - type: Transform
       pos: -10.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12719
     components:
     - type: Transform
       pos: -9.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12720
     components:
     - type: Transform
       pos: 8.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12721
     components:
     - type: Transform
       pos: -0.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12722
     components:
     - type: Transform
       pos: -8.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12723
     components:
     - type: Transform
       pos: -7.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12724
     components:
     - type: Transform
       pos: -5.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12725
     components:
     - type: Transform
       pos: -4.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12726
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12727
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12728
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12729
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12730
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12731
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12732
     components:
     - type: Transform
       pos: 6.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12733
     components:
     - type: Transform
       pos: 6.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12734
     components:
     - type: Transform
       pos: 8.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12735
     components:
     - type: Transform
       pos: 8.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12736
     components:
     - type: Transform
       pos: 34.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12737
     components:
     - type: Transform
       pos: 51.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12738
     components:
     - type: Transform
       pos: 49.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12739
     components:
     - type: Transform
       pos: -27.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12740
     components:
     - type: Transform
       pos: 10.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12741
     components:
     - type: Transform
       pos: 11.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12742
     components:
     - type: Transform
       pos: 12.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12743
     components:
     - type: Transform
       pos: 11.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12744
     components:
     - type: Transform
       pos: 22.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12745
     components:
     - type: Transform
       pos: 16.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12746
     components:
     - type: Transform
       pos: 17.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12747
     components:
     - type: Transform
       pos: 19.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12748
     components:
     - type: Transform
       pos: 20.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12749
     components:
     - type: Transform
       pos: 23.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12750
     components:
     - type: Transform
       pos: 25.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12751
     components:
     - type: Transform
       pos: 27.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12752
     components:
     - type: Transform
       pos: 28.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12753
     components:
     - type: Transform
       pos: 26.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12754
     components:
     - type: Transform
       pos: 29.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12755
     components:
     - type: Transform
       pos: 37.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12756
     components:
     - type: Transform
       pos: 33.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12757
     components:
     - type: Transform
       pos: 33.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12758
     components:
     - type: Transform
       pos: 34.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12759
     components:
     - type: Transform
       pos: 36.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12760
     components:
     - type: Transform
       pos: 35.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12761
     components:
     - type: Transform
       pos: 37.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12762
     components:
     - type: Transform
       pos: 41.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12763
     components:
     - type: Transform
       pos: 35.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12764
     components:
     - type: Transform
       pos: 36.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12765
     components:
     - type: Transform
       pos: 29.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12766
     components:
     - type: Transform
       pos: 54.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12767
     components:
     - type: Transform
       pos: 78.5,-17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12768
     components:
     - type: Transform
       pos: 78.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12769
     components:
     - type: Transform
       pos: 78.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12770
     components:
     - type: Transform
       pos: 78.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12771
     components:
     - type: Transform
       pos: 78.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12772
     components:
     - type: Transform
       pos: 79.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12773
     components:
     - type: Transform
       pos: 50.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12774
     components:
     - type: Transform
       pos: 44.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12775
     components:
     - type: Transform
       pos: 44.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12776
     components:
     - type: Transform
       pos: 44.5,28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12777
     components:
     - type: Transform
       pos: 44.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12778
     components:
     - type: Transform
       pos: 44.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12779
     components:
     - type: Transform
       pos: 53.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12780
     components:
     - type: Transform
       pos: 53.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12781
     components:
     - type: Transform
       pos: 54.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12782
     components:
     - type: Transform
       pos: 56.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12783
     components:
     - type: Transform
       pos: 56.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12784
     components:
     - type: Transform
       pos: 57.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12785
     components:
     - type: Transform
       pos: 59.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12786
     components:
     - type: Transform
       pos: 59.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12787
     components:
     - type: Transform
       pos: 60.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12788
     components:
     - type: Transform
       pos: 62.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12789
     components:
     - type: Transform
       pos: 62.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12790
     components:
     - type: Transform
       pos: 62.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12791
     components:
     - type: Transform
       pos: 52.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12792
     components:
     - type: Transform
       pos: 52.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12793
     components:
     - type: Transform
       pos: 54.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12794
     components:
     - type: Transform
       pos: 56.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12795
     components:
     - type: Transform
       pos: 49.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12796
     components:
     - type: Transform
       pos: 50.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12797
     components:
     - type: Transform
       pos: 51.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12798
     components:
     - type: Transform
       pos: 54.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12799
     components:
     - type: Transform
       pos: 55.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12800
     components:
     - type: Transform
       pos: 56.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12801
     components:
     - type: Transform
       pos: 51.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12802
     components:
     - type: Transform
       pos: 51.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12803
     components:
     - type: Transform
       pos: 48.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12804
     components:
     - type: Transform
       pos: -22.5,-33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12805
     components:
     - type: Transform
       pos: 26.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12806
     components:
     - type: Transform
       pos: 34.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12807
     components:
     - type: Transform
       pos: 35.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12808
     components:
     - type: Transform
       pos: 42.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12809
     components:
     - type: Transform
       pos: 24.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12810
     components:
     - type: Transform
       pos: 43.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12811
     components:
     - type: Transform
       pos: 45.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12812
     components:
     - type: Transform
       pos: 44.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12813
     components:
     - type: Transform
       pos: 50.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12814
     components:
     - type: Transform
       pos: 50.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12815
     components:
     - type: Transform
       pos: 50.5,-26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12816
     components:
     - type: Transform
       pos: -27.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12817
     components:
     - type: Transform
       pos: 45.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12818
     components:
     - type: Transform
       pos: 45.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12819
     components:
     - type: Transform
       pos: 45.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12820
     components:
     - type: Transform
       pos: 49.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12821
     components:
     - type: Transform
       pos: 43.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12822
     components:
     - type: Transform
       pos: 43.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: RemoteSignaller
   entities:
   - uid: 12823
@@ -86843,6 +86649,18 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,-21.5
       parent: 2
+    - type: Storage
+      storedItems:
+        15905:
+          position: 0,0
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15905
     - type: Fixtures
       fixtures: {}
 - proto: ShelfGlass
@@ -86906,6 +86724,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 11.5,-9.5
       parent: 2
+    - type: Storage
+      storedItems:
+        15906:
+          position: 4,3
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15906
     - type: Fixtures
       fixtures: {}
   - uid: 12933
@@ -87021,6 +86851,18 @@ entities:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
+    - type: Storage
+      storedItems:
+        15907:
+          position: 2,0
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15907
     - type: Fixtures
       fixtures: {}
   - uid: 12948
@@ -87052,6 +86894,18 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,-29.5
       parent: 2
+    - type: Storage
+      storedItems:
+        15908:
+          position: 0,0
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15908
     - type: Fixtures
       fixtures: {}
   - uid: 12952
@@ -87106,6 +86960,18 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -15.5,0.5
       parent: 2
+    - type: Storage
+      storedItems:
+        15909:
+          position: 0,0
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15909
     - type: Fixtures
       fixtures: {}
   - uid: 12959
@@ -87242,39 +87108,29 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -16.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12976
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12977
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12978
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12979
     components:
     - type: Transform
       pos: 44.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
     - type: DeviceLinkSink
       invokeCounter: 1
 - proto: ShuttersNormalOpen
@@ -87285,498 +87141,368 @@ entities:
       rot: 3.141592653589793 rad
       pos: 33.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12981
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12982
     components:
     - type: Transform
       pos: 24.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12984
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12985
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12986
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12987
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12988
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12989
     components:
     - type: Transform
       pos: 11.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12990
     components:
     - type: Transform
       pos: 12.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12991
     components:
     - type: Transform
       pos: 10.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12992
     components:
     - type: Transform
       pos: 1.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12993
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12994
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12995
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 12999
     components:
     - type: Transform
       pos: 0.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13001
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13002
     components:
     - type: Transform
       pos: 34.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13003
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13004
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13006
     components:
     - type: Transform
       pos: 6.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13007
     components:
     - type: Transform
       pos: 7.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13008
     components:
     - type: Transform
       pos: 8.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13012
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13013
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13014
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13015
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13016
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13017
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13018
     components:
     - type: Transform
       pos: 25.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13019
     components:
     - type: Transform
       pos: 26.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13020
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13022
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 38.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13023
     components:
     - type: Transform
       pos: 15.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13024
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13025
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13026
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13027
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13028
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13029
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13031
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13032
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13033
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13034
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13035
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13036
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13037
     components:
     - type: Transform
       pos: 4.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13039
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13040
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13041
     components:
     - type: Transform
       pos: -4.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13042
     components:
     - type: Transform
       pos: 14.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13043
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13044
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersWindow
   entities:
   - uid: 13045
@@ -87785,16 +87511,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 35.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13046
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersWindowOpen
   entities:
   - uid: 13047
@@ -87803,64 +87525,48 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13048
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13049
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13050
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13052
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13053
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13054
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttleConsoleCircuitboard
   entities:
   - uid: 13055
@@ -87875,253 +87581,181 @@ entities:
     - type: Transform
       pos: 14.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13057
     components:
     - type: Transform
       pos: 14.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13058
     components:
     - type: Transform
       pos: 4.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13059
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13060
     components:
     - type: Transform
       pos: 4.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13061
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13062
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13063
     components:
     - type: Transform
       pos: 19.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13064
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13065
     components:
     - type: Transform
       pos: 2.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13066
     components:
     - type: Transform
       pos: 9.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13067
     components:
     - type: Transform
       pos: 18.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13068
     components:
     - type: Transform
       pos: 18.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13069
     components:
     - type: Transform
       pos: -4.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13070
     components:
     - type: Transform
       pos: -2.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13071
     components:
     - type: Transform
       pos: -1.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13072
     components:
     - type: Transform
       pos: -10.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13073
     components:
     - type: Transform
       pos: -3.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13074
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13075
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13076
     components:
     - type: Transform
       pos: 12.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13077
     components:
     - type: Transform
       pos: 20.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13078
     components:
     - type: Transform
       pos: 9.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13079
     components:
     - type: Transform
       pos: -1.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13080
     components:
     - type: Transform
       pos: 9.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13081
     components:
     - type: Transform
       pos: 19.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13082
     components:
     - type: Transform
       pos: 20.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13083
     components:
     - type: Transform
       pos: 15.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13084
     components:
     - type: Transform
       pos: -1.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13085
     components:
     - type: Transform
       pos: 16.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13086
     components:
     - type: Transform
       pos: 11.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13087
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13088
     components:
     - type: Transform
       pos: -10.5,42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13089
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13090
     components:
     - type: Transform
       pos: 10.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13091
     components:
     - type: Transform
       pos: -4.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttleWindowDiagonal
   entities:
   - uid: 13092
@@ -88130,15 +87764,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -10.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 13093
     components:
     - type: Transform
       pos: -10.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: SignAiSyndie
   entities:
   - uid: 13094
@@ -91100,6 +90730,16 @@ entities:
       parent: 2
 - proto: SprayBottleSpaceCleaner
   entities:
+  - uid: 3561
+    components:
+    - type: Transform
+      pos: 12.746842,-27.95883
+      parent: 2
+  - uid: 10765
+    components:
+    - type: Transform
+      pos: -17.440601,-15.994387
+      parent: 2
   - uid: 13512
     components:
     - type: Transform
@@ -91114,6 +90754,66 @@ entities:
     components:
     - type: Transform
       pos: 4.818577,5.3499727
+      parent: 2
+  - uid: 15066
+    components:
+    - type: Transform
+      parent: 11572
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15889
+    components:
+    - type: Transform
+      pos: 35.27941,-1.9719868
+      parent: 2
+  - uid: 15903
+    components:
+    - type: Transform
+      parent: 11621
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 15904
+    components:
+    - type: Transform
+      rot: -6.283185307179586 rad
+      pos: 20.194897,-24.522432
+      parent: 2
+  - uid: 15905
+    components:
+    - type: Transform
+      parent: 12931
+    - type: Physics
+      canCollide: False
+  - uid: 15906
+    components:
+    - type: Transform
+      parent: 12932
+    - type: Physics
+      canCollide: False
+  - uid: 15907
+    components:
+    - type: Transform
+      parent: 12947
+    - type: Physics
+      canCollide: False
+  - uid: 15908
+    components:
+    - type: Transform
+      parent: 12951
+    - type: Physics
+      canCollide: False
+  - uid: 15909
+    components:
+    - type: Transform
+      parent: 12958
+    - type: Physics
+      canCollide: False
+  - uid: 15912
+    components:
+    - type: Transform
+      pos: 17.713945,25.441736
       parent: 2
 - proto: StasisBed
   entities:
@@ -93911,6 +93611,11 @@ entities:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
+  - uid: 15911
+    components:
+    - type: Transform
+      pos: 17.5,25.5
+      parent: 2
 - proto: TableReinforced
   entities:
   - uid: 13896
@@ -94566,57 +94271,41 @@ entities:
     - type: Transform
       pos: 1.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14016
     components:
     - type: Transform
       pos: 4.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14017
     components:
     - type: Transform
       pos: -19.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14018
     components:
     - type: Transform
       pos: 29.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14019
     components:
     - type: Transform
       pos: 28.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14020
     components:
     - type: Transform
       pos: 30.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14021
     components:
     - type: Transform
       pos: 33.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 14022
     components:
     - type: Transform
       pos: 37.5,-10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ToiletDirtyWater
   entities:
   - uid: 14023
@@ -95798,6 +95487,12 @@ entities:
       fixtures: {}
 - proto: WallReinforced
   entities:
+  - uid: 10767
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,28.5
+      parent: 2
   - uid: 14172
     components:
     - type: Transform
@@ -100273,11 +99968,6 @@ entities:
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
-  - uid: 15066
-    components:
-    - type: Transform
-      pos: 22.5,28.5
-      parent: 2
   - uid: 15067
     components:
     - type: Transform
@@ -103277,6 +102967,11 @@ entities:
     - type: Transform
       pos: 18.5,-21.5
       parent: 2
+  - uid: 15890
+    components:
+    - type: Transform
+      pos: 39.5,-16.5
+      parent: 2
 - proto: WaterTankHighCapacity
   entities:
   - uid: 15655
@@ -103471,46 +103166,34 @@ entities:
       rot: 3.141592653589793 rad
       pos: -21.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15687
     components:
     - type: Transform
       pos: 49.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15688
     components:
     - type: Transform
       pos: 50.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15690
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureArmoryLocked
   entities:
   - uid: 15692
@@ -103519,16 +103202,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 25.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureCargoLocked
   entities:
   - uid: 15694
@@ -103536,15 +103215,11 @@ entities:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15695
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureChapelLocked
   entities:
   - uid: 15696
@@ -103553,8 +103228,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 38.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureCommandLocked
   entities:
   - uid: 15697
@@ -103562,71 +103235,53 @@ entities:
     - type: Transform
       pos: 55.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15698
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15699
     components:
     - type: Transform
       pos: 53.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15701
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15702
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15705
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureDetectiveLocked
   entities:
   - uid: 15706
@@ -103635,8 +103290,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 25.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureEngineeringLocked
   entities:
   - uid: 15707
@@ -103644,70 +103297,52 @@ entities:
     - type: Transform
       pos: 47.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15709
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15710
     components:
     - type: Transform
       pos: 48.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15712
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15713
     components:
     - type: Transform
       pos: 46.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
   - uid: 15716
@@ -103716,8 +103351,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureLibraryLocked
   entities:
   - uid: 15717
@@ -103726,16 +103359,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 14.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureMedicalLocked
   entities:
   - uid: 15719
@@ -103744,24 +103373,18 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureSalvageLocked
   entities:
   - uid: 15722
@@ -103770,8 +103393,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -25.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureScienceLocked
   entities:
   - uid: 15723
@@ -103780,16 +103401,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 27.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15724
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureSecurityLocked
   entities:
   - uid: 15725
@@ -103798,24 +103415,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15726
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorServiceLocked
   entities:
   - uid: 15728
@@ -103823,8 +103434,6 @@ entities:
     - type: Transform
       pos: 22.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: Window
   entities:
   - uid: 15729
@@ -103832,337 +103441,241 @@ entities:
     - type: Transform
       pos: 24.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15730
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15731
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15732
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15733
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15734
     components:
     - type: Transform
       pos: 20.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15735
     components:
     - type: Transform
       pos: 24.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15736
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15737
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15738
     components:
     - type: Transform
       pos: 23.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15739
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15740
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15741
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15742
     components:
     - type: Transform
       pos: -6.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15743
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15744
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15745
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15746
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15747
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15748
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15749
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15750
     components:
     - type: Transform
       pos: 27.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15751
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15752
     components:
     - type: Transform
       pos: 27.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15753
     components:
     - type: Transform
       pos: 7.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15754
     components:
     - type: Transform
       pos: 7.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15755
     components:
     - type: Transform
       pos: 7.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15756
     components:
     - type: Transform
       pos: 5.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15757
     components:
     - type: Transform
       pos: -0.5,-26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15758
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15759
     components:
     - type: Transform
       pos: 32.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15760
     components:
     - type: Transform
       pos: 21.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15761
     components:
     - type: Transform
       pos: 3.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15762
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15763
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15764
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15765
     components:
     - type: Transform
       pos: 27.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15766
     components:
     - type: Transform
       pos: 24.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15767
     components:
     - type: Transform
       pos: -12.5,-22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15768
     components:
     - type: Transform
       pos: 25.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15769
     components:
     - type: Transform
       pos: 27.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15770
     components:
     - type: Transform
       pos: 17.5,-26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15771
     components:
     - type: Transform
       pos: 27.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15772
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15773
     components:
     - type: Transform
       pos: 82.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15774
     components:
     - type: Transform
       pos: 41.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15775
     components:
     - type: Transform
       pos: 41.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15776
     components:
     - type: Transform
       pos: 24.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowDirectional
   entities:
   - uid: 15777
@@ -104170,176 +103683,132 @@ entities:
     - type: Transform
       pos: 19.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15784
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15785
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15788
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15790
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15791
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowFrostedDirectional
   entities:
   - uid: 15799
@@ -104348,56 +103817,42 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,-10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15803
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15804
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 15806
@@ -104406,376 +103861,278 @@ entities:
       rot: 3.141592653589793 rad
       pos: 26.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15808
     components:
     - type: Transform
       pos: 51.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15809
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15810
     components:
     - type: Transform
       pos: 57.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15812
     components:
     - type: Transform
       pos: 54.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15815
     components:
     - type: Transform
       pos: 48.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15819
     components:
     - type: Transform
       pos: 56.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15826
     components:
     - type: Transform
       pos: 52.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15830
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15831
     components:
     - type: Transform
       pos: 51.5,32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15832
     components:
     - type: Transform
       pos: 54.5,35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15833
     components:
     - type: Transform
       pos: 48.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15834
     components:
     - type: Transform
       pos: 49.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15835
     components:
     - type: Transform
       pos: 50.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15836
     components:
     - type: Transform
       pos: 51.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15844
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15845
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15846
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15848
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15849
     components:
     - type: Transform
       pos: 55.5,35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15850
     components:
     - type: Transform
       pos: 56.5,35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15851
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15852
     components:
     - type: Transform
       pos: 42.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15853
     components:
     - type: Transform
       pos: 40.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 15854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WireBrush
   entities:
   - uid: 15855


### PR DESCRIPTION
## Why / Balance
Cleaning supplies have been added sparringly across Byoin, with the goal of letting people easily spot-clean at least one or two rooms in their departments without requiring a janitor. This is done to help people feel comfortable with at least a few spots in Byoin, since its such a grimey place! This as an alternative to just deleting the dirt decals also helps the place feel dirty, if an area is left neglected.



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: added extra cleaning supplies to Byoin departments

