### PR TITLE
tweak: allow emotes while asleep

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -75,7 +75,7 @@ public sealed partial class SleepingSystem : EntitySystem
 
         SubscribeLocalEvent<ForcedSleepingStatusEffectComponent, StatusEffectAppliedEvent>(OnStatusEffectApplied);
         SubscribeLocalEvent<SleepingComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
-        SubscribeLocalEvent<SleepingComponent, EmoteAttemptEvent>(OnEmoteAttempt);
+        //SubscribeLocalEvent<SleepingComponent, EmoteAttemptEvent>(OnEmoteAttempt); // starcup: allow emoting while sleeping
 
         SubscribeLocalEvent<SleepingComponent, BeforeForceSayEvent>(OnChangeForceSay, after: new []{typeof(PainNumbnessSystem)});
     }


### PR DESCRIPTION
Emotes are no longer blocked while you are sleeping. Notably, animated and audible emotes are still allowed and will animate/make noise still. 

## Why / Balance
While there is potential for intentional and unintentional abuse, there's a lot of RP potential to being able to emote while asleep. Bad dreams, restless sleep, reacting slightly to things around you, etc. Olivia can purr in her sleep now.

Also, having played a narcoleptic character, there's no indicator when you fall asleep while sitting except for the little "zzz"s that pop up after a few seconds. It'd be nice to be able to go "@ slumps over in her chair" or something. 

## Technical details
Based off of https://github.com/DeltaV-Station/Delta-v/pull/2084; comments an event subscription instead of modifying the rest of the code, for better upstream parity.

**Changelog**
:cl:
- tweak: It is now possible to emote while asleep. Remember that emotes pass through walls and be mindful of when emoting could unfairly reveal an antagonist.