### PR TITLE
tweak: remove lockout on cutting/pulsing wires without insuls

### DIFF
--- a/Content.Server/Power/PowerWireAction.cs
+++ b/Content.Server/Power/PowerWireAction.cs
@@ -207,8 +207,7 @@ public sealed partial class PowerWireAction : BaseWireAction
     public override bool Cut(EntityUid user, Wire wire)
     {
         base.Cut(user, wire);
-        if (!TrySetElectrocution(user, wire))
-            return false;
+        TrySetElectrocution(user, wire); // starcup: don't return false after electrocuting
 
         SetWireCuts(wire.Owner, true);
 
@@ -220,8 +219,7 @@ public sealed partial class PowerWireAction : BaseWireAction
     public override bool Mend(EntityUid user, Wire wire)
     {
         base.Mend(user, wire);
-        if (!TrySetElectrocution(user, wire))
-            return false;
+        TrySetElectrocution(user, wire); // starcup: don't return false after electrocuting
 
         // Mending any power wire restores shorts.
         WiresSystem.TryCancelWireAction(wire.Owner, PowerWireActionKey.PulseCancel);
@@ -239,7 +237,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         base.Pulse(user, wire);
         WiresSystem.TryCancelWireAction(wire.Owner, PowerWireActionKey.ElectrifiedCancel);
 
-        var electrocuted = !TrySetElectrocution(user, wire, true);
+        // var electrocuted = !TrySetElectrocution(user, wire, true); // starcup: variable goes unused, comment it out
 
         if (WiresSystem.TryGetData<bool>(wire.Owner, PowerWireActionKey.Pulsed, out var pulsedKey) && pulsedKey)
             return;
@@ -247,8 +245,7 @@ public sealed partial class PowerWireAction : BaseWireAction
         WiresSystem.SetData(wire.Owner, PowerWireActionKey.Pulsed, true);
         WiresSystem.StartWireAction(wire.Owner, _pulseTimeout, PowerWireActionKey.PulseCancel, new TimedWireEvent(AwaitPulseCancel, wire));
 
-        if (electrocuted)
-            return;
+        TrySetElectrocution(user, wire, true); // starcup: don't return after electrocuting
 
         SetPower(wire.Owner, true);
     }


### PR DESCRIPTION
removes the return statements on being electrocuted by cutting/pulsing wires, making the action actually go through instead of being stopped (it does still zap you)

## Why / Balance
it's one thing to electrocute players without insuls when they try to cut or pulse the power wires for a door, but making it so the action doesn't even go through makes even trying utterly pointless—it's all risk and no reward. this prohibits player movement without much clear benefit, and also results in insuls being even more of a frustratingly centralizing piece of gear. making it into something that has the reward of gaining access but still carries that risk of damage and a lengthy stun is much more interesting and more likely to drive player decisions

## Technical details
just replaces some if statements calling for the `TrySetElectrocution` function with direct calls of that function with no return statements involved. very simple stuff, should be a breeze to maintain

**Changelog**
:cl:
- tweak: cutting or pulsing an airlock's power wires without protection will now actually cut/pulse the wire (but it will still shock you, watch out!)