### PR TITLE
fix(rodentia): return repeatable rummaging

### DIFF
--- a/Content.Shared/RatKing/Components/RummageableComponent.cs
+++ b/Content.Shared/RatKing/Components/RummageableComponent.cs
@@ -20,6 +20,19 @@ public sealed partial class RummageableComponent : Component
     public bool Looted;
 
     /// <summary>
+    /// DeltaV: Last time the object was looted, used to check if cooldown has expired
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan? LastLooted;
+
+    /// <summary>
+    /// DeltaV: Minimum time between rummage attempts
+    /// </summary>
+    [DataField("rummageCooldown"), ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    public TimeSpan RummageCooldown = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// How long it takes to rummage through a rummageable container.
     /// </summary>
     [DataField("rummageDuration"), ViewVariables(VVAccess.ReadWrite)]


### PR DESCRIPTION
Re-adds the ability to repeatedly rummage trash chutes from #2.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
This was accidentally reverted in a previous upstream merge.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Rodentia can rummage garbage chutes repeatedly again.