### PR TITLE
fix: remove duplicate wrench from engineering belt

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -29,7 +29,6 @@
   - type: StorageFill
     contents:
       - id: CrowbarYellow
-      - id: Wrench
     # begin starcup: add misc tools & tweaks
       - id: Wrench
         orGroup: Wrenches


### PR DESCRIPTION
the old wrench listing was accidentally left in along with the new orGroup, leading to two wrenches being spawned. oops!

**Changelog**
:cl:
- fix: engineering's utility belts no longer spawn with a duplicate wrench