### PR TITLE
tweak: make flashlights take longer to start blinking

### DIFF
--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -240,11 +240,11 @@ namespace Content.Server.Light.EntitySystems
             var appearanceComponent = EntityManager.GetComponentOrNull<AppearanceComponent>(uid);
 
             var fraction = battery.CurrentCharge / battery.MaxCharge;
-            if (fraction >= 0.125) // starcup: 0.30 -> 0.125
+            if (fraction >= 0.10) // starcup: 0.30 -> 0.10
             {
                 _appearance.SetData(uid, HandheldLightVisuals.Power, HandheldLightPowerStates.FullPower, appearanceComponent);
             }
-            else if (fraction >= 0.05) // starcup: 0.10 -> 0.05
+            else if (fraction >= 0.04) // starcup: 0.10 -> 0.04
             {
                 _appearance.SetData(uid, HandheldLightVisuals.Power, HandheldLightPowerStates.LowPower, appearanceComponent);
             }


### PR DESCRIPTION
Currently, a flashlight (or lantern, or floodlight) will enter its low power state (where it starts blinking on and off) when it's at 30% charge, and blinks quickly at 10%. This changes it to blink at 10% and blink quickly at 4%.

## Why / Balance
This effect is extremely annoying and effectively just reduces the duration of a battery in a flashlight by 30%. It's bothered me for ages. 30% isn't even that low of a power, and is way too long for a warning that your flashlight is about to die because you still have almost a third of the charge left. 

If there's any concern about balance, I would prefer just increasing the wattage too so that at least you don't have 30% of your charge being useless. Another alternative is reducing the intensity of the blinking effect, since I could see how it might be desirable for spookiness. 

## Technical details
This value should not be hardcoded.

**Changelog**
:cl:
- tweak: Flashlights, lanterns, and floodlights will last longer before they start blinking.
