### PR TITLE
map(saltern): misaltaneous touch-ups

### DIFF
--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -4857,8 +4857,6 @@ entities:
       pos: -11.5,-19.5
       parent: 2
     - type: DeviceList
-      configurators:
-      - invalid
       devices:
       - 275
       - 8811
@@ -75480,10 +75478,6 @@ entities:
     - type: Transform
       pos: 30.5,-11.5
       parent: 2
-    - type: UserInterface
-      actors:
-        enum.StorageUiKey.Key:
-        - invalid
     - type: Storage
       storedItems:
         6489:
@@ -82362,6 +82356,7 @@ entities:
   - uid: 12522
     components:
     - type: Transform
+      anchored: true
       rot: -1.5707963267948966 rad
       pos: 5.5,-41.5
       parent: 2


### PR DESCRIPTION

Made a lot of various tweaks to Saltern. Most notably:
- The Burn Chamber now has a piece of "flawed reinforced plasma glass" on the outside which will begin to crack at 75,000 kPa, and the safety valve will begin to drain at 50k-60k kPa instead of 90k.
- Xenoarch now has a spare canister, some air alarm hookups, and an instrument.
- Main Botany now has a bottle of unstable mutagen and a windoor counter leading to the hallway.
- Maints Botany now has a bit more to work with, but still not much. Also, more Maints windows are shuttered by default.

## Why / Balance
Most of these are fairly self-evident, but a few explanations:
- **Burn Chamber:** Saltern Atmos has a perilous layout, with the burn chamber poised to flood the entire room should it suffer a TEGLoose. The addition of a new "safety valve" should help reduce the risk. It's hard to do more without compromising some part of Saltern's whole layout.
- Unstable Mutagen is extremely important for Botany, but I'm actually going back and forth on making it so available, especially with us likely planning to buff the agrichem kit in the future. Here's my logic, though: Saltern Botanist is more removed from the Chemist than normal, making it slightly harder for them to coordinate. You're also directly neighboring the Brig, and having some extra mutagen around might enable collaboration with Prisoners in the more easygoing lowpop rounds. It's an experiment.
- The many new windows were making Saltern's maintenance tunnels feel too open. Defaulting the shutters to closed was a way to address this.

## Media
Gave Botany a bottle of mutagen and a hall counter:
<img width="509" height="556" alt="image" src="https://github.com/user-attachments/assets/01c5016a-69d9-481d-8fd3-141973364ca3" />
Gave the Psychologist's Office slightly better visibility:
<img width="305" height="323" alt="image" src="https://github.com/user-attachments/assets/129ca221-3f79-4eb5-806b-1cb1f0cfbfd9" /> <img width="305" height="323" alt="image" src="https://github.com/user-attachments/assets/676e656b-3000-4389-a198-5de06eda1ce4" />
Gave Xenoarch an instrument and a spare canister:
<img width="549" height="655" alt="image" src="https://github.com/user-attachments/assets/c060b777-fb48-42e7-b41d-0bb76cfcb15e" />
Generally added more closed-by-default shutters to Maints:
<img width="295" height="161" alt="image" src="https://github.com/user-attachments/assets/251013cf-8ecd-4c9b-b263-61115e4ba81a" />
Reconfigured the Restaurant's tables slightly:
<img width="947" height="807" alt="image" src="https://github.com/user-attachments/assets/1fadb6f1-b89b-4892-b691-66e75504277f" />
Added a "flawed" window to the TEG Burn Chamber:
<img width="789" height="409" alt="image" src="https://github.com/user-attachments/assets/21f406e2-c9c1-497f-b58b-29650402367c" />



**Changelog**
:cl:
- add: Saltern Atmos is now a bit safer.
- tweak: Opened up Saltern's Botany/Psych and closed off Maints rooms a bit.
- tweak: Made various tweaks to improve Saltern experience.