### PR TITLE
map(train): remove population limit so it can join the map pool

### DIFF
--- a/Resources/Prototypes/_starcup/Maps/train.yml
+++ b/Resources/Prototypes/_starcup/Maps/train.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_starcup/train.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 35
+  minPlayers: 0
   maxPlayers: 70
   stations:
     Train:


### PR DESCRIPTION
Train now requires 0 players to be voted for. All aboard the Sentipode!

## Why / Balance
_*excited train track noises*_

(Our server is used to big maps with low populations, and people love trains.)

## Media
[L'Arrivée_d'un_train_en_gare_de_La_Ciotat,_Complete.webm](https://github.com/user-attachments/assets/75162bac-e8bc-4d76-b337-576239bac94f)

**Changelog**
:cl:
- tweak: Added Train to main map pool!