### PR TITLE
config: set uptime restart to 26 hours

### DIFF
--- a/Resources/ConfigPresets/starcup/starcup.toml
+++ b/Resources/ConfigPresets/starcup/starcup.toml
@@ -22,7 +22,7 @@ lobbyduration = 300
 [server]
 id = "starcup"
 rules_file = "starcupRuleset"
-uptime_restart_minutes = 1440
+uptime_restart_minutes = 1560
 
 [infolinks]
 discord = "https://discord.gg/5pC525RYbw"


### PR DESCRIPTION
Currently experiencing issues with SS14.Watchdog crashing when attempting to notify the server of an update but being unable to open a socket. I suspect this is due to an eclipse of the uptime restart (24 hours) and the CI workflow (24 hours.)

This change sets the uptime restart to 26 hours.
