### PR TITLE
feat: port Imp's pipe colors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -18,13 +18,19 @@
   - type: SprayPainter
     colorPalette:
       red: '#FF1212FF'
-      yellow: '#B3A234FF'
-      brown: '#947507FF'
+      yellow: '#FFFF00FF' # imp
+      orange: '#FF6600FF' # imp
       green: '#3AB334FF'
-      cyan: '#03FCD3FF'
+      cyan: '#00FFFFFF' # imp
       blue: '#0335FCFF'
       white: '#FFFFFFFF'
       black: '#333333FF'
+      purple: '#7A2DFFFF' # imp
+      magenta: '#FF00FFFF' # imp
+      ice blue: '#64DAFFFF' # imp
+      sky blue: '#0099FFFF' # imp
+      lime green: '#D3FC03FF' # imp
+      seafoam green: '#00FF87FF' # imp
       # standard atmos pipes
       waste: '#990000'
       distro: '#0055cc'


### PR DESCRIPTION
Ports part of Impstation's [#894](https://github.com/impstation/imp-station-14/pull/894) to introduce a bunch of new pipe colors and further differentiate a few existing ones.

## Why / Balance
It's really nice to have separate pipe colors for, say, plasma pipes, and is a nice tool for mappers to help clarify their setups.

## Technical details
A few colors were outright changed as part of differentiation. This may introduce slight issues on maps that used those colors? But I don't think that's likely.

**Changelog**
:cl:
- add: Adjusted spray painter pipe color options to be more distinct and added new color options.