### PR TITLE
tweak: crux changes (filled lathes, no more evil maints grill, etc)

### DIFF
--- a/Resources/Maps/_starcup/crux.yml
+++ b/Resources/Maps/_starcup/crux.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 12/29/2025 09:48:51
+  time: 12/29/2025 10:07:13
   entityCount: 14196
 maps:
 - 1
@@ -69851,24 +69851,24 @@ entities:
     - type: Transform
       pos: 10.5,24.5
       parent: 2
-- proto: PortableGeneratorJrPacman
+- proto: PortableGeneratorJrPacmanFilled
   entities:
   - uid: 10141
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 2
-  - uid: 14196
+  - uid: 14053
     components:
     - type: Transform
       pos: -20.5,25.5
       parent: 2
-  - uid: 14197
+  - uid: 14062
     components:
     - type: Transform
       pos: 25.5,13.5
       parent: 2
-  - uid: 14198
+  - uid: 14063
     components:
     - type: Transform
       pos: 7.5,-39.5


### PR DESCRIPTION
another round of crux changes! these include:

* replaces a bunch of lathes with the pre-filled versions added by #631, removes the nearby materials, and shuffles a few things around to fit the space
* replaced the research director's locker with the version that had the hardsuit and gave them an ai restoration console
* recolored the atmos pipes
* removed the electrified grill trap, replacing it with a generic lil hideout space
* replaced the combat medic's recharger (there are enough of those in security) with a rack with some body bags, and also gave them a defib
* extended the docking airlocks to be a little less cramped

**Changelog**
:cl:
- add: most of crux's lathes and generators will now start each shift with materials already loaded; expect this feature on other maps soon!
- remove: removed the electrified grill area in crux's maintenance and replaced it with something less dangerous
- fix: the rd's office on crux now has the hardsuit and ai restoration console it should have had
- tweak: recolored crux's atmos pipes
- tweak: extended crux's docking airlocks to be a little less cramped