### PR TITLE
map(saltern): fixes emergency lights and adds missing prototypes

### DIFF
--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -32713,11 +32713,6 @@ entities:
     - type: Transform
       pos: 10.66112,-19.235216
       parent: 2
-    - type: UserInterface
-      actors:
-        enum.StorageUiKey.Key:
-        - invalid
-    - type: ActiveUserInterface
 - proto: ClothingBeltUtilityFilled
   entities:
   - uid: 5246


### PR DESCRIPTION
It's another sweep for Lot's favorite station, baby!

- Added AI Restoration Console to RD's office.
- Removed ID Computers from RD/QM/CE offices.
- Gave Science an explosions suit closet, an interior artifact chamber escape button, and a filled silo.
- Gave Engineering some written prompts to warn people about the Tesla and guide players on TEG tricks.
- Gave the AI a Salvage Arm camera, and one of the two sets of airlocks leading to the Satellite is now Command-access instead of Externals access. May tweak that later.
- Moved an APC out to the outside of the dining area for better APC access.
- Added various supplies to the Tool Room and maints, like some space heaters and floodlights and a Cutting Machine.
- Stole a hand labeler from Cargo and gave it to the Morgue for naming body bags.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->

## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->

## Media
<img width="627" height="497" alt="image" src="https://github.com/user-attachments/assets/f3c90f8a-3ff5-45b1-bf05-d2691ddc3a77" />
<img width="598" height="403" alt="image" src="https://github.com/user-attachments/assets/332361d4-cfbf-4b69-8815-af54c1e4d0d5" />
<img width="445" height="381" alt="image" src="https://github.com/user-attachments/assets/36b3992a-7186-43ac-9c4d-3e5ad7f1f5f6" />

Overall:
<img width="4544" height="2848" alt="Saltern-0" src="https://github.com/user-attachments/assets/750ce852-6b50-4d9b-987d-880406aa52a9" />


**Changelog**
:cl:
- fix: Fixed Saltern's emergency lights!
- remove: Removed Saltern's CE/QM/RD id consoles
- tweak: Gave Saltern a dining area APC, a cutting machine, and an AI Restoration Console, plus other stuff.