### PR TITLE
fix: updates robotics control console description

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1546,7 +1546,7 @@
   parent: BaseComputerAiAccess
   id: ComputerRoboticsControl
   name: robotics control console
-  description: Used to remotely monitor the status and wellbeing of the station's cyborgs. # starcup - removed disable/destroy language
+  description: Used to remotely monitor the status and wellbeing of the station's cyborgs. # starcup - removed inaccurate disable/destroy language
   components:
   - type: Sprite
     layers:


### PR DESCRIPTION
The robotics control console has been changed from `Used to remotely monitor, disable and destroy the station's cyborgs.` to `Used to remotely monitor the status and wellbeing of the station's cyborgs.`

The console will no longer say it is usually locked to Research Director access.

## Why / Balance
Since starcup removed the RD's ability to remotely disable and destroy cyborgs with the console, the old description text is simply inaccurate, and the access limit did nothing. It was a little misleading. Just a minor oversight!

**Changelog**
:cl:
- fix: Updated robotics control console's description and access limits.