### PR TITLE
tweak: reduce meteor event frequency by folding them into standard tables

### DIFF
--- a/Resources/Prototypes/_starcup/GameRules/events.yml
+++ b/Resources/Prototypes/_starcup/GameRules/events.yml
@@ -22,6 +22,8 @@
     - id: GasLeak
     - id: GreytideVirus
     - !type:NestedSelector
+      tableId: BasicMeteorSwarmEventsTable
+    - !type:NestedSelector
       tableId: DerelictBorgEventTableNoAssault
 
 - type: entityTable

--- a/Resources/Prototypes/_starcup/game_presets.yml
+++ b/Resources/Prototypes/_starcup/game_presets.yml
@@ -30,7 +30,6 @@
   description: trouble-description
   rules:
   - TroubleStationEventScheduler
-  - SlowMeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
@@ -43,7 +42,6 @@
   description: danger-description
   rules:
   - DangerStationEventScheduler
-  - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
@@ -58,7 +56,6 @@
   - DummyNonAntagChance
   - Thief
   - TroubleStationEventScheduler
-  - SlowMeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
@@ -69,7 +66,6 @@
   description: late-start-description
   rules:
   - TroubleStationEventScheduler
-  - SlowMeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LateJoinAnomalySpawns

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -148,7 +148,7 @@
   - Traitor
   # - SubGamemodesRuleNoWizard # starcup: put thieves in their own gamemode
   - TroubleStationEventScheduler # starcup: change to trouble scheduler
-  - SlowMeteorSwarmScheduler # starcup: change to slow meteor scheduler
+  # - SlowMeteorSwarmScheduler # starcup: remove separate meteor scheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 


### PR DESCRIPTION
removes the separate meteor swarm schedulers from all of starcup's gamemodes (except survival), and instead adjusts the dangerous event table (used by all non-calm gamemodes) to include the meteor events. this will, overall, lead to a reduced presence of meteors in shifts.

## Why / Balance
meteors being part of their own event scheduler separately from all other events means that in all non-calm shifts, there will _always_ be a steady stream of meteor events, and it means that there will almost always be more meteor events than any other type of event.

this design suggests an assumption of meteors as being an essential part of nearly every ss14 round. while this may hold true and contribute to the gameplay of servers where station-wide destruction is more of a norm, it doesn't align with starcup's goal of being a more slow-paced and deliberate roleplaying experience.

meteors do not contribute enough to that experience to merit omnipresence during so many of our shifts—if anything, there's been a noted strain that they place on engineers that leads to them being taken _away_ from roleplaying opportunities.

it might be worthwhile to look into possibly increasing the scale of individual meteor events, allowing them to be much more destructive with their reduced frequency, but that's probably best saved for after we see this new system in action for a while.

survival's event schedulers, meanwhile, remain untouched because those are rounds in which the station being under constant destructive siege is the norm!

**Changelog**
:cl:
- tweak: meteor events should now be less frequent during all non-survival gamemodes