### PR TITLE
feat: Replaces placeholder paper with empty list on notice board fills

### DIFF
--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/brig.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/brig.yml
@@ -4,8 +4,7 @@
 - type: entityTable
   id: NoticeBoardFillBrig
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase

--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/command.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/command.yml
@@ -4,8 +4,7 @@
 - type: entityTable
   id: NoticeBoardFillBridge
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase

--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/general.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/general.yml
@@ -4,8 +4,7 @@
 - type: entityTable
   id: NoticeBoardFillGeneral
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase

--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/medical.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/medical.yml
@@ -4,8 +4,7 @@
 - type: entityTable
   id: NoticeBoardFillMedical
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase

--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/science.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/science.yml
@@ -4,8 +4,7 @@
 - type: entityTable
   id: NoticeBoardFillScience
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase

--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/security.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/security.yml
@@ -4,8 +4,7 @@
 - type: entityTable
   id: NoticeBoardFillSecurity
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase

--- a/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/service.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/NoticeBoards/service.yml
@@ -4,38 +4,32 @@
 - type: entityTable
   id: NoticeBoardFillServiceJanitor
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entityTable
   id: NoticeBoardFillServiceKitchen
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entityTable
   id: NoticeBoardFillServiceBar
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entityTable
   id: NoticeBoardFillServicePerformer
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entityTable
   id: NoticeBoardFillServiceLibrary
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entityTable
   id: NoticeBoardFillServiceBotany
   table: !type:AllSelector
-    children:
-    - id: Paper # cannot have an empty list here
+    children: []
 
 - type: entity
   parent: NoticeBoardDepartmentalBase


### PR DESCRIPTION
## Why / Balance
Makes it easier to tell when there are actual notices on the board. Less confusing to see blank papers on there.

## Technical details
Empty list is valid

**Changelog**
:cl:
- tweak: Department notice boards should no longer be filled with blank papers. Remember to check them if you see a notice!