### PR TITLE
feat: sets cargo to receive 100% of station funds

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -9,7 +9,7 @@
   abstract: true
   components:
     - type: StationBankAccount
-      primaryCut: 1.00
+      primaryCut: 1.00 # starcup
     - type: StationCargoOrderDatabase
       orders:
         Cargo: [ ]


### PR DESCRIPTION
## Why / Balance
We don't use departmental economy; Nobody is able to access these other accounts and this just makes cargo confusing when they get less money than they expect on sales

## Technical details
Cargo now receives 100% of sales.

**Changelog**
:cl:
- fix: The supply account should now receive the full value of transactions instead of half. Restitution for the stolen funds is not available to employees or contractors at this time.