### PR TITLE
tweak: all heads have externals access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -35,6 +35,7 @@
   - Brigmedic
   - Paramedic
   - Psychologist
+  - External
   # end starcup additions
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -26,6 +26,7 @@
   - Brig
   - Robotics # DeltaV - Robotics access
   - Cryogenics
+  - External # starcup
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
Adds Externals access to the RD and CMO's ID cards.

## Why / Balance
Parity across all head roles. Another reason is that EVA storage, if I'm not mistaken, is externals access and heads needs to be able to access/allow the crew access to that in emergencies. Denying these roles this access might make sense on a larger server, but not as much here.

**Changelog**
:cl:
- tweak: The Research Director and Chief Medical Officer now have Externals access.