### PR TITLE
tweak: exclude MKCs from Narcolepsy trait

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -32,6 +32,14 @@
   name: trait-narcolepsy-name
   description: trait-narcolepsy-desc
   category: Disabilities
+  # begin starcup: exclude MKCs
+  blacklist:
+    components:
+      - Silicon
+      - BorgChassis
+  excludedSpecies:
+    - IPC
+  # end starcup
   components:
     - type: Narcolepsy
       maxTimeBetweenIncidents: 600


### PR DESCRIPTION
In its current state the trait just makes the player stop moving and cancels speech with no indication of what's happening. It might be viable to reimplement after an MKC rework, but for now it's better to exclude it. Copied the section from the Synth trait.

**Changelog**
:cl:
- tweak: MKCs can no longer take the narcolepsy trait, as it does not work properly on them.
