### PR TITLE
tweak: greatly expand smes battery capacity for more power at roundstart

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -157,8 +157,8 @@
   - type: Machine
     board: SMESAdvancedMachineCircuitboard
   - type: Battery
-    maxCharge: 48000000 # starcup: 16MJ > 80MJ
-    startingCharge: 48000000 # starcup: 16MJ > 80MJ
+    maxCharge: 48000000 # starcup: 16MJ > 48MJ
+    startingCharge: 48000000 # starcup: 16MJ > 48MJ
   - type: PowerMonitoringDevice
     group: SMES
     sourceNode: input


### PR DESCRIPTION
triples the maximum/starting energy capacity of smes units, applying to both the basic (8MJ > 24MJ) and advanced (16MJ > 48MJ) ones

## Why / Balance
roundstart for engineers on almost all maps usually consists of a rapid, stressful dash to set up station power within the first few minutes, under threat of station-wide blackouts. on a lower-population server like starcup, this is hostile to those who might be learning the job or an aspect thereof for the first time, and generally places even experienced engineers under an unpleasant time crunch.

currently, most maps will end up completely drained of power within 5-6 minutes on average. here are the approximate numbers I found on each map, followed by the post-pr numbers

### approx. times to blackout, in minutes (current vs post-pr)

- byoin & glacier: 4 > 10
- saltern: 5 > 12
- shoko & train: 6 > 16
- omega: 7 > 20

crux and loop are outliers, currently blacking out at around 10 minutes. they'll be getting updates that replace their main smes arrays with basic units instead of advanced ones, which will overall bring their times to about 15 minutes.

**Changelog**
:cl:
- tweak: smes batteries have had their storage greatly increased, increasing the length of time a station can stay powered at roundstart