### PR TITLE
map(crux): main smes swap

### DIFF
--- a/Resources/Maps/_starcup/crux.yml
+++ b/Resources/Maps/_starcup/crux.yml
@@ -75071,7 +75071,7 @@ entities:
     - type: Transform
       pos: 18.5,-5.5
       parent: 2
-- proto: SMESAdvanced
+- proto: SMESBasic
   entities:
   - uid: 10944
     components:
@@ -75115,8 +75115,6 @@ entities:
     - type: Transform
       pos: -43.5,1.5
       parent: 2
-- proto: SMESBasic
-  entities:
   - uid: 10950
     components:
     - type: MetaData


### PR DESCRIPTION
replaces crux's main smes array with basic units instead of advanced ones, to bring their roundstart power supply in line with the other maps following #665 

**Changelog**
:cl:
- tweak: crux's main smes array has been swapped to basic units to better match the roundstart power supply of other stations