### PR TITLE
map(loop): main smes swap

### DIFF
--- a/Resources/Maps/_starcup/loop.yml
+++ b/Resources/Maps/_starcup/loop.yml
@@ -92307,7 +92307,7 @@ entities:
     - type: Transform
       pos: -14.5,25.5
       parent: 2
-- proto: SMESAdvanced
+- proto: SMESBasic
   entities:
   - uid: 13983
     components:
@@ -92339,8 +92339,6 @@ entities:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
-- proto: SMESBasic
-  entities:
   - uid: 13989
     components:
     - type: Transform


### PR DESCRIPTION
replaces loop's main smes array with basic units instead of advanced ones, to bring their roundstart power supply in line with the other maps following #665 

**Changelog**
:cl:
- tweak: loop's main smes array has been swapped to basic units to better match the roundstart power supply of other stations