### PR TITLE
tweak: change 'angry' to 'hostile' suffixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -167,7 +167,7 @@
 
 - type: entity
   name: bee
-  suffix: Angry
+  suffix: hostile # starcup: changed Angry to hostile
   parent: [ MobBee, MobCombat ]
   id: MobAngryBee
   description: How nice a bee. Oh no, it looks angry and wants my pizza.
@@ -2620,6 +2620,7 @@
 - type: entity
   parent: MobSpiderBase
   id: MobSpiderAngryBase
+  suffix: AI, hostile
   abstract: true
   components:
   - type: NpcFactionMember

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -163,7 +163,7 @@
   name: blue slime
   parent: MobAdultSlimesBlue
   id: MobAdultSlimesBlueAngry
-  suffix: Angry
+  suffix: AI, hostile # starcup: mob suffix consistency
   components:
     - type: NpcFactionMember
       factions:
@@ -203,7 +203,7 @@
   name: green slime
   parent: MobAdultSlimesGreen
   id: MobAdultSlimesGreenAngry
-  suffix: Angry
+  suffix: AI, hostile # starcup: mob suffix consistency
   components:
     - type: NpcFactionMember
       factions:
@@ -242,7 +242,7 @@
   name: yellow slime
   parent: MobAdultSlimesYellow
   id: MobAdultSlimesYellowAngry
-  suffix: Angry
+  suffix: AI, hostile # starcup: mob suffix consistency
   components:
     - type: NpcFactionMember
       factions:

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -154,7 +154,7 @@
 
 - type: entity
   id: KudzuFlowerAngry
-  suffix: Angry, Floral Anomaly
+  suffix: hostile, floral anomaly # starcup: changed angry to hostile, turned to lowercase for consistency
   parent: KudzuFlowerFriendly
   components:
     - type: Kudzu


### PR DESCRIPTION
## Why / Balance
I don't feel like 'angry' is a very good term for enemy NPCs, I'd rather hostile.

## Technical details
Changed all instances of the "Angry" suffix to "hostile". Note that this is for _suffixes,_ IDs and spawner names that include the word "Angry" were left as is. Also, added the suffix to MobGiantSpiderAngry, which previously didn't have it - resulting in the entity spawn menu having two identical tarantulas, one of which was hostile, without any indication to which was which.

## Media
<img width="350" height="400" alt="image" src="https://github.com/user-attachments/assets/7977640c-b6d5-4e2f-a0e4-bf2748adb6c0" />
