### PR TITLE
fix: thief gamemode actually selects thieves

### DIFF
--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -38,7 +38,6 @@
     cost: 75
   # begin starcup: added so thief can be a standalone gamemode
   - type: GameRule
-    minPlayers: 5
     delay:
       min: 240
       max: 420


### PR DESCRIPTION
it turns out, the thief game rule was missing the `GameRule` component, causing it to fail to actually do anything at roundstart

**Changelog**
:cl:
- fix: the thief gamemode will now actually select thieves