### PR TITLE
fix: fixes client warning spam from alternate typing indicators

### DIFF
--- a/Content.Client/_DV/Chat/TypingIndicator/TypingIndicatorSystem.AlternateTypingIndicator.cs
+++ b/Content.Client/_DV/Chat/TypingIndicator/TypingIndicatorSystem.AlternateTypingIndicator.cs
@@ -23,7 +23,7 @@ public sealed partial class TypingIndicatorSystem
     /// <param name="protoId">The TypingIndicator to show in place of the normal TypingIndicator</param>
     public void ClientAlternateTyping(TypingIndicatorState state, ProtoId<TypingIndicatorPrototype> protoId)
     {
-        if (_shouldShowTyping)
+        if (_shouldShowTyping || _playerManager.LocalEntity == null) // starcup: avoid warning spam when player isn't attached to an entity
             return;
 
         _isClientTyping = true;


### PR DESCRIPTION
## Why / Balance
Bugfix

## Technical details
Don't try to change the typing indicator when you don't have an entity

## Media
[Insert image with no warning spam here]

**Changelog**
N/A - minor warning