### PR TITLE
fix: remove pullable component from burrowed creatures

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/burrowed_creature.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/burrowed_creature.yml
@@ -116,12 +116,12 @@
     baseWalkSpeed : 0
     baseSprintSpeed : 0
   - type: NoSlip
-    # the components below were copied from MobDamageable, and maybe tweaked a little.
-    # the burrowed creature was not parented to it because MobDamageable has the pullable component.
-    # we don't want burrowed creatures to be pullable.
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: burrowed
+    # the components below were copied from MobDamageable, and maybe tweaked a little.
+    # the burrowed creature was not parented to it because MobDamageable has the pullable component.
+    # we don't want burrowed creatures to be pullable.
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
Whoops. Follow-up to https://github.com/teamstarcup/starcup/pull/676.

## Technical details
BurrowedCreatureSmall was parented to MobDamageable, which includes the Pullable component. I removed the parent and copied its components nearly wholesale except for that one. Also tweaked the Alive and Dead thresholds for both burrowed creature entities.
