### PR TITLE
fix: moves AAC button styles from StyleNano to sheetlets

### DIFF
--- a/Content.Client/Stylesheets/CommonStylesheet.cs
+++ b/Content.Client/Stylesheets/CommonStylesheet.cs
@@ -73,4 +73,14 @@ public abstract class CommonStylesheet : PalettedStylesheet, IButtonConfig, IWin
     ColorPalette IButtonConfig.ButtonPalette => PrimaryPalette with { PressedElement = PositivePalette.PressedElement };
     ColorPalette IButtonConfig.PositiveButtonPalette => PositivePalette;
     ColorPalette IButtonConfig.NegativeButtonPalette => NegativePalette;
+
+    // begin starcup: department buttons
+    ColorPalette IButtonConfig.CommandButtonPalette => Palettes.DepartmentCommand;
+    ColorPalette IButtonConfig.EngineeringButtonPalette => Palettes.DepartmentEngineering;
+    ColorPalette IButtonConfig.ScienceButtonPalette => Palettes.DepartmentScience;
+    ColorPalette IButtonConfig.LogisticsButtonPalette => Palettes.DepartmentLogistics;
+    ColorPalette IButtonConfig.MedicalButtonPalette => Palettes.DepartmentMedical;
+    ColorPalette IButtonConfig.SecurityButtonPalette => Palettes.DepartmentSecurity;
+    ColorPalette IButtonConfig.ServiceButtonPalette => Palettes.DepartmentService;
+    // end starcup
 }

--- a/Content.Client/Stylesheets/Palette/Palettes.cs
+++ b/Content.Client/Stylesheets/Palette/Palettes.cs
@@ -27,4 +27,14 @@ public static class Palettes
     // Intended to be used with `ModulateSelf` to darken / lighten something
     public static readonly ColorPalette AlphaModulate = ColorPalette.FromHexBase("#ffffff");
 
+    // begin starcup: department color palettes
+    public static readonly ColorPalette DepartmentCommand = ColorPalette.FromHexBase("#55203f");
+    public static readonly ColorPalette DepartmentEngineering = ColorPalette.FromHexBase("#77684B");
+    public static readonly ColorPalette DepartmentScience = ColorPalette.FromHexBase("#6F5973");
+    public static readonly ColorPalette DepartmentLogistics = ColorPalette.FromHexBase("#61503A");
+    public static readonly ColorPalette DepartmentMedical = ColorPalette.FromHexBase("#49687D");
+    public static readonly ColorPalette DepartmentSecurity = ColorPalette.FromHexBase("#724449");
+    public static readonly ColorPalette DepartmentService = ColorPalette.FromHexBase("#607952");
+    // end starcup
+
 }

--- a/Content.Client/Stylesheets/SheetletConfigs/IButtonConfig.cs
+++ b/Content.Client/Stylesheets/SheetletConfigs/IButtonConfig.cs
@@ -20,4 +20,14 @@ public interface IButtonConfig : ISheetletConfig
     public ColorPalette ButtonPalette { get; }
     public ColorPalette PositiveButtonPalette { get; }
     public ColorPalette NegativeButtonPalette { get; }
+
+    // begin starcup: department buttons
+    public ColorPalette CommandButtonPalette { get; }
+    public ColorPalette EngineeringButtonPalette { get; }
+    public ColorPalette ScienceButtonPalette { get; }
+    public ColorPalette LogisticsButtonPalette { get; }
+    public ColorPalette MedicalButtonPalette { get; }
+    public ColorPalette SecurityButtonPalette { get; }
+    public ColorPalette ServiceButtonPalette { get; }
+    // end starcup
 }

--- a/Content.Client/Stylesheets/Sheetlets/ButtonSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/ButtonSheetlet.cs
@@ -74,6 +74,16 @@ public sealed class ButtonSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet
         MakeButtonRules(rules, buttonCfg.PositiveButtonPalette, StyleClass.Positive);
         MakeButtonRules(rules, buttonCfg.NegativeButtonPalette, StyleClass.Negative);
 
+        // begin starcup: add the AAC styles
+        MakeButtonRules(rules, buttonCfg.CommandButtonPalette, StyleClass.DepartmentCommand);
+        MakeButtonRules(rules, buttonCfg.EngineeringButtonPalette, StyleClass.DepartmentEngineering);
+        MakeButtonRules(rules, buttonCfg.ScienceButtonPalette, StyleClass.DepartmentScience);
+        MakeButtonRules(rules, buttonCfg.LogisticsButtonPalette, StyleClass.DepartmentLogistics);
+        MakeButtonRules(rules, buttonCfg.MedicalButtonPalette, StyleClass.DepartmentMedical);
+        MakeButtonRules(rules, buttonCfg.SecurityButtonPalette, StyleClass.DepartmentSecurity);
+        MakeButtonRules(rules, buttonCfg.ServiceButtonPalette, StyleClass.DepartmentService);
+        // end starcup
+
         return rules.ToArray();
     }
 

--- a/Content.Client/Stylesheets/StyleClass.cs
+++ b/Content.Client/Stylesheets/StyleClass.cs
@@ -67,4 +67,15 @@ public static class StyleClass
     public const string TooltipPanel = "TooltipPanel";
     public const string TooltipTitle = "TooltipTitle";
     public const string TooltipDesc = "TooltipDesc";
+
+
+    // begin starcup: departmental color classes
+    public const string DepartmentCommand = "DepartmentCommand";
+    public const string DepartmentEngineering = "DepartmentEngineering";
+    public const string DepartmentScience = "DepartmentScience";
+    public const string DepartmentLogistics = "DepartmentLogistics";
+    public const string DepartmentMedical = "DepartmentMedical";
+    public const string DepartmentSecurity = "DepartmentSecurity";
+    public const string DepartmentService = "DepartmentService";
+    // end starcup
 }

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -159,35 +159,6 @@ namespace Content.Client.Stylesheets
 
         public static readonly Color ChatBackgroundColor = Color.FromHex("#25252ADD");
 
-        // DeltaV - AAC button variables
-        public static readonly string CommandButtonClass = "CommandButton";
-        public static readonly string EngineeringButtonClass = "EngineeringButton";
-        public static readonly string ScienceButtonClass = "ScienceButton";
-        public static readonly string JusticeButtonClass = "JusticeButton";
-        public static readonly string LogisticsButtonClass = "LogisticsButton";
-        public static readonly string MedicalButtonClass = "MedicalButton";
-        public static readonly string SecurityButtonClass = "SecurityButton";
-        public static readonly string ServiceButtonClass = "ServiceButton";
-
-        // DeltaV - AAC button colors
-        public static readonly Color CommandButtonColorDefault = Color.FromHex("#404A58");
-        public static readonly Color CommandColorHovered = Color.FromHex("#4F587B");
-        public static readonly Color EngineeringButtonColorDefault = Color.FromHex("#77684B");
-        public static readonly Color EngineeringColorHovered = Color.FromHex("#776D71");
-        public static readonly Color ScienceButtonColorDefault = Color.FromHex("#6F5973");
-        public static readonly Color ResearchColorHovered = Color.FromHex("#71638E");
-        public static readonly Color LogisticsButtonColorDefault = Color.FromHex("#61503A");
-        public static readonly Color LogisticsColorHovered = Color.FromHex("#675C64");
-        public static readonly Color JusticeButtonColorDefault = Color.FromHex("#4F3D4C");
-        public static readonly Color JusticeColorHovered = Color.FromHex("#5C4B5A");
-        public static readonly Color MedicalButtonColorDefault = Color.FromHex("#49687D");
-        public static readonly Color MedicalColorHovered = Color.FromHex("#556E95");
-        public static readonly Color SecurityButtonColorDefault = Color.FromHex("#724449");
-        public static readonly Color SecurityColorHovered = Color.FromHex("#745370");
-        public static readonly Color ServiceButtonColorDefault = Color.FromHex("#607952");
-        public static readonly Color ServiceColorHovered = Color.FromHex("#667A76");
-        // End DeltaV
-
         // i'm not sure what the missing symbols were referencing, and this is getting obseleted anyway so:
         public const string ButtonOpenRight = "OpenRight";
         public const string ButtonOpenLeft = "OpenLeft";
@@ -1659,88 +1630,6 @@ namespace Content.Client.Stylesheets
                     {
                         BackgroundColor = FancyTreeSelectedRowColor,
                     }),
-
-                // DeltaV - AAC button styles
-                Element<ContainerButton>()
-                    .Class(CommandButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, CommandButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(CommandButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, CommandColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(EngineeringButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, EngineeringButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(EngineeringButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, EngineeringColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(ScienceButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, ScienceButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(ScienceButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, ResearchColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(LogisticsButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, LogisticsButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(LogisticsButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, LogisticsColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(MedicalButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, MedicalButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(MedicalButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, MedicalColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(SecurityButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, SecurityButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(SecurityButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, SecurityColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(ServiceButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, ServiceButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(ServiceButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, ServiceColorHovered),
-
-                Element<ContainerButton>()
-                    .Class(JusticeButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(Control.StylePropertyModulateSelf, JusticeButtonColorDefault),
-
-                Element<ContainerButton>()
-                    .Class(JusticeButtonClass)
-                    .Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, JusticeColorHovered),
-                // End DeltaV
 
                 // Silicon law edit ui
                 Element<Label>().Class(SiliconLawContainer.StyleClassSiliconLawPositionLabel)

--- a/Resources/Prototypes/_DV/QuickPhrases/Threats/hazards.yml
+++ b/Resources/Prototypes/_DV/QuickPhrases/Threats/hazards.yml
@@ -2,7 +2,7 @@
   id: BaseHazardThreatPhrase
   parent: BaseThreatPhrase
   group: Hazards
-  styleClass: EngineeringButton
+  styleClass: DepartmentEngineering # starcup: EngineeringButton -> DepartmentEngineering
   abstract: true
 
 - type: quickPhrase

--- a/Resources/Prototypes/_DV/QuickPhrases/Threats/hostiles.yml
+++ b/Resources/Prototypes/_DV/QuickPhrases/Threats/hostiles.yml
@@ -2,7 +2,7 @@
   id: BaseHostileThreatPhrase
   parent: BaseThreatPhrase
   group: Hostiles
-  styleClass: SecurityButton
+  styleClass: DepartmentSecurity # starcup: SecurityButton -> DepartmentSecurity
   abstract: true
 
 - type: quickPhrase

--- a/Resources/Prototypes/_DV/QuickPhrases/Threats/status.yml
+++ b/Resources/Prototypes/_DV/QuickPhrases/Threats/status.yml
@@ -82,19 +82,19 @@
   id: SafetyHereToHelpPhrase
   parent: BaseSafetyStatusPhrase
   text: phrase-safety-here-to-help
-  styleClass: ServiceButton
+  styleClass: DepartmentService # starcup: ServiceButton -> DepartmentService
 
 - type: quickPhrase
   id: SafetyHowToHelpPhrase
   parent: BaseSafetyStatusPhrase
   text: phrase-safety-how-to-help
-  styleClass: ServiceButton
+  styleClass: DepartmentService # starcup: ServiceButton -> DepartmentService
 
 - type: quickPhrase
   id: SafetyEvacPhrase
   parent: BaseSafetyStatusPhrase
   text: phrase-safety-evac
-  styleClass: ServiceButton
+  styleClass: DepartmentService # starcup: ServiceButton -> DepartmentService
 
 - type: quickPhrase
   id: SafetyNotPhrase

--- a/Resources/Prototypes/_DV/QuickPhrases/base.yml
+++ b/Resources/Prototypes/_DV/QuickPhrases/base.yml
@@ -40,41 +40,41 @@
 - type: quickPhrase
   id: BaseCommandPhrase
   group: Command
-  styleClass: CommandButton
+  styleClass: DepartmentCommand # starcup: change to department class
   abstract: true
 
 - type: quickPhrase
   id: BaseEngineeringPhrase
   group: Engineering
-  styleClass: EngineeringButton
+  styleClass: DepartmentEngineering # starcup: change to department class
   abstract: true
 
 - type: quickPhrase
   id: BaseSciencePhrase # starcup: epistemics to science
   group: Science # starcup: epistemics to science
-  styleClass: ScienceButton # starcup: epistemics to science
+  styleClass: DepartmentScience # starcup: change to department class & epistemics to science
   abstract: true
 
 - type: quickPhrase
   id: BaseLogisticsPhrase
   group: Logistics
-  styleClass: LogisticsButton
+  styleClass: DepartmentLogistics # starcup: change to department class
   abstract: true
 
 - type: quickPhrase
   id: BaseMedicalPhrase
   group: Medical
-  styleClass: MedicalButton
+  styleClass: DepartmentMedical # starcup: change to department class
   abstract: true
 
 - type: quickPhrase
   id: BaseSecurityPhrase
   group: Security
-  styleClass: SecurityButton
+  styleClass: DepartmentSecurity # starcup: change to department class
   abstract: true
 
 - type: quickPhrase
   id: BaseServicePhrase
   group: Service
-  styleClass: ServiceButton
+  styleClass: DepartmentService # starcup: change to department class
   abstract: true


### PR DESCRIPTION
## Why / Balance
Gives AAC back its colored buttons.
fixes  #591

## Technical details
- Set up a generic department class and palettes to make them more generic. 
- Added button styles to buttonconfig.
- Changed command to Tyrian purple

## Media
<img width="478" height="698" alt="image" src="https://github.com/user-attachments/assets/98dbff93-5a86-49f0-96a0-24d2dd1b581e" />

**Changelog**
:cl:
- fix: The AAC tablet's buttons have colors again!