### PR TITLE
tweak: allow detail examination from a distance

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -40,7 +40,7 @@ namespace Content.Shared.Examine
         public const float DeadExamineRange = 0.75f;
 
         public const float ExamineRange = 16f;
-        protected const float ExamineDetailsRange = 3f;
+        protected const float ExamineDetailsRange = ExamineRange; //starcup: increase details range
 
         protected const float ExamineBlurrinessMult = 2.5f;
 


### PR DESCRIPTION
People can now read detailed examine text so long as the person is within examinable range. 

## Why / Balance
I'm not sure what function the restriction serves. The idea seems to be that it's realistic to not be able to see detailed markings from afar, but it mostly just ends up being inconvenient. People put all kinds of things in their detailed examines, some visible from afar and some still hidden even when close, and the abuse case is comical and inconsequential ("hey, you with the slight scar hidden underneath your coat! come here!"). I'd rather get a clearer mental image of a character without having to do an awkward OOC shuffle closer.

## Technical details
This might not be the best way to do it. CL is technically misleading but that's how players will see it.

**Changelog**
:cl:
- tweak: Detailed examines are now visible from any range.
