### PR TITLE
fix: limited attack memory for spiders (and Shiva)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2664,6 +2664,7 @@
         Burn: -0.07
   # begin starcup: make spiders defend themselves and attack bugs
   - type: NPCRetaliation
+    attackMemoryLength: 15
   - type: FactionException
   - type: HTN
     rootTask:


### PR DESCRIPTION
Fixing an unintended consequence of https://github.com/teamstarcup/starcup/pull/574.

## Technical details
- Added missing attackmemoryretaliation duration to the spider's NPCRetaliation component.

**Changelog**
:cl:
- fix: Spiders' retaliation over friendly fire will expire after 15 seconds. Shiva will no longer hate you forever if you accidentally stick your knife in her.
