### PR TITLE
tweak: whitelist the prisoner job

### DIFF
--- a/Resources/Prototypes/_starcup/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_starcup/Roles/Jobs/Wildcards/prisoner.yml
@@ -3,10 +3,7 @@
   name: job-name-prisoner
   description: job-description-prisoner
   playTimeTracker: JobPrisoner
-  requirements:
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 7200 #2 hr
+  whitelisted: true
   startingGear: PrisonerGear
   icon: JobIconPermaPrisoner
   supervisors: job-supervisors-security


### PR DESCRIPTION
makes prisoner a whitelisted job

## Why / Balance
the team's still trying to figure out what to do with the prisoner, but is in agreement that the job probably shouldn't be available to just anybody due to its disproportionate potential impact on other people's shifts. as both a filtering measure and also in the hopes of gathering more data, we've decided to put it on our whitelist

**Changelog**
:cl:
- tweak: the prisoner is now a whitelisted job