### PR TITLE
map(crux): more fixes, security renovations

### DIFF
--- a/Resources/Maps/_starcup/crux.yml
+++ b/Resources/Maps/_starcup/crux.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/20/2026 08:48:28
-  entityCount: 14208
+  time: 01/20/2026 08:53:30
+  entityCount: 14210
 maps:
 - 1
 grids:
@@ -41214,6 +41214,12 @@ entities:
     - type: Transform
       pos: -4.5,32.5
       parent: 2
+  - uid: 14210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,-43.5
+      parent: 2
 - proto: Fireplace
   entities:
   - uid: 6396
@@ -71207,7 +71213,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 17.5,4.5
       parent: 2
-  - uid: 11647
+  - uid: 11648
     components:
     - type: Transform
       pos: 11.5,18.5
@@ -72525,6 +72531,11 @@ entities:
     components:
     - type: Transform
       pos: 36.5,-2.5
+      parent: 2
+  - uid: 14209
+    components:
+    - type: Transform
+      pos: 27.5,-48.5
       parent: 2
 - proto: RandomDrinkGlass
   entities:
@@ -78254,6 +78265,11 @@ entities:
     - type: Transform
       pos: -7.5,-31.5
       parent: 2
+  - uid: 11647
+    components:
+    - type: Transform
+      pos: 27.5,-48.5
+      parent: 2
   - uid: 12832
     components:
     - type: Transform
@@ -80107,11 +80123,6 @@ entities:
     components:
     - type: Transform
       pos: 17.5,18.5
-      parent: 2
-  - uid: 11648
-    components:
-    - type: Transform
-      pos: 27.5,-48.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:


### PR DESCRIPTION
time for another crux patch! in addition to some miscellaneous fixing up of stuff (and including more counter firelocks cuz I forgot them) this also does the following to the security department:

- expands the locker room a bit to give some more breathing room
- brings the secdrobe over from the checkpoint to the locker room.
- adds an eod closet and a mechanical toolbox
- replaces the disabler safe with a contraband storage crate
- adds a mixed lights box to the brig
- replaces the lizard and drazil with eskie and eikse due to explosive mothroach incidents

## Why / Balance
security on crux has been a little bit barebones and cramped. this should hopefully alleviate that a little bit and give them a bit more to work with!

**Changelog**
:cl:
- tweak: crux station has seen another wave of fixes!
- tweak: crux's security department has received a bit of expansion and some additional tools, as well as their missing secdrobe
- tweak: replaced the lizard and drazil plushies in crux's interrogation room after reports of the divorce proceedings leading to explosive fallout