### PR TITLE
fix: insect swarms and giant insects contain slime

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/insects.yml
@@ -135,6 +135,10 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/_starcup/Animals/Swarm/swarmpet.ogg
+  - type: Butcherable
+    spawned:
+    - id: FoodMeatSlime
+      amount: 2
 
 - type: entity
   name: bees


### PR DESCRIPTION
Makes insect swarms (flies, bees, wasps, fireflies, mosquitoes) work like cockroaches, where they contain slime and you can blend them up. Have a delicious, nutritious glass of ground housefly slime. Mmmmm.

Addition to https://github.com/teamstarcup/starcup/pull/574.

## Why / Balance
Not being able to easily get rid of the corpses they leave behind is awkward and gross.

## Technical details
- Made MobFlyingInsect have slime you can grind it into.
- MobGiantFlyingInsect can be butchered for 3 slimeballs. Bug meat may come in a future PR. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

**Changelog**
:cl:
- tweak: You can grind houseflies and other small bug insect swarms into slime. Mmmmm.
- tweak: You can butcher large insects like mosquitos and wasps into slimeballs.
