### PR TITLE
feat: add penguin awareness day

### DIFF
--- a/Resources/Locale/en-US/_starcup/holiday/greet/holiday-greet.ftl
+++ b/Resources/Locale/en-US/_starcup/holiday/greet/holiday-greet.ftl
@@ -1,0 +1,1 @@
+holiday-name-penguin-awareness-day = Penguin Awareness Day

--- a/Resources/Prototypes/_starcup/holidays.yml
+++ b/Resources/Prototypes/_starcup/holidays.yml
@@ -1,0 +1,5 @@
+- type: holiday
+  id: PenguinAwarenessDay
+  name: holiday-name-penguin-awareness-day
+  beginDay: 20
+  beginMonth: January


### PR DESCRIPTION
adds penguin awareness day (january 20th) as a holiday acknowledged by the game

## Why / Balance
it's very important to be aware of them

(also there's a lot of penguin paraphernalia in the game that could make use of `GiveItemOnHolidaySpecial`)

**Changelog**
not player facing until next year, no cl