### PR TITLE
fix(crux): add missing combat medic job slot

### DIFF
--- a/Resources/Prototypes/_starcup/Maps/crux.yml
+++ b/Resources/Prototypes/_starcup/Maps/crux.yml
@@ -57,6 +57,7 @@
             Warden: [ 1, 1 ]
             SecurityOfficer: [ 3, 3 ]
             Detective: [ 1, 1 ]
+            Brigmedic: [ 1, 1 ]
             SecurityCadet: [ 2, 2 ] #intern, not counted
             Prisoner: [ 2, 2 ]
             #supply (6)


### PR DESCRIPTION
oops I forgot!!

**Changelog**
:cl:
- fix: crux should now have a slot for combat medics, as intended