### PR TITLE
tweak: rename altars to remove religious references

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/altar.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/altar.yml
@@ -2,7 +2,7 @@
   id: AltarBase
   parent: BaseStructure
   name: altar
-  description: Altar of the Gods.
+  description: An altar for meditation and prayer. # starcup: rewritten to remove mention of gods
   abstract: true
   components:
   - type: Anchorable
@@ -106,7 +106,7 @@
 - type: entity
   id: AltarSpaceChristian
   parent: AltarNanotrasen
-  name: space-Christian altar
+  name: bright altar # starcup: renamed to remove religious reference
   components:
   - type: Sprite
     sprite: Structures/Furniture/Altars/Gods/nanotrasen.rsi
@@ -125,7 +125,7 @@
 - type: entity
   id: AltarSatana
   parent: AltarNanotrasen
-  name: satanic altar
+  name: ominous altar # starcup: renamed to remove religious reference
   components:
   - type: Sprite
     sprite: Structures/Furniture/Altars/Gods/nanotrasen.rsi


### PR DESCRIPTION
renames the space-christian and satanic altars to "bright altar" and "ominous altar" respectively, and slightly rewrites the altar description text to remove the mention of gods

## Why / Balance
part of the ongoing effort to remove the chaplain's references to real-world religion and broaden the job's thematic space for our players!

**Changelog**
:cl:
- tweak: altar names and descriptions have been lightly rewritten to remove associations with real-world religion