### PR TITLE
map(shoko): tesla, general update

### DIFF
--- a/Resources/Maps/_starcup/shoukou.yml
+++ b/Resources/Maps/_starcup/shoukou.yml
@@ -44265,7 +44265,7 @@ entities:
     - type: Transform
       pos: 51.475582,-34.342915
       parent: 2
-- proto: DrinkMilkCarton
+- proto: DrinkCreamCarton
   entities:
   - uid: 10441
     components:


### PR DESCRIPTION
Housekeeping for Shoukou and the addition of a Tesla... poor girl hasn't had an update specific to her since being introduced. There are quite a few removals; timed mouse spawners, a large amount of mapped food, excessive mapped dirt decal and trash spawners, medibots and cleanbots, and a few more things. Some wiring was also redone to make more sense and to make APCs more local, in addition to standardizing APC/substation/SMES names. The mining shuttle is on the salvage arm, now. Justice rooms have been trimmed; Clerk room is now part of maints, Chief Justice is a little fancy date room, and one of the lawyer offices (prosecutor?) is replaced with a laundry room. The courtroom itself is still there; I thought about making a park there, but it's a cute room.

The two main points:
- There is now a Tesla engine setup.
- Atmos has been tweaked; there is now three times the roundstart oxygen and stored oxygen temperature management should be easier.

My hopes with these changes is that it becomes a less atmospherics-dependent station. I expect that a calm shift could be run without the need for a atmos tech if the Tesla is set up and there are no incidents. 

## Media
<img width="4672" height="3232" alt="Shoukou-0" src="https://github.com/user-attachments/assets/72e8c387-b78d-4530-9d46-4f3f1151fd9e" />

Most of the changes are in the south/southwest of the station. I like the ice cream parlor :3

**Changelog**
:cl:
- add: Shoukou has received a round of renovations! Engineers in particular can look forward to a cozy Tesla setup.
- tweak: Shoukou has three times the roundstart oxygen, to reduce strain on atmos techs.
