### PR TITLE
tweak: Increase/Remove character limit of Character's Records

### DIFF
--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -12,7 +12,7 @@ namespace Content.Shared._CD.Records;
 public sealed partial class PlayerProvidedCharacterRecords
 {
     public const int TextMedLen = 64;
-    public const int TextVeryLargeLen = 65536;
+    public const int TextVeryLargeLen = 65536; // starcup
 
     /* Basic info */
 


### PR DESCRIPTION
Updates the character limit from the previously small 4096 characters to a much larger 65536 characters.



## Why / Balance
Just to allow more player freedom when making records. Personally, a lot of my records are long or rely on complex headers and footers made from papercode. Markups and papercode and eat up an insane amount of that 4096 character allowance. This just makes the character limit 65536 characters so it's no longer a problem.

## Technical details
I changed one number in a line from 4096 to 65536

**Changelog**
tweak: Increased the character limit on records from 4096 characters to 65536 characters. Go ham with records!