### PR TITLE
fix: remove rat king from antag pool

### DIFF
--- a/Resources/Prototypes/_starcup/GameRules/events.yml
+++ b/Resources/Prototypes/_starcup/GameRules/events.yml
@@ -32,7 +32,7 @@
     children:
     - id: ClosetSkeleton
     - id: DragonSpawn
-    - id: KingRatMigration
+    #- id: KingRatMigration # disabled pending reworks
     - id: ParadoxCloneSpawn
     - id: SleeperAgents
     - !type:NestedSelector


### PR DESCRIPTION
removes the rat king event from the starcup antag pool

## Why / Balance
it being there at all was erroneous; it was deemed early on that we wanted to remove it until we could give it a rework, but it snuck back in during the event overhaul

**Changelog**
not player-facing, no cl