### PR TITLE
tweak: make sbiten actually use honey, and adjust its recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -1036,9 +1036,14 @@
 
 - type: reaction
   id: Sbiten
+  minTemp: 350 # starcup: you gotta boil it!
   reactants:
-    Mead: # starcup: changed from vodka (replace with honey once it exists?)
-      amount: 1
+    # begin starcup: changed recipe to be non-alcoholic
+    Honey:
+      amount: 2
+    Water:
+      amount: 2
+    # end starcup
     CapsaicinOil:
       amount: 1
   products:


### PR DESCRIPTION
changes sbiten's recipe (again)! it now uses two parts honey, two parts water, and one part capsaicin oil, and must be heated to 350K

## Why / Balance
mead was essentially a placeholder until we had honey, since that's what sbiten is based on in real life! the heating requirement, in turn, is a reflection of how sbiten is boiled as part of making it. makes the drink a little bit more special, and truer to its real-world origin

**Changelog**
:cl:
- tweak: sbiten's recipe has been changed to include honey!