### PR TITLE
fix: store heisentest from l6 bundle

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -77,7 +77,7 @@ public sealed class StoreTests
             var mind = mindSystem.CreateMind(null);
             mindSystem.TransferTo(mind, human, mind: mind);
 
-            FixedPoint2 originalBalance = 20;
+            FixedPoint2 originalBalance = 30; // starcup: up from 20, fix test failure with L6 SAW bundle
             uplinkSystem.AddUplink(human, originalBalance, null, true);
 
             var storeComponent = entManager.GetComponent<StoreComponent>(pda);


### PR DESCRIPTION
`StoreDiscountAndRefund` was failing because it only gave its test uplink a budget of 20 TC, causing errors if the L6 SAW bundle was chosen as one of the items due to it costing 24 TC

**Changelog**
not player-facing, no cl