### PR TITLE
feat: new starcup feedback popups

### DIFF
--- a/Content.Shared/CCVar/CCVars.Feedback.cs
+++ b/Content.Shared/CCVar/CCVars.Feedback.cs
@@ -13,5 +13,5 @@ public sealed partial class CCVars
     /// wizden deltav
     /// </example>
     public static readonly CVarDef<string> FeedbackValidOrigins =
-        CVarDef.Create("feedback.valid_origins", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("feedback.valid_origins", "starcup", CVar.SERVER | CVar.REPLICATED);
 }

--- a/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
+++ b/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
@@ -1,0 +1,124 @@
+# Maps
+
+- type: feedbackPopup
+  id: FeedbackPopupMapBanana
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Banana[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/banana-station-feedback-thread/354"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapByoin
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Byōin[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/byoin-station-feedback-thread/355"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapCrux
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Crux[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/crux-station-feedback-thread/319"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapGlacier
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Glacier[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/glacier-station-feedback-thread/356"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapLoop
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Loop[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/loop-station-feedback-thread/357"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapOmega
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Omega[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/omega-station-feedback-thread/359"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapReach
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Reach[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/reach-station-feedback-thread/358"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapSaltern
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Saltern[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/saltern-station-feedback-thread/360"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapShoukou
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Shōkō[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/shoko-feedback-thread/361"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupMapTrain
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Train[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/train-feedback-thread/362"
+  showRoundEnd: false
+
+# Game
+
+- type: feedbackPopup
+  id: FeedbackPopupGameMail
+  popupOrigin: starcup
+  title: "[bold]Gameplay Feedback: Mail[/bold]"
+  description: |-
+    We can always use more data for our recently reworked mail system! Let us know what you got and how you feel about it!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/mail-feedback-thread/375"
+  showRoundEnd: false
+
+- type: feedbackPopup
+  id: FeedbackPopupGameSanctification
+  popupOrigin: starcup
+  title: "[bold]Gameplay Feedback: Sanctification[/bold]"
+  description: |-
+    Our new sanctification system for chaplains is in early stages of development, and can thus be greatly helped by feedback from players!
+    Tell us if you enjoy the new system, and what improvements you can think to make on it!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/sanctification-feedback-thread/401"
+  showRoundEnd: false


### PR DESCRIPTION
adds new starcup-specific feedback popups and sets the ccvar to make starcup popups the default. they all have `showRoundEnd` set to false for the moment, but can be toggled back on or manually shown to players as desired

## Why / Balance
we are a very small development team and desperately need feedback to live

**Changelog**
not player-facing by default, no cl