### PR TITLE
feat: reagent whitelists for metabolizers

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -96,6 +97,14 @@ public sealed partial class MetabolizerComponent : Component
     /// </summary>
     [DataField]
     public List<ProtoId<MetabolismStagePrototype>> Stages = new();
+
+    /// <summary>
+    ///     starcup: Whitelist of reagents that this metabolizer will exclusively process.
+    ///     If this field is specified, all non-whitelisted reagents in the metabolizer's stage
+    ///     will remain unprocessed.
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<ReagentPrototype>>? ReagentWhitelist;
 }
 
 [DataDefinition]

--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -171,6 +171,14 @@ public sealed class MetabolizerSystem : EntitySystem
             if (ev.Reagents.Contains(reagent))
                 continue;
 
+            // begin starcup: metabolizer whitelist
+            if (ent.Comp1.ReagentWhitelist != null)
+            {
+                if (!ent.Comp1.ReagentWhitelist.Contains(proto))
+                    continue;
+            }
+            // end starcup
+
             if (proto.Metabolisms is null || !proto.Metabolisms.Metabolisms.TryGetValue(stage, out var entry))
             {
                 var mostToTransfer = FixedPoint2.Clamp(solutionData.TransferRate, 0, quantity);


### PR DESCRIPTION
allows for metabolizers to be given a whitelist of reagents that they will process, to the exclusion of all other reagents.

## Why / Balance
atomized out from the mkc rework, which needs this in order to retain the species's selective reagent processing after metabolism groups were outmoded.

## Technical details
uses a hashset of reagent ids specified underneath the metabolizer component. bit of a brute-force solution and will probably lead to unflatteringly long bulleted lists in the yaml files, but it works for now and is easy to maintain since reagents don't get added very often.

**Changelog**
not player-facing, no cl