### PR TITLE
fix: invalid glowstick prototype in mail pool

### DIFF
--- a/Resources/Prototypes/_starcup/Catalog/Fills/tools.yml
+++ b/Resources/Prototypes/_starcup/Catalog/Fills/tools.yml
@@ -80,7 +80,13 @@
     - id: GeigerCounter
     - id: HandheldGPSBasic
     - id: HandLabeler
-    - id: GlowstickBase
+    - !type:GroupSelector
+      children:
+      - id: GlowstickGreen
+      - id: GlowstickRed
+      - id: GlowstickPurple
+      - id: GlowstickYellow
+      - id: GlowstickBlue
     - id: RadioHandheld
     - id: AppraisalTool
     - !type:NestedSelector


### PR DESCRIPTION
the `RandomSmallToolTable` was occasionally trying to spawn the now-abstract `GlowstickBase`. this replaces it with a group selector for all colors of glowstick instead!

**Changelog**
not player-facing, no cl