### PR TITLE
fix: mirror stimulant tc prices to nt uplink

### DIFF
--- a/Resources/Prototypes/_starcup/Catalog/uplink_catalog_nt.yml
+++ b/Resources/Prototypes/_starcup/Catalog/uplink_catalog_nt.yml
@@ -583,9 +583,9 @@
   productEntity: StimpackNT
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkChemicalsNT
 
@@ -596,9 +596,9 @@
   productEntity: StimkitFilledNT
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 3
   cost:
-    Telecrystal: 12
+    Telecrystal: 5
   categories:
   - UplinkChemicalsNT
 


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14/pull/42383 snuck by unnoticed and didn't get mirrored in the nt uplink! this lowers our prices to match theirs

**Changelog**
:cl:
- fix: the nt uplink prices of the hyperzine injector and kit have been lowered to match the syndicate uplink