### PR TITLE
fix: human hair marking point limit

### DIFF
--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -5,7 +5,7 @@
   id: Human
   limits:
     enum.HumanoidVisualLayers.Hair:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.FacialHair:
       limit: 1


### PR DESCRIPTION
the point limit for human hair accidentally got set back to 1! oops! I set it back to 2

**Changelog**
:cl:
- fix: humans can select 2 different hair markings again