### PR TITLE
fix: felinid overlay marking layering

### DIFF
--- a/Resources/Prototypes/_DV/Body/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Body/Species/felinid.yml
@@ -71,13 +71,9 @@
     - map: [ "enum.HumanoidVisualLayers.RLeg" ]
     - map: [ "enum.HumanoidVisualLayers.LLeg" ]
 
-    # starcup: moved underneath clothes
-    - map: [ "enum.HumanoidVisualLayers.Overlay" ]
-
     # Underwear & clothing
     - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-    - map: [ "jumpsuit" ]
 
     # Extremities
     - map: [ "enum.HumanoidVisualLayers.LFoot" ]
@@ -85,7 +81,11 @@
     - map: [ "enum.HumanoidVisualLayers.LHand" ]
     - map: [ "enum.HumanoidVisualLayers.RHand" ]
 
+    # Stuff that goes over the body but below equipment
+    - map: [ "enum.HumanoidVisualLayers.Overlay" ]
+
     # More equipment
+    - map: [ "jumpsuit" ] # starcup: moved above feet, hands, and overlay
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     - map: [ "ears" ]


### PR DESCRIPTION
overlay markings got changed to render above jumpsuits, which caused the "points" and "patches" markings for felinids to render above their outfits. this moves jumpsuits above the overlay layer for felinids and fixes that

**Changelog**
:cl:
- fix: felinid overlay markings no longer render above jumpsuits