### PR TITLE
fix: moths can eat fruit again

### DIFF
--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -319,6 +319,7 @@
       - ClothMade
       - Paper
       - Pill
+      - Fruit # starcup: let moths eat fruit
 
 - type: entity
   parent: [ OrganBaseLiver, OrganSpriteHumanInternal, OrganMothInternal, OrganAnimalMetabolizer ]


### PR DESCRIPTION
when doing #685 I forgot to add the fruit tag to the whitelists on the new doptera stomach prototype!

**Changelog**
:cl:
- fix: moths can eat fruit again