### PR TITLE
tweak: greatly reduce chance for sleeper agents

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -603,7 +603,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 8
+    weight: 1 # starcup: reduced from 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception


### PR DESCRIPTION
reduces the weight for the sleeper agent event from 8 to 1. see below for an idea of how this changes probability odds

## Why / Balance
first off: with starcup's much longer roundtimes, sleeper agents are currently a guaranteed spawn every single danger shift that has the population count for it. here's the results of running `stationevent:simulate` for 100 rounds with our danger event scheduler, with 20 players and a round length of 200 minutes (3.33 hours):
<details>
<summary><b>simulation before changes</b></summary>
GameRuleSpaceDustMinorStarcup: 749<br>
GameRuleSpaceDustMajorStarcup: 371<br>
GameRuleMeteorSwarmSmall: 271<br>
AnomalySpawn: 161<br>
SolarFlare: 149<br>
IonStorm: 149<br>
BluespaceArtifact: 143<br>
<b>SleeperAgents: 131</b><br>
MassHallucinations: 125<br>
GasLeak: 125<br>
BreakerFlip: 120<br>
SnailMigrationLowPop: 116<br>
CockroachMigration: 109<br>
PowerGridCheck: 101<br>
KudzuGrowth: 97<br>
DragonSpawn: 96<br>
SlimesSpawnLocalized: 93<br>
RandomSentience: 92<br>
MouseMigration: 92<br>
ClosetSkeleton: 90<br>
SnakeSpawnLocalized: 84<br>
ParadoxCloneSpawn: 82<br>
SpiderSpawnLocalized: 82<br>
VentClog: 80<br>
BluespaceLocker: 68<br>
MothroachSpawn: 68<br>
SpiderClownSpawnLocalized: 30<br>
DerelictJanitorCyborgSpawn: 17<br>
DerelictMedicalCyborgSpawn: 17<br>
DerelictMiningCyborgSpawn: 17<br>
GiftsPizzaPartySmall: 12<br>
DerelictEngineerCyborgSpawn: 10<br>
GiftsEngineering: 10<br>
DerelictGenericCyborgSpawn: 10<br>
DerelictSyndicateAssaultCyborgSpawn: 7
</details>

setting aside that I'm not really sure how sleepers are being run more than 100 times across 100 rounds when they can only occur once per round, the fact that they're in the top 10 of all events being run feels erroneous in and of itself.

as for the more direction-y side of things, unlike all of the other antag events on the table which have to be filled in by a ghost role before taking effect and don't have any immediate bearing on any one player's gameplay, sleeper agents immediately turning someone into a traitor has a big, and more importantly *permanent* effect on roundflow. they also, in many cases we've seen, aren't something the crew is expecting or prepared to handle.

but if sleepers *are* expected every single danger round, then danger rounds just become traitor rounds with greater random event density, which isn't in line with the initial vision established for them. danger rounds should be mostly cooperative station-vs-environment games with *occasional* bits of internal threats thrown in with sleepers and paradox clones.

by the way, this is another simulation run after the above change in event weight:

<details>
<summary><b>simulation after changes</b></summary>
GameRuleSpaceDustMinorStarcup: 651<br>
GameRuleSpaceDustMajorStarcup: 354<br>
GameRuleMeteorSwarmSmall: 302<br>
AnomalySpawn: 158<br>
BluespaceArtifact: 145<br>
IonStorm: 134<br>
GasLeak: 133<br>
SolarFlare: 130<br>
MassHallucinations: 124<br>
BreakerFlip: 110<br>
KudzuGrowth: 109<br>
CockroachMigration: 104<br>
MouseMigration: 102<br>
PowerGridCheck: 93<br>
RandomSentience: 89<br>
SnailMigrationLowPop: 86<br>
ClosetSkeleton: 79<br>
VentClog: 79<br>
SlimesSpawnLocalized: 75<br>
SnakeSpawnLocalized: 67<br>
DragonSpawn: 66<br>
ParadoxCloneSpawn: 64<br>
SpiderSpawnLocalized: 64<br>
BluespaceLocker: 57<br>
MothroachSpawn: 54<br>
SpiderClownSpawnLocalized: 22<br>
<b>SleeperAgents: 21</b><br>
DerelictMedicalCyborgSpawn: 15<br>
DerelictGenericCyborgSpawn: 13<br>
DerelictEngineerCyborgSpawn: 12<br>
DerelictJanitorCyborgSpawn: 9<br>
GiftsEngineering: 7<br>
DerelictMiningCyborgSpawn: 5<br>
GiftsPizzaPartySmall: 2<br>
</details>

this is a pretty drastic hit, bringing the chance for the event down by a factor of about 85%, but I think I'd rather see things start out very rare and bring it back up if it ends up being missed.

**Changelog**
:cl:
- tweak: sleeper agents are now much more rare