### PR TITLE
fix: decaf coffee and imitation hot chocolate are safe for creatures

### DIFF
--- a/Resources/Prototypes/_starcup/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_starcup/Reagents/Consumable/Drink/drinks.yml
@@ -9,6 +9,7 @@
   recognizable: true
   metabolisms:
     Digestion:
+      metabolites: null
       effects:
       - !type:SatiateThirst
         factor: 2
@@ -26,6 +27,7 @@
   desc: reagent-desc-hot-cocoa-imitation
   metabolisms:
     Digestion:
+      metabolites: null
       effects:
       - !type:SatiateThirst
         factor: 2


### PR DESCRIPTION
Decaf coffee and imitation hot chocolate no longer inherit respective caffeine and theobromine metabolites from their parents. This issue was caused by upstream metabolism changes and refactors.

## Technical details
Adds a null metabolites field to the two reagents.

**Changelog**
:cl:
- fix: Decaf coffee and imitation hot cocoa are again safe for sensitive species.
