### PR TITLE
fix: felinids are poisoned by caffeine

### DIFF
--- a/Resources/Prototypes/_DV/Body/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Body/Species/felinid.yml
@@ -47,9 +47,9 @@
       Appendix: OrganHumanAppendix
       Ears: OrganHumanEars
       Lungs: OrganHumanLungs
-      Heart: OrganHumanHeart
+      Heart: OrganAnimalHeart # starcup
       Stomach: OrganAnimalStomach # starcup
-      Liver: OrganHumanLiver
+      Liver: OrganAnimalLiver # starcup
       Kidneys: OrganHumanKidneys
   - type: HumanoidProfile
     species: Felinid


### PR DESCRIPTION
In my testing for #736, I noticed felinids weren't poisoned by caffeine as rodentia and other sensitive species are. In the future, it will likely be better to organize custom species organs more closely to upstream's organization, where distinct organs exist for species even if vulpkanin's are indistinguishable from generic animal organs. That might just be vulpkanins being a special case, though. I'd need to look into it more; in either case this is a sufficient temporary fix.

## Why / Balance
Expected behaviour.

## Technical details
Caffeine is metabolized by the heart, but felinids had human hearts. Kidneys were changed too to match rodentia's organs.

**Changelog**
:cl:
- fix: Felinids are poisoned by caffeine, as they are meant to be.