### PR TITLE
feat: uncloneable trait

### DIFF
--- a/Content.Server/Cloning/CloningPodSystem.cs
+++ b/Content.Server/Cloning/CloningPodSystem.cs
@@ -31,6 +31,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared._starcup.Traits; // starcup
 
 namespace Content.Server.Cloning;
 
@@ -164,6 +165,11 @@ public sealed class CloningPodSystem : EntitySystem
 
         if (HasComp<SiliconComponent>(bodyToClone))
             return false; // Goobstation: Don't clone IPCs.
+
+        // begin starcup: uncloneable component
+        if (HasComp<UncloneableComponent>(bodyToClone))
+            return false;
+        // end starcup
 
         var cloningCost = (int)Math.Round(physics.FixturesMass);
 

--- a/Content.Shared/_starcup/Traits/UncloneableComponent.cs
+++ b/Content.Shared/_starcup/Traits/UncloneableComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._starcup.Traits;
+
+/// <summary>
+/// Used for characters who cannot be cloned, but can be revived through other means.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class UncloneableComponent : Component;

--- a/Resources/Locale/en-US/_starcup/traits/traits.ftl
+++ b/Resources/Locale/en-US/_starcup/traits/traits.ftl
@@ -18,3 +18,6 @@ trait-pottymouth-desc = You're quite above improper language, sometimes even pro
 
 trait-vowed-name = Vow of Silence
 trait-vowed-desc = You're serious about your vow, and uphold it outside of jobs that require one.
+
+trait-uncloneable-name = Uncloneable
+trait-uncloneable-desc = Due to some quirk in your physical composition, you cannot be reconstituted by medical cloning.

--- a/Resources/Prototypes/_EE/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_EE/Body/Species/ipc.yml
@@ -259,6 +259,7 @@
   - type: CombatMode # DeltaV - let IPCs disarm
     canDisarm: true
   - type: Fingerprint # starcup: give ipcs fingerprints
+  - type: Uncloneable # starcup
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/_starcup/Traits/disabilities.yml
+++ b/Resources/Prototypes/_starcup/Traits/disabilities.yml
@@ -1,0 +1,9 @@
+- type: trait
+  id: Uncloneable
+  name: trait-uncloneable-name
+  description: trait-uncloneable-desc
+  category: Disabilities
+  excludedSpecies:
+  - IPC
+  components:
+  - type: Uncloneable


### PR DESCRIPTION
adds a trait that grants the new "uncloneable" component, preventing players from being cloned!

## Why / Balance
requested by players for some time for roleplaying/character background reasons, and also atomized out from the [mkc rework](https://github.com/teamstarcup/starcup/pull/724) since this can just be put on the base mkc prototype to keep them from being cloneable

## Technical details
simple addition of a new trait that grants the component and a single check in cloning pod logic that returns a failure if it detects the component

**Changelog**
:cl:
- add: new trait: uncloneable, which prevents medical cloning pods from working on your character