### PR TITLE
tweak: reset digestion transfer efficacy to default value

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerComponent.cs
+++ b/Content.Shared/Metabolism/MetabolizerComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class MetabolizerComponent : Component
             SolutionName = "stomach",
             SolutionOnBody = false,
             TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
-            TransferEfficacy = 0.5
+            // TransferEfficacy = 0.5 // starcup: reset to default value
         },
         ["Bloodstream"] = new()
         {


### PR DESCRIPTION
removes the line that sets the transfer efficacy of digestion to 0.5, resetting it back to the default value

## Why / Balance
https://github.com/space-wizards/space-station-14/pull/41360 replaced metabolism groups with metabolism stages, but in doing this they gave the "digestion" stage (handling anything that goes through the stomach) a transfer efficacy of 0.5, meaning only half of its actual contents get put into the bloodstream.

this had a number of knock-on effects, most prominently severely reducing the effectiveness of pills at delivering reagents into the bloodstream. this in turn severely impacted those with the chronic pain trait, making keeping up with the much lower rate of medicine very difficult.

since the reason for this change was not documented anywhere I could find, and since this has generally created more problems in the game than it's solved, it's likely best to revert it to previously expected behavior until an explanation comes forth.

**Changelog**
:cl:
- tweak: pills no longer transfer their contents at half the expected rate
- fix: those with chronic pain should no longer have less effective medicine than before
