### PR TITLE
fix: repeatable rummaging

### DIFF
--- a/Content.Shared/RatKing/Systems/RummagerSystem.cs
+++ b/Content.Shared/RatKing/Systems/RummagerSystem.cs
@@ -72,7 +72,7 @@ public sealed class RummagerSystem : EntitySystem
         ent.Comp.LastLooted = time;
         // End DeltaV change
 
-        // ent.Comp.Looted = true;  # starcup: removed to enable repeatable rummaging
+        // ent.Comp.Looted = true;  // starcup: removed to enable repeatable rummaging
         Dirty(ent, ent.Comp);
         _audio.PlayPredicted(ent.Comp.Sound, ent, args.User);
 


### PR DESCRIPTION
Rummaging will no longer set the target's Looted variable to True. This was bypassing the intended ability cooldown and preventing any future attempts at rummaging through the same entity.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
Entities with the RummagerComponent are intended to be able to rummage through entities with the RummageableComponent once every five minutes, but an unintended line of code in the RummagerSystem was _also_ toggling a variable that prevents all future rummage attempts. This PR simply comments out that code, re-enabling repeatable rummaging as intended.

## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
When the rummage doafter finishes, RummageableComponent writes the current in-game time to the LastLooted variable and prevents further attempts to rummage through that entity until a length of time set by the RummageCooldown variable has passed. RummageableComponent _also_ has a boolean variable, Looted, which if set to True will prevent rummage attempts on that entity. This variable is intended to be a tool for mappers and admins to use to turn off rummaging for specific entities. However, RummagerSystem had code that was toggling the Looted variable to True after the rummage doafter finished - this prevented all future rummaging attempts for that entity even after the RummageCooldown period had lapsed, as the code didn't account for a way to set Looted back to False. 

LastLooted and RummageCooldown are already used to check whether an entity can be rummaged independently of the Looted variable - as such, there's no reason the rummage doafter event should ever interact with the Looted variable at all. The PR simply comments out the two lines which set Looted to True, which fixes the issue - I've tested this in a local server and can confirm that it works.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Rodentia can rummage through the same disposal unit multiple times per shift again