### PR TITLE
fix: fixes footprints spawning rotated incorrectly

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/_starcup/Entities/Effects/puddle.yml
@@ -8,7 +8,7 @@
   components:
   - type: Clickable
   - type: Transform
-    noRot: false
+    noRot: true
     anchored: true
   - type: Sprite
     drawdepth: FloorObjects


### PR DESCRIPTION
## Why / Balance
bugfix

## Technical details
Engine change caused the footprint entities to be spawned with 0 world rotation instead of 0 grid rotation. See https://github.com/space-wizards/RobustToolbox/commit/3bec89aaa5cca15005fce6b002cf4ac5967bd096

Setting noRot to true causes the entity to always use 0 grid rotation, which is desired on the footprint entity. 

## Media
N/A

**Changelog**
:cl:
- fix: Footprints should now point the correct direction again
