### PR TITLE
tweak: pet faction tweaks

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/animals.yml
@@ -104,7 +104,7 @@
     baseSprintSpeed : 5.0
   - type: NpcFactionMember
     factions:
-    - PetsNT
+    - Protector # starcup: no more hunting mice
   - type: Sprite
     drawdepth: Mobs
     sprite: _DV/Mobs/Pets/secdog.rsi

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -176,11 +176,9 @@
       interactSuccessSpawn: EffectHearts
       interactSuccessSound:
         path: /Audio/Animals/snake_hiss.ogg
-    # begin starcup: removed, hostiles attacking silvia feels weird when she doesn't fight back and has healing attacks anyways
-    #- type: NpcFactionMember
-    #  factions:
-    #    - PetsNT
-    # end starcup
+    - type: NpcFactionMember
+      factions:
+        - Passive # starcup: hostiles attacking silvia feels weird when she doesn't fight back and has healing attacks anyways
     - type: Grammar
       attributes:
         proper: true

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -176,9 +176,11 @@
       interactSuccessSpawn: EffectHearts
       interactSuccessSound:
         path: /Audio/Animals/snake_hiss.ogg
-    - type: NpcFactionMember
-      factions:
-        - PetsNT
+    # begin starcup: removed, hostiles attacking silvia feels weird when she doesn't fight back and has healing attacks anyways
+    #- type: NpcFactionMember
+    #  factions:
+    #    - PetsNT
+    # end starcup
     - type: Grammar
       attributes:
         proper: true

--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/pets.yml
@@ -136,6 +136,7 @@
   - type: NpcFactionMember
     factions:
     - BugHunter
+    - MouseHunter
   - type: HTN
     rootTask:
       task: SimpleHostileCompound

--- a/Resources/Prototypes/_starcup/ai_factions.yml
+++ b/Resources/Prototypes/_starcup/ai_factions.yml
@@ -5,6 +5,23 @@
   id: GiantBug
 
 - type: npcFaction
+  id: PestHunter
+  hostile:
+  - Mouse
+  - Bug
+
+- type: npcFaction
+  id: Protector
+  friendly:
+  - NanoTrasen
+  hostile:
+  - SimpleHostile
+  - Zombie
+  - Xeno
+  - AllHostile
+  - Dragon
+
+- type: npcFaction
   id: BugHunter
   hostile:
   - Bug

--- a/Resources/Prototypes/_starcup/ai_factions.yml
+++ b/Resources/Prototypes/_starcup/ai_factions.yml
@@ -15,6 +15,11 @@
   - GiantBug
 
 - type: npcFaction
+  id: MouseHunter
+  hostile:
+  - Mouse
+
+- type: npcFaction
   id: Bloodsucker # Does not target bugs, xenos or xenoborgs
   hostile:
   - NanoTrasen

--- a/Resources/Prototypes/_starcup/ai_factions.yml
+++ b/Resources/Prototypes/_starcup/ai_factions.yml
@@ -5,12 +5,6 @@
   id: GiantBug
 
 - type: npcFaction
-  id: PestHunter
-  hostile:
-  - Mouse
-  - Bug
-
-- type: npcFaction
   id: Protector
   friendly:
   - NanoTrasen

--- a/Resources/Prototypes/_starcup/ai_factions.yml
+++ b/Resources/Prototypes/_starcup/ai_factions.yml
@@ -5,17 +5,6 @@
   id: GiantBug
 
 - type: npcFaction
-  id: Protector
-  friendly:
-  - NanoTrasen
-  hostile:
-  - SimpleHostile
-  - Zombie
-  - Xeno
-  - AllHostile
-  - Dragon
-
-- type: npcFaction
   id: BugHunter
   hostile:
   - Bug
@@ -36,3 +25,14 @@
   - Dragon
   - SimpleNeutral
   - Wizard
+
+- type: npcFaction
+  id: Protector
+  friendly:
+  - NanoTrasen
+  hostile:
+  - SimpleHostile
+  - Zombie
+  - Xeno
+  - AllHostile
+  - Dragon

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -11,6 +11,7 @@
   - Wizard
   - Xenoborg
   - SimpleHostile # starcup: carp did not defend themselves from hostile spawns
+  - Protector # starcup
 
 - type: npcFaction
   id: NanoTrasen
@@ -61,6 +62,7 @@
   - AllHostile
   - Wizard
   - Xenoborg
+  - Protector # starcup
 
 - type: npcFaction
   id: SimpleNeutral
@@ -77,6 +79,7 @@
   - AllHostile
   - Wizard
   - Xenoborg
+  - Protector # starcup
 
 - type: npcFaction
   id: Xeno
@@ -91,6 +94,7 @@
   - Wizard
   - Dragon
   - Xenoborg
+  - Protector # starcup
 
 - type: npcFaction
   id: Zombie
@@ -106,6 +110,7 @@
   - Wizard
   - Dragon
   - Xenoborg
+  - Protector # starcup
 
 - type: npcFaction
   id: Revolutionary
@@ -135,6 +140,7 @@
   - Wizard
   - Xenoborg
   - Bug # starcup
+  - Protector # starcup
 
 - type: npcFaction
   id: Wizard
@@ -152,6 +158,7 @@
   - Revolutionary
   - AllHostile
   - Xenoborg
+  - Protector # starcup
 
 - type: npcFaction
   id: Xenoborg


### PR DESCRIPTION
* adds a new `Protector` faction that's basically just `PetsNT` but not hostile to mice, and gives this faction to laika
* gives silvia the Passive faction, making mobs no longer hostile against her by default
* adds a `MouseHunter` faction that's just hostile against mice, and gives it to henrietta

## Why / Balance

- laika's new role as a psychology pet makes it a bit jarring to see her mercilessly hunting down harmless pests!
- as for silvia, current faction interactions would mean that hostile mobs (spiders, fellow cobras, etc) will kill her without her doing anything at all to retaliate, which doesn't seem super desirable!
- @shirigaruonna tells me that henrietta was originally supposed to hunt mice and such in addition to roaches, so this lets her do that!

**Changelog**
:cl:
- tweak: laika will no longer hunt down mice
- tweak: since silvia does not automatically attack hostile mobs, they will no longer automatically attack her
- tweak: henrietta's dedication to ridding the station of wretched pests now extends to mice