### PR TITLE
feat: emotes for mmis, posibrains, and the ai

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -530,6 +530,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         ClearEye(ent);
         ent.Comp.Remote = true;
+        EnsureComp<InputMoverComponent>(args.Entity); // starcup change, ensures AI has the InputMover component upon insertion so they can ghost using the move keys if their core is damaged.
 
         if (SetupEye(ent))
             AttachEye(ent);
@@ -547,6 +548,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         // Remove eye relay
         RemCompDeferred<RelayInputMoverComponent>(args.Entity);
+        RemCompDeferred<InputMoverComponent>(args.Entity); // starcup change, ensures carded AI does not have the InputMover component, as this throws an assert and crashes the server.
 
         if (TryComp(args.Entity, out EyeComponent? eyeComp))
         {

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -530,7 +530,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         ClearEye(ent);
         ent.Comp.Remote = true;
-        EnsureComp<InputMoverComponent>(args.Entity); // starcup change, ensures AI has the InputMover component upon insertion so they can ghost using the move keys if their core is damaged.
+        EnsureComp<InputMoverComponent>(args.Entity); // starcup - ensures AI has the InputMover component upon insertion so they can ghost using the move keys if their core is damaged.
 
         if (SetupEye(ent))
             AttachEye(ent);
@@ -548,7 +548,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         // Remove eye relay
         RemCompDeferred<RelayInputMoverComponent>(args.Entity);
-        RemCompDeferred<InputMoverComponent>(args.Entity); // starcup change, ensures carded AI does not have the InputMover component, as this throws an assert and crashes the server.
+        RemCompDeferred<InputMoverComponent>(args.Entity); // starcup - ensures carded AI does not have the InputMover component, as this throws an assert and crashes the server.
 
         if (TryComp(args.Entity, out EyeComponent? eyeComp))
         {

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -457,7 +457,7 @@
     - HideContextMenu
     - StationAi
     - NoConsoleSound
-    - SiliconEmotes # starcup change - Allows use of borg emotes
+    - SiliconEmotes # starcup - Allows use of borg emotes
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -457,6 +457,7 @@
     - HideContextMenu
     - StationAi
     - NoConsoleSound
+    - SiliconEmotes # starcup change - Allows use of borg emotes
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -39,7 +39,7 @@
     proto: robot
   - type: Speech
     speechSounds: Pai
-    # start starcup change - Allows use of borg emotes
+    # begin starcup - Allows use of borg emotes
   - type: Tag
     tags:
     - SiliconEmotes
@@ -47,7 +47,7 @@
   - type: Vocal
     sounds:
       Unsexed: UnisexSilicon
-    # end starcup change
+    # end starcup
   - type: ItemSlots
   - type: ContainerContainer
     containers:
@@ -119,12 +119,12 @@
       group: PositronicBrain
     - type: DoAfter
     - type: Actions
-    # start starcup change - Allows use of borg emotes
+    # begin starcup - Allows use of borg emotes
     - type: Emoting
     - type: Vocal
       sounds:
         Unsexed: UnisexSilicon
-    # end starcup change
+    # end starcup
     - type: TypingIndicator
       proto: robot
     - type: Speech

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -39,6 +39,15 @@
     proto: robot
   - type: Speech
     speechSounds: Pai
+    # start starcup change - Allows use of borg emotes
+  - type: Tag
+    tags:
+    - SiliconEmotes
+  - type: Emoting
+  - type: Vocal
+    sounds:
+      Unsexed: UnisexSilicon
+    # end starcup change
   - type: ItemSlots
   - type: ContainerContainer
     containers:
@@ -110,6 +119,12 @@
       group: PositronicBrain
     - type: DoAfter
     - type: Actions
+    # start starcup change - Allows use of borg emotes
+    - type: Emoting
+    - type: Vocal
+      sounds:
+        Unsexed: UnisexSilicon
+    # end starcup change
     - type: TypingIndicator
       proto: robot
     - type: Speech
@@ -123,6 +138,7 @@
     - type: Tag
       tags:
       - CannotSuicide
+      - SiliconEmotes # starcup - Allows use of borg emotes
     - type: GenericVisualizer
       visuals:
         enum.ToggleableGhostRoleVisuals.Status:


### PR DESCRIPTION

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
if pAIs can emote, there's no reason that other chassis-less silicons can't. listed as a todo on the discord.

## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
a few yaml changes, and two lines of code in SharedStationAiSystem to ensure the InputMover component doesn't transfer to intellicards, as for whatever reason this causes a server crash when emote capabilities are added.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

https://github.com/user-attachments/assets/bd6fd8d4-1f8d-455c-bc51-4bef7d3bdca2

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: MMIs, positronic brains, and the station AI can now emote, with the same emotes available to them as pAIs.
