### PR TITLE
feat: blood deficiency traits

### DIFF
--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -23,10 +23,10 @@ using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
-// Start starcup/Box Change - For blood deficiency
+// Start Box Change - For blood deficiency
 using Content.Shared._Box.Traits.Assorted; 
 using Content.Shared._Box.Body.Events;
-// End starcup/Box Change
+// End Box Change
 
 namespace Content.Shared.Body.Systems;
 
@@ -59,7 +59,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
         SubscribeLocalEvent<BloodstreamComponent, ApplyMetabolicMultiplierEvent>(OnApplyMetabolicMultiplier);
         SubscribeLocalEvent<BloodstreamComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<BloodstreamComponent, MetabolismExclusionEvent>(OnMetabolismExclusion);
-        SubscribeLocalEvent<BloodDeficiencyComponent, NaturalBloodRegenerationEvent>(OnNaturalBloodRegeneration); // starcup/Box Change: Event subscription for blood deficiency
+        SubscribeLocalEvent<BloodDeficiencyComponent, NaturalBloodRegenerationEvent>(OnNaturalBloodRegeneration); // Box Change: Event subscription for blood deficiency
     }
 
     public override void Update(float frameTime)
@@ -82,12 +82,12 @@ public abstract class SharedBloodstreamSystem : EntitySystem
             // Blood level regulation. Must be alive.
             if (!_mobStateSystem.IsDead(uid))
             {
-                //Start starcup/Box Change - Event for blood deficiency traits
+                //Start Box Change - Event for blood deficiency traits
                 //TryRegulateBloodLevel(uid, bloodstream.BloodRefreshAmount);
                 var ev = new NaturalBloodRegenerationEvent(bloodstream.BloodRefreshAmount, 1.0f); //Raise event before natural blood regen tick, for anything that might want to modify it
                 RaiseLocalEvent(uid, ref ev);
-                TryRegulateBloodLevel(uid, ev.BloodRefreshAmount, ev.BloodReferenceLevel);
-                //End starcup/Box Change
+                TryRegulateBloodLevel(uid, ev.BloodRefreshAmount, ev.BloodReferenceFactor);
+                //End Box Change
 
                 TickBleed((uid, bloodstream));
 
@@ -301,7 +301,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
         }
     }
 
-    // Start starcup/Box Change: Blood deficiency value modifications
+    // Start Box Change: Blood deficiency value modifications
     /// <summary>
     /// Modify blood regen amount for blood deficiency traits
     /// </summary>
@@ -309,16 +309,16 @@ public abstract class SharedBloodstreamSystem : EntitySystem
     /// <param name="args">Event to modify.</param>
     private void OnNaturalBloodRegeneration(Entity<BloodDeficiencyComponent> ent, ref NaturalBloodRegenerationEvent args)
     {
-        if (ent.Comp.BloodRegenAmount != 1.0f) // Don't mess with the input values unless the comp has been changed from default settings
+        if (ent.Comp.BloodRefreshAmount != 1.0f) // Don't mess with the input values unless the comp has been changed from default settings
         {
-            args.BloodRefreshAmount = ent.Comp.BloodRegenAmount;
+            args.BloodRefreshAmount = ent.Comp.BloodRefreshAmount;
         }
-        if (ent.Comp.BloodLevelTarget != 1.0f)
+        if (ent.Comp.BloodReferenceFactor != 1.0f)
         {
-            args.BloodReferenceLevel = ent.Comp.BloodLevelTarget;
+            args.BloodReferenceFactor = ent.Comp.BloodReferenceFactor;
         }
     }
-    //End starcup/Box Changes
+    //End Box Changes
 
     /// <summary>
     /// This returns the minimum amount of *usable* blood.

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -23,6 +23,10 @@ using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+// Start starcup/Box Change - For blood deficiency
+using Content.Shared._Box.Traits.Assorted; 
+using Content.Shared._Box.Body.Events;
+// End starcup/Box Change
 
 namespace Content.Shared.Body.Systems;
 
@@ -55,6 +59,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
         SubscribeLocalEvent<BloodstreamComponent, ApplyMetabolicMultiplierEvent>(OnApplyMetabolicMultiplier);
         SubscribeLocalEvent<BloodstreamComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<BloodstreamComponent, MetabolismExclusionEvent>(OnMetabolismExclusion);
+        SubscribeLocalEvent<BloodDeficiencyComponent, NaturalBloodRegenerationEvent>(OnNaturalBloodRegeneration); // starcup/Box Change: Event subscription for blood deficiency
     }
 
     public override void Update(float frameTime)
@@ -77,7 +82,12 @@ public abstract class SharedBloodstreamSystem : EntitySystem
             // Blood level regulation. Must be alive.
             if (!_mobStateSystem.IsDead(uid))
             {
-                TryRegulateBloodLevel(uid, bloodstream.BloodRefreshAmount);
+                //Start starcup/Box Change - Event for blood deficiency traits
+                //TryRegulateBloodLevel(uid, bloodstream.BloodRefreshAmount);
+                var ev = new NaturalBloodRegenerationEvent(bloodstream.BloodRefreshAmount, 1.0f); //Raise event before natural blood regen tick, for anything that might want to modify it
+                RaiseLocalEvent(uid, ref ev);
+                TryRegulateBloodLevel(uid, ev.BloodRefreshAmount, ev.BloodReferenceLevel);
+                //End starcup/Box Change
 
                 TickBleed((uid, bloodstream));
 
@@ -290,6 +300,25 @@ public abstract class SharedBloodstreamSystem : EntitySystem
             args.Reagents.Add(reagent);
         }
     }
+
+    // Start starcup/Box Change: Blood deficiency value modifications
+    /// <summary>
+    /// Modify blood regen amount for blood deficiency traits
+    /// </summary>
+    /// <param name="ent">Component to reference.</param>
+    /// <param name="args">Event to modify.</param>
+    private void OnNaturalBloodRegeneration(Entity<BloodDeficiencyComponent> ent, ref NaturalBloodRegenerationEvent args)
+    {
+        if (ent.Comp.BloodRegenAmount != 1.0f) // Don't mess with the input values unless the comp has been changed from default settings
+        {
+            args.BloodRefreshAmount = ent.Comp.BloodRegenAmount;
+        }
+        if (ent.Comp.BloodLevelTarget != 1.0f)
+        {
+            args.BloodReferenceLevel = ent.Comp.BloodLevelTarget;
+        }
+    }
+    //End starcup/Box Changes
 
     /// <summary>
     /// This returns the minimum amount of *usable* blood.

--- a/Content.Shared/_Box/Body/Events/NaturalBloodRegenerationEvent.cs
+++ b/Content.Shared/_Box/Body/Events/NaturalBloodRegenerationEvent.cs
@@ -6,6 +6,6 @@ namespace Content.Shared._Box.Body.Events;
 /// Raised on an entity before they naturally regenerate blood to modify the amount.
 /// </summary>
 /// <param name="BloodRefreshAmount">The amount of blood the entity will gain or lose.</param>
-/// <param name="BloodReferenceLevel">The target volume of blood in the entities bloodstream, as a multiplier of their max blood capacity..</param>
+/// <param name="BloodReferenceFactor">The target volume of blood in the entities bloodstream, as a multiplier of their max blood capacity..</param>
 [ByRefEvent]
-public record struct NaturalBloodRegenerationEvent(FixedPoint2 BloodRefreshAmount, float BloodReferenceLevel);
+public record struct NaturalBloodRegenerationEvent(FixedPoint2 BloodRefreshAmount, float BloodReferenceFactor);

--- a/Content.Shared/_Box/Body/Events/NaturalBloodRegenerationEvent.cs
+++ b/Content.Shared/_Box/Body/Events/NaturalBloodRegenerationEvent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._Box.Body.Events;
+
+/// <summary>
+/// Raised on an entity before they naturally regenerate blood to modify the amount.
+/// </summary>
+/// <param name="BloodRefreshAmount">The amount of blood the entity will gain or lose.</param>
+/// <param name="BloodReferenceLevel">The target volume of blood in the entities bloodstream, as a multiplier of their max blood capacity..</param>
+[ByRefEvent]
+public record struct NaturalBloodRegenerationEvent(FixedPoint2 BloodRefreshAmount, float BloodReferenceLevel);

--- a/Content.Shared/_Box/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/_Box/Traits/BloodDeficiencyComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+using Content.Shared.Body.Systems;
+
+namespace Content.Shared._Box.Traits.Assorted;
+
+/// <summary>
+/// Used for the blood deficiency trait. BloodstreamSystem will check for this component and modify blood regen amount accordingly.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedBloodstreamSystem))]
+public sealed partial class BloodDeficiencyComponent : Component
+{
+    [DataField("bloodRegenAmount"), ViewVariables(VVAccess.ReadWrite)]
+    public float BloodRegenAmount = 1f;
+    [DataField("bloodLevelTarget"), ViewVariables(VVAccess.ReadWrite)]
+    public float BloodLevelTarget = 1f;
+}

--- a/Content.Shared/_Box/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Shared/_Box/Traits/BloodDeficiencyComponent.cs
@@ -10,8 +10,19 @@ namespace Content.Shared._Box.Traits.Assorted;
 [Access(typeof(SharedBloodstreamSystem))]
 public sealed partial class BloodDeficiencyComponent : Component
 {
-    [DataField("bloodRegenAmount"), ViewVariables(VVAccess.ReadWrite)]
-    public float BloodRegenAmount = 1f;
-    [DataField("bloodLevelTarget"), ViewVariables(VVAccess.ReadWrite)]
-    public float BloodLevelTarget = 1f;
+    /// <summary>
+    /// The maximum amount of blood, in units, we are allowed to add or remove per update. This should generally be positive; negative numbers will do nothing.
+    /// In the case of the blood deficiency trait, this is set to 0.08f, as this is the amount of blood we want to modify the moob's blood volume by per update.
+    /// In the case of the minor blood deficiency trait, this is set to 0f, completely halting natural blood regeneration.
+    /// </summary>
+    [DataField("bloodRefreshAmount"), ViewVariables(VVAccess.ReadWrite)]
+    public float BloodRefreshAmount = 1f;
+
+    /// <summary>
+    /// The volume of blood that natural regeneration will aim for, expressed as a multiplier of the mob's maximum blood volume.
+    /// For most humanoid mobs, the maximum volume is 300u; A value of 0.5 means that every 3 seconds, natural blood regeneration will attempt to add or remove up to {BloodRefreshAmount}u of reagent until the mob's bloodstream reaches 150u.
+    /// In the case of the blood defiiciency trait, this is set to 0f, so that natural blood regeneration will always tick downwards towards 0u.
+    /// </summary>
+    [DataField("bloodReferenceFactor"), ViewVariables(VVAccess.ReadWrite)]
+    public float BloodReferenceFactor = 1f;
 }

--- a/Resources/Locale/en-US/_Box/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Box/traits/traits.ftl
@@ -4,5 +4,5 @@ trait-blood-deficiency-name = Blood Deficiency
 trait-blood-deficiency-desc = Your body loses more blood than it can produce. After about 18 minutes you will start taking damage from bloodloss, and will eventually die without medical intervention.
 
 trait-blood-deficiency-minor-name = Minor Blood Deficiency
-trait-blood-deficiency-minor-desc = Your body does not naturally restore its own blood level. You will require medical treatment to recover from bloodloss. Has no effect on MKCs. 
-# starcup change - MKCs, not IPCs
+trait-blood-deficiency-minor-desc = Your body does not naturally restore its own blood level. You will require medical treatment to recover from bloodloss.
+# starcup - Removed mention of IPCs, as the trait isn't selectable for MKCs.

--- a/Resources/Locale/en-US/_Box/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Box/traits/traits.ftl
@@ -1,0 +1,8 @@
+trait-category-blood-deficiency = Blood Deficiency
+
+trait-blood-deficiency-name = Blood Deficiency
+trait-blood-deficiency-desc = Your body loses more blood than it can produce. After about 18 minutes you will start taking damage from bloodloss, and will eventually die without medical intervention.
+
+trait-blood-deficiency-minor-name = Minor Blood Deficiency
+trait-blood-deficiency-minor-desc = Your body does not naturally restore its own blood level. You will require medical treatment to recover from bloodloss. Has no effect on MKCs. 
+# starcup change - MKCs, not IPCs

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -54,6 +54,7 @@
   - SouthernAccent
   - SpanishAccent
   - StutteringAccent
+  - BloodDeficiency # starcup/Box Change - For blood deficiency traits
 
 # for job-specific traits etc.
 - type: cloningSettings

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -54,7 +54,7 @@
   - SouthernAccent
   - SpanishAccent
   - StutteringAccent
-  - BloodDeficiency # starcup/Box Change - For blood deficiency traits
+  - BloodDeficiency # Box Change - For blood deficiency traits
 
 # for job-specific traits etc.
 - type: cloningSettings

--- a/Resources/Prototypes/_Box/Traits/categories.yml
+++ b/Resources/Prototypes/_Box/Traits/categories.yml
@@ -1,0 +1,4 @@
+- type: traitCategory
+  id: BloodDeficiency
+  name: trait-category-blood-deficiency
+  maxTraitPoints: 1

--- a/Resources/Prototypes/_Box/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Box/Traits/disabilities.yml
@@ -8,8 +8,8 @@
   cost: 1
   components:
     - type: BloodDeficiency
-      bloodRegenAmount: 0.08
-      bloodLevelTarget: 0
+      bloodRefreshAmount: 0.08
+      bloodReferenceFactor: 0
       
 - type: trait
   id: BloodDeficiencyMinor
@@ -19,5 +19,9 @@
   cost: 1
   components:
     - type: BloodDeficiency
-      bloodRegenAmount: 0
-      bloodLevelTarget: 1
+      bloodRefreshAmount: 0
+      bloodReferenceFactor: 1
+  # begin starcup - exclude MKCs
+  excludedSpecies:
+  - MKC
+  # end starcup

--- a/Resources/Prototypes/_Box/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Box/Traits/disabilities.yml
@@ -1,0 +1,23 @@
+# If you add a new trait, make sure to add the corresponding component to the whitelist in \Resources\Prototypes\Entities\Mobs\Player\clone.yml so it gets copied to clones correctly!
+
+- type: trait
+  id: BloodDeficiency
+  name: trait-blood-deficiency-name
+  description: trait-blood-deficiency-desc
+  category: BloodDeficiency
+  cost: 1
+  components:
+    - type: BloodDeficiency
+      bloodRegenAmount: 0.08
+      bloodLevelTarget: 0
+      
+- type: trait
+  id: BloodDeficiencyMinor
+  name: trait-blood-deficiency-minor-name
+  description: trait-blood-deficiency-minor-desc
+  category: BloodDeficiency
+  cost: 1
+  components:
+    - type: BloodDeficiency
+      bloodRegenAmount: 0
+      bloodLevelTarget: 1


### PR DESCRIPTION
adds two traits that affect a character's natural blood regeneration, inspired by the Einstein Engines & SS13 traits of the same name. originally developed for boxstation @ ss14-boxstation/ss14-boxstation/pull/128

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
i've been enjoying the trait on another server; i think the mechanical changes and roleplay opportunities it provides allow for some interesting character expression.
## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
before TryRegulateBloodLevel is called to perform natural blood regeneration, an event is raised. the component added by these traits subscribes to that event and modifies its values, which are then fed into the TryRegulateBloodLevel call instead of the values read from the entity's prototype. if either of the component's values are default, the corresponding event value will not be changed, to avoid issues with entities that may have different blood refresh amounts than humans.

since the modification of blood regen amount is handled via an event, it could potentially be used for other mechanics in the future, if applicable.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->
<img width="1489" height="116" alt="SS14 Loader_J12KnK5LSC" src="https://github.com/user-attachments/assets/c49c1616-8cd0-4da4-b841-d03097d7d94c" />
<img width="1338" height="123" alt="SS14 Loader_IUD5ixyn9H" src="https://github.com/user-attachments/assets/a1bb6450-5be5-4e87-8fc3-0899f5d3fb35" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added traits for blood deficiency, which cause your character to either not regenerate or actively lose blood.
