### PR TITLE
tweak: double trinket limit from 3 to 6

### DIFF
--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -15,7 +15,7 @@
   id: Trinkets
   name: loadout-group-trinkets
   minLimit: 0
-  maxLimit: 3
+  maxLimit: 6 # starcup: increased to 6 from 3
   loadouts:
   - FlowerWreath
   - Hairflower


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
three trinkets just feels slightly too limiting to me. i believe a limit _is_ necessary, i don't think people should be spawning with 20 plushies on the ground, but so long as the trinkets category is kept to its intended purpose—small trinkets with little to no mechanical function—i personally don't see an issue with raising it a bit to allow for more customization.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Trinket limit has been doubled to 6, from 3.
