### PR TITLE
fix: rodentia can be forced to empty their cheek storage 

### DIFF
--- a/Content.Shared/_DV/Rodentia/SharedMouthStorageSystem.cs
+++ b/Content.Shared/_DV/Rodentia/SharedMouthStorageSystem.cs
@@ -12,6 +12,12 @@ using Content.Shared.Throwing;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
+// begin starcup
+using Robust.Shared.Random;
+using System.Linq;
+using Content.Shared.Popups;
+using Robust.Shared.Player;
+// end starcup
 
 namespace Content.Shared._DV.Rodentia;
 
@@ -20,6 +26,11 @@ public abstract class SharedMouthStorageSystem : EntitySystem
     // [Dependency] private readonly DumpableSystem _dumpableSystem = default!;  // starcup: removed for refactor
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    // begin starcup: additions for DropAllContents refactor
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    // end starcup
 
     public override void Initialize()
     {
@@ -60,12 +71,25 @@ public abstract class SharedMouthStorageSystem : EntitySystem
 
     private void DropAllContents<T>(EntityUid uid, MouthStorageComponent component, ref T _)
     {
-        // begin starcup: upstream breaking changes but this so rarely comes up so it's disabled for now
-        if (component.MouthId == null)
-            return;
-
+        // begin starcup: total refactor due to relying on methods missing from wizden
+        //if (component.MouthId == null)
+        //    return;
+        //
         // _dumpableSystem.DumpContents(component.MouthId.Value, uid, uid);
         // end starcup
+        TryComp<StorageComponent>(component.MouthId, out var storage);
+        if (storage != null)
+        {
+            var contained = storage.Container.ContainedEntities.ToArray();
+            var targetPos = _transformSystem.GetWorldPosition(uid);
+            foreach (var ent in contained)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("rodentia-cheek-storage-eject-self"), uid, uid, PopupType.MediumCaution); // For whatever reason PopupClient and PopupPredicted do not work, so we use this instead.
+                _popupSystem.PopupEntity(Loc.GetString("rodentia-cheek-storage-eject-other", ("rat", Identity.Entity(component.Owner, EntityManager))), uid, Filter.PvsExcept(uid), true, PopupType.MediumCaution);
+                var transform = Transform(ent);
+                _transformSystem.SetWorldPositionRotation(ent, targetPos + _random.NextVector2Box() / 4, _random.NextAngle(), transform);
+            }
+        }
     }
 
     private void OnDamageModified(EntityUid uid, MouthStorageComponent component, DamageChangedEvent args)

--- a/Content.Shared/_DV/Rodentia/SharedMouthStorageSystem.cs
+++ b/Content.Shared/_DV/Rodentia/SharedMouthStorageSystem.cs
@@ -37,7 +37,7 @@ public abstract class SharedMouthStorageSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<MouthStorageComponent, MapInitEvent>(OnMouthStorageInit);
-        SubscribeLocalEvent<MouthStorageComponent, KnockedDownEvent>(DropAllContents);
+        SubscribeLocalEvent<MouthStorageComponent, StunnedEvent>(DropAllContents); // starcup: use StunnedEvent instead of KnockedDown event so you don't spit up your items when going prone
         SubscribeLocalEvent<MouthStorageComponent, DisarmedEvent>(DropAllContents);
         SubscribeLocalEvent<MouthStorageComponent, DamageChangedEvent>(OnDamageModified);
         SubscribeLocalEvent<MouthStorageComponent, ExaminedEvent>(OnExamined);

--- a/Resources/Locale/en-US/_starcup/rodentia/rodentia.ftl
+++ b/Resources/Locale/en-US/_starcup/rodentia/rodentia.ftl
@@ -1,0 +1,2 @@
+rodentia-cheek-storage-eject-other = {CAPITALIZE(THE($rat))} spits something out!
+rodentia-cheek-storage-eject-self = You spit out the items in your mouth!

--- a/Resources/ServerInfo/Guidebook/_starcup/Mobs/RodentiaStarcup.xml
+++ b/Resources/ServerInfo/Guidebook/_starcup/Mobs/RodentiaStarcup.xml
@@ -20,7 +20,7 @@
   Rodentia have a toggleable Sneak Mode that allows you to slip underneath tables and counters, which not only lets you easily bypass these obstacles, but also hides you from view.
 
   ### Cheek Storage
-  The cheeks of Rodentia can be used as a small storage compartment that can be accessed at any time. Do note, however, that any attempt at speech while carrying an item in your cheeks will be replaced with unintelligible mumbling!
+  The cheeks of Rodentia can be used as a small storage compartment that can be accessed at any time. Do note, however, that any attempt at speech while carrying an item in your cheeks will be replaced with unintelligible mumbling! Additionaly, if you are stunned, disarmed, or sufficiently damaged, [color=yellow]you will spit out any items[/color] stored in your cheeks.
 
   ### Duffel Critter
   <Box>


### PR DESCRIPTION
Rodentia now will spit out any items in their cheek storage when stunned, disarmed, or hit for enough damage.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
This was originally a part of the cheek storage mechanic, but was dummied out when ported due to missing supporting methods. Without this, cheek storage is functionally a black hole for antag objective items, since security has no way of getting items out of it. 
## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
I've refactored DropAllContents based on the method(s) it originally used, so the functionality should be similar if not identical to its original implementation. I've also added a red warning popup to make it clearer what's happening, and updated the guidebook to explain that this part of the mechanic exists. I also put in a StunnedEvent subscription in place of the original KnockedDownEvent subscription, since that caused Rodentia to spit up their items when going prone, which felt silly.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->

https://github.com/user-attachments/assets/8456cbae-6f08-4b81-9589-c6cfaddb79c2

https://github.com/user-attachments/assets/3da9d54c-38f2-4aff-9bb6-901791ccc070

https://github.com/user-attachments/assets/22159c38-619d-40ad-96c9-ec0073e0a74a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Rodentia will now eject any items in their cheek storage upon being knocked down, disarmed, or hit for enough damage. Your cheese is no longer safe.
