### PR TITLE
tweak: removes landmines from salvage debris

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -418,13 +418,13 @@
       children:
       - id: MobCarpSalvage
         weight: 2
-      - !type:AllSelector
-        weight: 1
-        children:
-        - id: LandMineExplosive
-        - !type:NestedSelector # what's that thing underneath the scrap?
-          prob: 0.33
-          tableId: SalvageScrapSpawnerCommon
+#      - !type:AllSelector # starcup - Salvie insta-kills are annoying. Replace with something more fun later.
+#        weight: 1
+#        children:
+#        - id: LandMineExplosive
+#        - !type:NestedSelector # what's that thing underneath the scrap?
+#          prob: 0.33
+#          tableId: SalvageScrapSpawnerCommon
     - !type:GroupSelector # scary monsters
       weight: 5
       children:


### PR DESCRIPTION
This PR comments landmines out from the SalvageMagnetMobTable.

## Why / Balance
Hidden traps can be a good addition to debris, but instant kills are rarely any fun, especially for Salvagers. A replacement such as tunneled exomorph spawners might be a good idea later on, but concocting replacements felt like something that could be saved for a separate PR.

**Changelog**
:cl:
- remove: Removed salvage debris landmines!