### PR TITLE
map(shoko): add missing directional fans

### DIFF
--- a/Resources/Maps/_starcup/shoukou.yml
+++ b/Resources/Maps/_starcup/shoukou.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/25/2026 05:04:35
-  entityCount: 16776
+  time: 04/16/2026 20:53:32
+  entityCount: 16778
 maps:
 - 1
 grids:
@@ -8377,6 +8377,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -61.5,3.5
+      parent: 2
+  - uid: 13983
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-54.5
+      parent: 2
+  - uid: 13985
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-52.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:


### PR DESCRIPTION
Adds directional fans to the cargo shuttle docks to prevent loss of atmosphere.

**Changelog**
:cl:
- fix: Shoko's cargo bay will no longer space itself.
