### PR TITLE
feat: add new Factions palette for neocorporate pride

### DIFF
--- a/Resources/Prototypes/_starcup/Palettes/factions.yml
+++ b/Resources/Prototypes/_starcup/Palettes/factions.yml
@@ -1,0 +1,33 @@
+- type: palette
+  id: Factions
+  name: Factions
+  colors:
+    "bishop olive": "#323D33C8"
+    "bishop teal": "#3F7E7796"
+    "cybersun dawn": "#CE333896"
+    "cybersun dusk": "#FF8E0096"
+    "cybersun twilight": "#1e0f26C2"
+    "cybersun noon": "#00A7E196" # alternate 83BFB096 from the notebook for a less saturated hue
+    "cybersun green": "#1D580D96" # a green sun. like from homestuck.
+    "donk salmon": "#CC7B78CC"
+    "donk rye": "#A4762296"
+    "electra earth": "#717A5596"
+    "electra sunbeam": "#F7B90096"
+    "electra ocean": "#253E56C8"
+    "gorlex bloodred": "#EA251A96"
+    "gorlex venom": "#25FF0096"
+    "hawkmoon lavender": "#B78EC3CC"
+    "hawkmoon silver": "#C5C6DBCC"
+    "interdyne bone": "#DEDDEDDD"
+    "interdyne verdigris": "#00C1C196"
+    "nanotrasen blue": "#334E6DC8" # just Nano Command
+    "nanotrasen blueblood": "#1a77ea96"
+    "syndicate black": "#282828CC" # just SyndComm Black
+    "syndicate red": "#DE3A3A96" # just Security
+
+# Most colors were taken from branded notebooks, posters, or incoming branded coats.
+# Cybersun Dawn and Cybersun Twilight taken from the pen. Twilight's Value was decreased by 5.
+# Donk Rye taken from the donk pocket flippo
+# Gorlex Venom taken from lit match
+# Hawkmoon Lavender taken from poster concept art not yet implemented.
+# NanoTrasen Blueblood and Gorlex Bloodred taken from the nukie plushies


### PR DESCRIPTION
This PR adds a new palette, Factions, containing the "primary" palettes for all major Syndicate companies, plus NanoTrasen, Bishop Industries, and any others we wish to add later.

Notable exclusions include SELF, FAID, the Acid Enterprise, and most of the smaller companies, simply because we don't have colors or logos for them yet.

These various color choices were assembled by the collective efforts of asterism, Disciple, foxcurl, KoboldCatgirl, Princess Pengy, and Psymbiote, and many others. Many colors were taken from upstream items, of course.

## Why / Balance
This palette is intended to provide standardized, easily-referenced "canon palettes" for the various companies, enabling mappers to more easily reference specific companies and artists to more easily find the colors they're looking for.

This palette is not intended to provide ironclad rules, only guidance on what colors the various corporations _tend_ to use. The United States flag's official blue might be #00205B, but plenty of merch diverges from that hexcode.

The palette file contains ample documentation because I, personally, find tracking down "the right colors" to be a real hassle, and clarity on where colors come from is something I've been missing.

## Media
Showing off these palettes on light plastic, dark plastic, and concrete.
<img width="509" height="454" alt="image" src="https://github.com/user-attachments/assets/6e2359eb-ca5b-4041-8d33-809b9550460e" />
<img width="509" height="454" alt="image" src="https://github.com/user-attachments/assets/d2fbe678-57a1-48bb-b094-a1f78489dcd8" />
<img width="509" height="454" alt="image" src="https://github.com/user-attachments/assets/16079e94-2470-4b3b-aef4-ebec72f1daa1" />

**Changelog**
No player-facing changes.

**Dev's Changelog**
- add: Added a new decals palette for the neocorporate factions!