### PR TITLE
tweak: makes nt nukes syndie instead

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -74,6 +74,7 @@
     text: nuclear fission explosive
     enabled: false
   - type: NukeLabel
+    prefix: nuke-label-syndicate # starcup: To make nukes syndie.
   - type: Nuke
     explosionType: Default
     maxIntensity: 100


### PR DESCRIPTION
Nuke's now load with the suffix "SYN-######" instead of "NT-######"

## Why / Balance
For Syndicate stations that would not be in possession of NanoTrasen branded nukes.

## Technical details
Replaces NT in the prefix generator in nuke.yml with SYN

## Media
<img width="490" height="204" alt="image" src="https://github.com/user-attachments/assets/8137828b-ecfe-4167-aad5-f8acfe07086f" />


Thanks Ox, Catty and Fox for helping teach me to do this <3

**Changelog**
:cl:
- tweak: Replaced NT with SYN in the nuke prefix generator