### PR TITLE
fix: NanoMed to SyndMed

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -101,8 +101,8 @@
 - type: entity
   parent: CrateMedicalSecure
   id: CrateVendingMachineRestockMedicalFilled
-  name: NanoMed restock crate
-  description: Contains a restock box, compatible with the NanoMed and NanoMedPlus.
+  name: SyndMed restock crate # starcup: changed NanoMed to SyndMed
+  description: Contains a restock box, compatible with the SyndMed and SyndMedPlus. # starcup: changed instances of NanoMed and NanoMedPlus to SyndMed and SyndmedPlus
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -276,8 +276,9 @@
 - type: entity
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockMedical
-  name: NanoMed restock box
-  description: Slot into your department's NanoMed or NanoMedPlus to dispense. Handle with care.
+  name: SyndMed restock box # starcup: renamed to SyndMed
+  description: Slot into your department's SyndMed or SyndMedPlus to dispense. Handle with care.
+  # starcup: changed instances of NanoMed to Syndmed in description
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -924,7 +924,7 @@
 - type: entity
   parent: VendingMachine
   id: VendingMachineMedicalBase
-  name: NanoMed Civilian
+  name: SyndMed Civilian # starcup: changed name from NanoMed to SyndMed
   description: It's a medical drug dispenser. Natural chemicals only!
   components:
   - type: VendingMachine
@@ -960,7 +960,7 @@
 - type: entity
   parent: VendingMachineMedicalBase
   id: VendingMachineMedical
-  name: NanoMed Plus
+  name: Syndmed Plus # starcup: changed name from NanoMed to SyndMed
   components:
   - type: VendingMachine
     pack: NanoMedPlusInventory
@@ -2294,7 +2294,7 @@
 - type: entity
   parent: VendingMachineWallmount
   id: VendingMachineWallMedicalCivilian
-  name: NanoMed band-aid
+  name: SyndMed band-aid # starcup: changed name from NanoMed to SyndMed
   description: It's a wall-mounted medical equipment dispenser. Natural chemicals only!
   components:
   - type: VendingMachine
@@ -2324,7 +2324,7 @@
 - type: entity
   parent: VendingMachineWallMedicalCivilian
   id: VendingMachineWallMedical
-  name: NanoMed
+  name: SyndMed # starcup: changed name from NanoMed to SyndMed
   components:
   - type: VendingMachine
     pack: NanoMedInventory

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -960,7 +960,7 @@
 - type: entity
   parent: VendingMachineMedicalBase
   id: VendingMachineMedical
-  name: Syndmed Plus # starcup: changed name from NanoMed to SyndMed
+  name: SyndMed Plus # starcup: changed name from NanoMed to SyndMed
   components:
   - type: VendingMachine
     pack: NanoMedPlusInventory


### PR DESCRIPTION

## Why / Balance
For Syndicate stations that would instead be sporting Syndicate branded medical vendors.

## Technical details
I went through and changed all of the viewable instances of NanoMed to SyndMed

## Media
<img width="343" height="236" alt="{BAD67591-5B2F-4BEC-A93B-C6A694AA9669}" src="https://github.com/user-attachments/assets/80c87f78-58ae-4a68-9765-b0308a6b3b91" />