### PR TITLE
tweak: NanoMed changed to Interdyne PharmAssist

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -102,7 +102,7 @@
   parent: CrateMedicalSecure
   id: CrateVendingMachineRestockMedicalFilled
   name: Interdyne PharmAssist restock crate # starcup: NanoMed to Interdyne PharmAssist
-  description: Contains a restock box, compatible with the Interdyne PharmAssist and Interdyne PharmAssistPlus. # starcup: NanoMed to Interdyne PharmAssist
+  description: Contains a restock box, compatible with the Interdyne PharmAssist and PharmAssistPlus. # starcup: NanoMed to Interdyne PharmAssist
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -101,8 +101,8 @@
 - type: entity
   parent: CrateMedicalSecure
   id: CrateVendingMachineRestockMedicalFilled
-  name: NanoMed restock crate
-  description: Contains a restock box, compatible with the NanoMed and NanoMedPlus.
+  name: Interdyne PharmAssist restock crate # starcup: NanoMed to Interdyne PharmAssist
+  description: Contains a restock box, compatible with the Interdyne PharmAssist and Interdyne PharmAssistPlus. # starcup: NanoMed to Interdyne PharmAssist
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -277,7 +277,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockMedical
   name: Interdyne PharmAssist restock box # NanoMed to Interdyne PharmAssist
-  description: Slot into your department's Interdyne PharmAssist or Interdyne PharmAssist Plus to dispense. Handle with care.
+  description: Slot into your department's Interdyne PharmAssist or PharmAssist Plus to dispense. Handle with care.
   # starcup: NanoMed to Interdyne PharmAssist
   components:
   - type: VendingMachineRestock

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -276,8 +276,9 @@
 - type: entity
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockMedical
-  name: NanoMed restock box
-  description: Slot into your department's NanoMed or NanoMedPlus to dispense. Handle with care.
+  name: Interdyne PharmAssist restock box # NanoMed to Interdyne PharmAssist
+  description: Slot into your department's Interdyne PharmAssist or Interdyne PharmAssist Plus to dispense. Handle with care.
+  # starcup: NanoMed to Interdyne PharmAssist
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -924,7 +924,7 @@
 - type: entity
   parent: VendingMachine
   id: VendingMachineMedicalBase
-  name: NanoMed Civilian
+  name: Interdyne PharmAssist Civilian # starcup: NanoMed to Interdyne PharmAssist
   description: It's a medical drug dispenser. Natural chemicals only!
   components:
   - type: VendingMachine
@@ -960,7 +960,7 @@
 - type: entity
   parent: VendingMachineMedicalBase
   id: VendingMachineMedical
-  name: NanoMed Plus
+  name: Interdyne PharmAssist Plus # starcup: NanoMed to Interdyne PharmAssist
   components:
   - type: VendingMachine
     pack: NanoMedPlusInventory
@@ -2294,7 +2294,7 @@
 - type: entity
   parent: VendingMachineWallmount
   id: VendingMachineWallMedicalCivilian
-  name: NanoMed band-aid
+  name: Interdyne PharmAssist band-aid # starcup: NanoMed to Interdyne PharmAssist
   description: It's a wall-mounted medical equipment dispenser. Natural chemicals only!
   components:
   - type: VendingMachine
@@ -2324,7 +2324,7 @@
 - type: entity
   parent: VendingMachineWallMedicalCivilian
   id: VendingMachineWallMedical
-  name: NanoMed
+  name: Interdyne PharmAssist # starcup: NanoMed to Interdyne PharmAssist
   components:
   - type: VendingMachine
     pack: NanoMedInventory


### PR DESCRIPTION
Replaces NanoMed with Interdyne PharmAssist

## Why / Balance
Syndicate stations would not be using Nanotrasen medical vendors.

## Technical details
I have replaced every viewable instance of the word "NanoMed" with "Interdyne PharmAssist"

## Media
<img width="415" height="265" alt="image" src="https://github.com/user-attachments/assets/b3637d26-2134-4f6b-9493-0e42c057eba5" />

thank you Dizzy for suggesting the name Interdyne PharmAssist. It rocks.

**Changelog**
:cl:
- tweak: Replaced instances of the name NanoMed with Interdyne PharmAssist or simply PharmAssist.