### PR TITLE
tweak: Mannequin and condiment station collision tweak

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Decoration/mannequin.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/mannequin.yml
@@ -30,9 +30,9 @@
         density: 200
         mask:
         - MachineMask
-        layer:
-        - MidImpassable
-        - BulletImpassable
+        #layer:
+        #- MidImpassable
+        #- BulletImpassable
   - type: InteractionOutline
   - type: Construction
     graph: Mannequin

--- a/Resources/Prototypes/Entities/Structures/Decoration/mannequin.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/mannequin.yml
@@ -28,9 +28,9 @@
           !type:PhysShapeCircle
           radius: 0.2
         density: 200
-        mask:
-        - MachineMask
-        #layer:
+        #mask:
+        # - MachineMask # starcup: rendered inert
+        #layer: # starcup: rendered inert
         #- MidImpassable
         #- BulletImpassable
   - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -197,9 +197,8 @@
         mask:
         - MachineMask
         layer:
-        - MachineLayer
-        #- MidPassable # starcup
-        #- BulletPassable # starcup
+        - Opaque #starcup: changed machine layer to opaque
+        - BulletImpassable #starcup
         density: 190
   - type: DatasetVocalizer
     dataset: CondimentVendAds

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -197,8 +197,7 @@
         mask:
         - MachineMask
         layer:
-        - Opaque #starcup: changed machine layer to opaque
-        - BulletImpassable #starcup
+        - BulletImpassable #starcup: removed machine layer and replaced it with BulletImpassable
         density: 190
   - type: DatasetVocalizer
     dataset: CondimentVendAds

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -198,6 +198,8 @@
         - MachineMask
         layer:
         - MachineLayer
+        - MidPassable # starcup
+        - BulletPassable # starcup
         density: 190
   - type: DatasetVocalizer
     dataset: CondimentVendAds

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -198,8 +198,8 @@
         - MachineMask
         layer:
         - MachineLayer
-        - MidPassable # starcup
-        - BulletPassable # starcup
+        #- MidPassable # starcup
+        #- BulletPassable # starcup
         density: 190
   - type: DatasetVocalizer
     dataset: CondimentVendAds

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -194,8 +194,8 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.3,-0.16,0.3,0.40"
-        mask:
-        - MachineMask
+        # mask:
+        # - MachineMask # starcup: rendered this inert
         layer:
         - BulletImpassable #starcup: removed machine layer and replaced it with BulletImpassable
         density: 190


### PR DESCRIPTION
Makes it so Mannequins and condiment stations have more sensible collision.

## Why / Balance
Condiment stations couldn't have firelocks closed on them which got very annoying for bars and kitchens and mannequins couldn't be walked through which seemed a bit silly.

## Technical details
I've essentially modified the mask and layer functions of the mannequin and the condiment station. Both can now be walked through and a condiment station can now have a firelock closed on it. A mannequin however, cannot, because that seemed a bit of a far stretch to me.

## Media
<img width="285" height="201" alt="{8D127CCA-8F84-4064-AF9A-6FA61756DE55}" src="https://github.com/user-attachments/assets/c780861c-335b-4852-8e6e-ef03c9ac10ed" />

Thank you Nox and PL4SMA for being sounding boards while I was trying to figure out why my first attempts didn't work lol

**Changelog**
:cl:
tweak: Mannequins and condiment stations now have collision that makes sense.