### PR TITLE
map(freighter): telegraph singulo setup better, minor fixes

### DIFF
--- a/Resources/Maps/_starcup/Shuttles/cargo_freighter.yml
+++ b/Resources/Maps/_starcup/Shuttles/cargo_freighter.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/17/2026 22:11:04
-  entityCount: 351
+  time: 04/28/2026 00:33:01
+  entityCount: 352
 maps: []
 grids:
 - 1
@@ -36,9 +36,8 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: grid
+      name: HWKM Cargo Shuttle "Ladybug"
     - type: Transform
-      pos: 0,0
       parent: invalid
     - type: MapGrid
       chunks:
@@ -381,25 +380,25 @@ entities:
       invokeCounter: 1
 - proto: AirlockExternalGlassShuttleLocked
   entities:
-  - uid: 10
+  - uid: 8
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-8.5
       parent: 1
-  - uid: 11
+  - uid: 9
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 316
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-5.5
       parent: 1
-  - uid: 333
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -433,30 +432,30 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 9
+  - uid: 16
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-5.5
       parent: 1
-  - uid: 16
+  - uid: 17
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-8.5
       parent: 1
-  - uid: 17
+  - uid: 18
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 20
+  - uid: 19
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 150
+  - uid: 20
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -464,28 +463,28 @@ entities:
       parent: 1
 - proto: BlastDoorUnlinkedLogistics
   entities:
-  - uid: 22
+  - uid: 21
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 23
+  - uid: 22
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 221
+  - uid: 23
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 272
+  - uid: 24
     components:
     - type: Transform
       pos: 9.5,-6.5
@@ -494,25 +493,25 @@ entities:
       invokeCounter: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 27
+  - uid: 25
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 28
+  - uid: 26
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 139
+  - uid: 27
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-  - uid: 152
+  - uid: 28
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -520,162 +519,162 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 21
+  - uid: 29
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 1
-  - uid: 29
+  - uid: 30
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 30
+  - uid: 31
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 31
+  - uid: 32
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 32
+  - uid: 33
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 33
+  - uid: 34
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 34
+  - uid: 35
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 35
+  - uid: 36
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 36
+  - uid: 37
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 37
+  - uid: 38
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 38
+  - uid: 39
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 39
+  - uid: 40
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 40
+  - uid: 41
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 41
+  - uid: 42
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 42
+  - uid: 43
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 43
+  - uid: 44
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 44
+  - uid: 45
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 45
+  - uid: 46
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 46
+  - uid: 47
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 47
+  - uid: 48
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 48
+  - uid: 49
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 49
+  - uid: 50
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 50
+  - uid: 51
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 51
+  - uid: 52
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 52
+  - uid: 53
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 53
+  - uid: 54
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 54
+  - uid: 55
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 55
+  - uid: 56
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 56
+  - uid: 57
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 57
+  - uid: 58
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 58
+  - uid: 59
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 59
+  - uid: 60
     components:
     - type: Transform
       pos: 6.5,-1.5
@@ -700,391 +699,391 @@ entities:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 66
+  - uid: 65
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 67
+  - uid: 66
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 68
+  - uid: 67
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 69
+  - uid: 68
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 70
+  - uid: 69
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 71
+  - uid: 70
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 72
+  - uid: 71
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 73
+  - uid: 72
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 74
+  - uid: 73
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 75
+  - uid: 74
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 76
+  - uid: 75
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 77
+  - uid: 76
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 78
+  - uid: 77
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 79
+  - uid: 78
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 80
+  - uid: 79
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 81
+  - uid: 80
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 82
+  - uid: 81
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 83
+  - uid: 82
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 84
+  - uid: 83
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 85
+  - uid: 84
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 140
+  - uid: 85
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 141
+  - uid: 86
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 227
+  - uid: 87
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 235
+  - uid: 88
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 279
+  - uid: 89
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 86
+  - uid: 90
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 87
+  - uid: 91
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 88
+  - uid: 92
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 89
+  - uid: 93
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 90
+  - uid: 94
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 91
+  - uid: 95
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 92
+  - uid: 96
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 93
+  - uid: 97
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 94
+  - uid: 98
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 95
+  - uid: 99
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 96
+  - uid: 100
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 97
+  - uid: 101
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 98
+  - uid: 102
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 99
+  - uid: 103
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 100
+  - uid: 104
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 101
+  - uid: 105
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 102
+  - uid: 106
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 103
+  - uid: 107
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 104
+  - uid: 108
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 105
+  - uid: 109
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 106
+  - uid: 110
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 107
+  - uid: 111
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 108
+  - uid: 112
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 109
+  - uid: 113
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 110
+  - uid: 114
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 111
+  - uid: 115
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 112
+  - uid: 116
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 113
+  - uid: 117
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 114
+  - uid: 118
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 115
+  - uid: 119
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 116
+  - uid: 120
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 117
+  - uid: 121
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 118
+  - uid: 122
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 119
+  - uid: 123
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 120
+  - uid: 124
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 121
+  - uid: 125
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 122
+  - uid: 126
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 123
+  - uid: 127
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 124
+  - uid: 128
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 125
+  - uid: 129
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 126
+  - uid: 130
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 127
+  - uid: 131
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
-  - uid: 128
+  - uid: 132
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 129
+  - uid: 133
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 130
+  - uid: 134
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 167
+  - uid: 135
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 203
+  - uid: 136
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
 - proto: Chair
   entities:
-  - uid: 131
+  - uid: 137
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 132
+  - uid: 138
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 133
+  - uid: 139
     mapInit: true
     paused: true
     components:
@@ -1094,7 +1093,7 @@ entities:
       parent: 1
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 134
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1102,7 +1101,7 @@ entities:
       parent: 1
 - proto: ClosetWallEmergencyN2FilledRandom
   entities:
-  - uid: 135
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1110,68 +1109,68 @@ entities:
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 136
+  - uid: 142
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
 - proto: ConveyorBelt
   entities:
-  - uid: 19
+  - uid: 143
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 1
-  - uid: 137
+  - uid: 144
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-1.5
       parent: 1
-  - uid: 138
+  - uid: 145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 143
+  - uid: 146
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-7.5
       parent: 1
-  - uid: 144
+  - uid: 147
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
-  - uid: 145
+  - uid: 148
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 146
+  - uid: 149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 148
+  - uid: 150
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 1
-  - uid: 315
+  - uid: 151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 1
-  - uid: 334
+  - uid: 152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1179,7 +1178,7 @@ entities:
       parent: 1
 - proto: FirelockEdge
   entities:
-  - uid: 151
+  - uid: 153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1279,35 +1278,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 168
+  - uid: 167
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 169
+  - uid: 168
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 170
+  - uid: 169
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 171
+  - uid: 170
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 172
+  - uid: 171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1315,14 +1314,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 173
+  - uid: 172
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 174
+  - uid: 173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1330,7 +1329,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 175
+  - uid: 174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1338,7 +1337,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 176
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1346,7 +1345,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 177
+  - uid: 176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1354,7 +1353,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 178
+  - uid: 177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1362,7 +1361,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 180
+  - uid: 178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1370,7 +1369,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 181
+  - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1378,7 +1377,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 182
+  - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1386,7 +1385,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 183
+  - uid: 181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1394,7 +1393,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 184
+  - uid: 182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1402,7 +1401,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 186
+  - uid: 183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1410,7 +1409,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 187
+  - uid: 184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1418,7 +1417,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 189
+  - uid: 185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1426,7 +1425,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 195
+  - uid: 186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1434,7 +1433,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 204
+  - uid: 187
     components:
     - type: Transform
       pos: 5.5,0.5
@@ -1443,7 +1442,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 179
+  - uid: 188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1451,7 +1450,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 185
+  - uid: 189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1459,7 +1458,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 188
+  - uid: 190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1467,7 +1466,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 190
+  - uid: 191
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1475,7 +1474,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 191
+  - uid: 192
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1483,7 +1482,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 192
+  - uid: 193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1491,7 +1490,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 193
+  - uid: 194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1499,7 +1498,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 194
+  - uid: 195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1567,7 +1566,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 244
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1575,7 +1574,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 246
+  - uid: 204
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1611,124 +1610,124 @@ entities:
       parent: 1
 - proto: Grille
   entities:
-  - uid: 142
+  - uid: 209
     components:
     - type: Transform
       pos: 9.5,-4.5
-      parent: 1
-  - uid: 209
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
       parent: 1
   - uid: 210
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 0.5,-3.5
       parent: 1
   - uid: 211
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 0.5,-5.5
+      pos: 0.5,-4.5
       parent: 1
   - uid: 212
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 6.5,7.5
+      pos: 0.5,-5.5
       parent: 1
   - uid: 213
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 2.5,8.5
+      pos: 6.5,7.5
       parent: 1
   - uid: 214
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 4.5,9.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 215
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 2.5,7.5
+      pos: 4.5,9.5
       parent: 1
   - uid: 216
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 3.5,9.5
+      pos: 2.5,7.5
       parent: 1
   - uid: 217
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 5.5,9.5
+      pos: 3.5,9.5
       parent: 1
   - uid: 218
     mapInit: true
     paused: true
     components:
     - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 219
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 222
+  - uid: 220
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 223
+  - uid: 221
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 224
+  - uid: 222
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 225
+  - uid: 223
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 226
+  - uid: 224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 241
+  - uid: 225
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: HolopadCargoShuttle
   entities:
-  - uid: 228
+  - uid: 226
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: Lamp
   entities:
-  - uid: 229
+  - uid: 227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1736,21 +1735,21 @@ entities:
       parent: 1
 - proto: NewtonCradle
   entities:
-  - uid: 230
+  - uid: 228
     components:
     - type: Transform
       pos: 5.609627,8.682032
       parent: 1
 - proto: NotebookSpiralBeige
   entities:
-  - uid: 231
+  - uid: 229
     components:
     - type: Transform
       pos: 5.3359833,8.487801
       parent: 1
 - proto: Pen
   entities:
-  - uid: 232
+  - uid: 230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1758,12 +1757,12 @@ entities:
       parent: 1
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 24
+  - uid: 231
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 1
-  - uid: 220
+  - uid: 232
     components:
     - type: Transform
       pos: 9.5,-2.5
@@ -1780,54 +1779,54 @@ entities:
       parent: 1
 - proto: PosterLegitHawkmoonAd
   entities:
-  - uid: 237
+  - uid: 235
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
 - proto: PosterLegitHawkmoonAdTattered
   entities:
-  - uid: 238
+  - uid: 236
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
 - proto: PosterLegitMail
   entities:
-  - uid: 239
+  - uid: 237
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
 - proto: PottedPlantRandom
   entities:
-  - uid: 240
+  - uid: 238
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
 - proto: PottedPlantRandomPlastic
   entities:
-  - uid: 242
+  - uid: 239
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 259
+  - uid: 240
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
 - proto: PoweredFloorLight
   entities:
-  - uid: 26
+  - uid: 241
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 65
+  - uid: 242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1839,26 +1838,26 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 245
+  - uid: 244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-9.5
       parent: 1
-  - uid: 247
+  - uid: 245
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 248
+  - uid: 246
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 249
+  - uid: 247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1866,19 +1865,19 @@ entities:
       parent: 1
 - proto: Rack
   entities:
-  - uid: 250
+  - uid: 248
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 251
+  - uid: 249
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
 - proto: RadioHandheld
   entities:
-  - uid: 252
+  - uid: 250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1886,49 +1885,49 @@ entities:
       parent: 1
 - proto: RailingDeltaVGrey
   entities:
-  - uid: 25
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 253
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 254
+  - uid: 253
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 255
+  - uid: 254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 256
+  - uid: 255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
-  - uid: 257
+  - uid: 256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
-  - uid: 260
+  - uid: 257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 280
+  - uid: 258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1936,111 +1935,111 @@ entities:
       parent: 1
 - proto: RandomPainting
   entities:
-  - uid: 261
+  - uid: 259
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 147
+  - uid: 260
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 1
-  - uid: 262
+  - uid: 261
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 263
+  - uid: 262
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 264
+  - uid: 263
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 265
+  - uid: 264
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 266
+  - uid: 265
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 267
+  - uid: 266
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 268
+  - uid: 267
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 269
+  - uid: 268
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 270
+  - uid: 269
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 271
+  - uid: 270
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 273
+  - uid: 271
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 274
+  - uid: 272
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 275
+  - uid: 273
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 276
+  - uid: 274
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 60
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2048,22 +2047,22 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        146:
+        149:
         - - On
           - Forward
         - - Off
           - Off
-        19:
+        143:
         - - On
           - Forward
         - - Off
           - Off
-        221:
+        23:
         - - On
           - Open
         - - Off
           - Close
-  - uid: 258
+  - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2071,17 +2070,17 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        315:
+        151:
         - - On
           - Forward
         - - Off
           - Off
-        334:
+        152:
         - - On
           - Forward
         - - Off
           - Off
-        272:
+        24:
         - - On
           - Open
         - - Off
@@ -2094,22 +2093,22 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        138:
-        - - On
-          - Forward
-        - - Off
-          - Off
-        137:
-        - - On
-          - Forward
-        - - Off
-          - Off
         145:
         - - On
           - Forward
         - - Off
           - Off
-        22:
+        144:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        148:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        21:
         - - On
           - Open
         - - Off
@@ -2122,62 +2121,62 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        144:
+        147:
         - - On
           - Forward
         - - Off
           - Off
-        143:
+        146:
         - - On
           - Forward
         - - Off
           - Off
-        148:
+        150:
         - - On
           - Forward
         - - Off
           - Off
-        23:
+        22:
         - - On
           - Open
         - - Off
           - Close
 - proto: SignDoors
   entities:
-  - uid: 281
+  - uid: 279
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
-  - uid: 282
+  - uid: 280
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
 - proto: StairDark
   entities:
-  - uid: 283
+  - uid: 281
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 284
+  - uid: 282
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
 - proto: Table
   entities:
-  - uid: 285
+  - uid: 283
     mapInit: true
     paused: true
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 286
+  - uid: 284
     mapInit: true
     paused: true
     components:
@@ -2186,70 +2185,70 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 287
+  - uid: 285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 1
-  - uid: 288
+  - uid: 286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 289
+  - uid: 287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
-  - uid: 290
+  - uid: 288
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 291
+  - uid: 289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 1
-  - uid: 292
+  - uid: 290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-  - uid: 293
+  - uid: 291
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,5.5
       parent: 1
-  - uid: 294
+  - uid: 292
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 295
+  - uid: 293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 296
+  - uid: 294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 297
+  - uid: 295
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 298
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2257,254 +2256,254 @@ entities:
       parent: 1
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 299
+  - uid: 297
     components:
     - type: Transform
       pos: 1.4730053,-9.295185
       parent: 1
 - proto: ToolboxEmergencyFilled
   entities:
-  - uid: 300
+  - uid: 298
     components:
     - type: Transform
       pos: 3.6099548,6.5636864
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 8
+  - uid: 299
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 18
+  - uid: 300
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 149
+  - uid: 301
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
-  - uid: 153
+  - uid: 302
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 219
+  - uid: 303
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 236
+  - uid: 304
     components:
     - type: Transform
       pos: 8.5,-8.5
-      parent: 1
-  - uid: 301
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 302
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -0.5,-6.5
-      parent: 1
-  - uid: 303
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
-  - uid: 304
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
       parent: 1
   - uid: 305
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 306
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 307
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: 0.5,-6.5
       parent: 1
   - uid: 308
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 0.5,1.5
+      pos: 0.5,-2.5
       parent: 1
   - uid: 309
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 1.5,1.5
+      pos: -0.5,-2.5
       parent: 1
   - uid: 310
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 2.5,1.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 311
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 7.5,6.5
+      pos: 0.5,0.5
       parent: 1
   - uid: 312
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 0.5,1.5
       parent: 1
   - uid: 313
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 7.5,1.5
+      pos: 1.5,1.5
       parent: 1
   - uid: 314
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 8.5,0.5
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 315
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 316
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: 6.5,1.5
       parent: 1
   - uid: 317
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 8.5,-9.5
+      pos: 7.5,1.5
       parent: 1
   - uid: 318
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 7.5,-10.5
+      pos: 8.5,0.5
       parent: 1
   - uid: 319
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 6.5,-10.5
+      pos: 8.5,-9.5
       parent: 1
   - uid: 320
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 5.5,-10.5
+      pos: 7.5,-10.5
       parent: 1
   - uid: 321
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 3.5,-10.5
+      pos: 6.5,-10.5
       parent: 1
   - uid: 322
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 2.5,-10.5
+      pos: 5.5,-10.5
       parent: 1
   - uid: 323
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 1.5,-10.5
+      pos: 3.5,-10.5
       parent: 1
   - uid: 324
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 0.5,-10.5
+      pos: 2.5,-10.5
       parent: 1
   - uid: 325
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 0.5,-9.5
+      pos: 1.5,-10.5
       parent: 1
   - uid: 326
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: 0.5,-10.5
       parent: 1
   - uid: 327
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 1.5,6.5
+      pos: 0.5,-9.5
       parent: 1
   - uid: 328
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 2.5,6.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 329
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 6.5,6.5
+      pos: 1.5,6.5
       parent: 1
   - uid: 330
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 331
     mapInit: true
     paused: true
     components:
     - type: Transform
-      pos: 8.5,-10.5
+      pos: 6.5,6.5
       parent: 1
   - uid: 332
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 333
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 1
+  - uid: 334
     mapInit: true
     paused: true
     components:
@@ -2581,6 +2580,15 @@ entities:
     components:
     - type: Transform
       pos: 2.5,9.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 352
+    components:
+    - type: MetaData
+      name: Cargo Shuttle
+    - type: Transform
+      pos: 4.5,-4.5
       parent: 1
 - proto: Windoor
   entities:

--- a/Resources/Maps/_starcup/Shuttles/emergency_freighter.yml
+++ b/Resources/Maps/_starcup/Shuttles/emergency_freighter.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/24/2026 00:54:40
-  entityCount: 1097
+  time: 04/28/2026 00:30:12
+  entityCount: 1098
 maps: []
 grids:
 - 1
@@ -36,7 +36,7 @@ entities:
     - type: MetaData
       name: SYND Transfer Shuttle "Impedance"
     - type: Transform
-      pos: -30.413116,-35.551765
+      pos: 0, 0
       parent: invalid
     - type: MapGrid
       chunks:
@@ -7010,6 +7010,15 @@ entities:
     components:
     - type: Transform
       pos: -2.5,19.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 1098
+    components:
+    - type: MetaData
+      name: Evacuation Shuttle
+    - type: Transform
+      pos: 5.5,8.5
       parent: 1
 - proto: Windoor
   entities:

--- a/Resources/Maps/_starcup/freighter.yml
+++ b/Resources/Maps/_starcup/freighter.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/24/2026 01:59:58
-  entityCount: 13323
+  time: 04/28/2026 00:28:20
+  entityCount: 13348
 maps:
 - 1
 grids:
@@ -184,7 +184,7 @@ entities:
           version: 7
         -2,1:
           ind: -2,1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAQABAAAAAAMAAAAAAAAAAAgAAAAAAAAIAAAAAAAABwAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAACAAAAAAAAAAAHAAAAAAAACAAAAAAAAAcAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAgABAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAHAAAAAAAACAAAAAAAAAcAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAHAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAIAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAHAAAAAAAABwAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAABAAAAAAAQALAAAAAAMACwAAAAADABAAAAAAAQAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAAAcAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAAQAAAAAAIACwAAAAAAAAsAAAAAAQAQAAAAAAIAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAADAAsAAAAAAgALAAAAAAMAEAAAAAACAC8AAAAAAgAuAAAAAAEALgAAAAABAC4AAAAAAgAvAAAAAAMALgAAAAADAAAAAAAAAAAuAAAAAAEALgAAAAACAC4AAAAAAgAuAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAEAAwAAAAAAAAAAAAAAAAAvAAAAAAEALgAAAAABAC4AAAAAAgAuAAAAAAEALwAAAAADAC8AAAAAAgACAAAAAAAALwAAAAABAC8AAAAAAQAvAAAAAAAALwAAAAADAAIAAAAAAAAvAAAAAAEALwAAAAABAC8AAAAAAwAvAAAAAAIALwAAAAABAC8AAAAAAgAvAAAAAAMALwAAAAADAC8AAAAAAgAvAAAAAAEAAgAAAAAAAC8AAAAAAwAvAAAAAAEALwAAAAADAC8AAAAAAwACAAAAAAAALwAAAAABAC8AAAAAAgAvAAAAAAIALwAAAAACAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAQABAAAAAAMAAAAAAAAAAAgAAAAAAAAIAAAAAAAABwAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAACAAAAAAAAAAAHAAAAAAAACAAAAAAAAAcAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAgABAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAHAAAAAAAACAAAAAAAAAcAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAHAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAIAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAHAAAAAAAABwAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAABAAAAAAAQALAAAAAAMACwAAAAADABAAAAAAAQAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAAAcAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAAQAAAAAAIACwAAAAAAAAsAAAAAAQAQAAAAAAIAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAADAAsAAAAAAgALAAAAAAMAEAAAAAACAC8AAAAAAgAuAAAAAAEALgAAAAABAC4AAAAAAgAvAAAAAAMALgAAAAADAAAAAAAAAAAuAAAAAAEALgAAAAACAC4AAAAAAgAuAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAEAAwAAAAAAAAAAAAAAAAAvAAAAAAEALgAAAAABAC4AAAAAAgAuAAAAAAEALwAAAAADAC8AAAAAAgACAAAAAAAALwAAAAABAC8AAAAAAQAvAAAAAAAALwAAAAADAAIAAAAAAAAvAAAAAAEALwAAAAABAC8AAAAAAwAvAAAAAAIALwAAAAABAC8AAAAAAgAvAAAAAAMALwAAAAADAC8AAAAAAgAvAAAAAAEAAgAAAAAAAC8AAAAAAwAvAAAAAAEALwAAAAADAC8AAAAAAwACAAAAAAAALwAAAAABAC8AAAAAAgAvAAAAAAIALwAAAAACAA==
           version: 7
         -2,0:
           ind: -2,0
@@ -303,6 +303,18 @@ entities:
         version: 2
         nodes:
         - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            3432: 7,12
+        - node:
+            angle: -4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            3431: 3,8
+        - node:
             zIndex: 6
             angle: -3.141592653589793 rad
             color: '#FFFFFFFF'
@@ -314,6 +326,12 @@ entities:
             2654: 1,32
             2655: 1,42
             2656: 1,52
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            3429: 5,10
         - node:
             color: '#FFFFFFFF'
             id: Arrows
@@ -348,6 +366,7 @@ entities:
             1438: 5.9790525,-13.437271
             2956: -12,-16
             2959: -4,-16
+            3450: 8,10
         - node:
             color: '#FFFFFFFF'
             id: Basalt6
@@ -476,13 +495,18 @@ entities:
           decals:
             1006: 16,4
             1044: 31,4
-            1186: 8,10
         - node:
             color: '#66244AB2'
             id: BrickLineOverlayE
           decals:
             1241: 3,74
             1242: 3,77
+        - node:
+            angle: -6.283185307179586 rad
+            color: '#DE3A3A96'
+            id: BrickLineOverlayE
+          decals:
+            3441: 8,10
         - node:
             zIndex: 5
             color: '#DE3A3A96'
@@ -839,7 +863,6 @@ entities:
           decals:
             1075: 16,4
             1100: 31,4
-            1192: 8,10
         - node:
             zIndex: 5
             color: '#FFFFFFFF'
@@ -853,6 +876,12 @@ entities:
           decals:
             443: 11,23
         - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: BrickTileSteelInnerNe
+          decals:
+            3447: 7,10
+        - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelInnerNe
           decals:
@@ -864,6 +893,12 @@ entities:
             id: BrickTileSteelInnerNe
           decals:
             347: 28,56
+        - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: BrickTileSteelInnerNw
+          decals:
+            3446: 8,10
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelInnerNw
@@ -880,6 +915,13 @@ entities:
           decals:
             346: 32,56
         - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: BrickTileSteelInnerSe
+          decals:
+            3436: 8,12
+            3439: 7,12
+        - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelInnerSe
           decals:
@@ -889,6 +931,13 @@ entities:
             3069: 42,39
             3078: 42,24
         - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: BrickTileSteelInnerSw
+          decals:
+            3437: 8,12
+            3438: 7,12
+        - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelInnerSw
           decals:
@@ -896,6 +945,12 @@ entities:
             1110: 30,11
             3068: 44,39
             3077: 44,24
+        - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineE
+          decals:
+            3440: 8,10
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineE
@@ -1466,6 +1521,22 @@ entities:
           decals:
             2342: 38,18
         - node:
+            cleanable: True
+            color: '#9D9D97BF'
+            id: CrayonShortlineH
+          decals:
+            3419: -31,11
+        - node:
+            cleanable: True
+            color: '#9D9D97BF'
+            id: CrayonThinlineH
+          decals:
+            3411: -30,19
+            3412: -29,19
+            3415: -35,11
+            3416: -34,11
+            3417: -30,11
+        - node:
             angle: 6.283185307179586 rad
             color: '#FFFFFFFF'
             id: DarkSlatSingleE
@@ -1888,6 +1959,12 @@ entities:
             2596: -3,0
             2602: -1,-8
         - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: GrayConcreteTrimInnerNe
+          decals:
+            3433: 3,8
+        - node:
             color: '#FFFFFFFF'
             id: GrayConcreteTrimInnerNe
           decals:
@@ -1938,7 +2015,6 @@ entities:
             2309: 32,15
             2565: 3,3
             2566: 3,6
-            2567: 3,8
             2568: 3,10
             2570: 3,24
             2571: 3,30
@@ -2028,6 +2104,12 @@ entities:
             2718: 1,61
             2754: 2,21
         - node:
+            angle: -6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: GrayConcreteTrimInnerSe
+          decals:
+            3434: 3,8
+        - node:
             color: '#FFFFFFFF'
             id: GrayConcreteTrimInnerSe
           decals:
@@ -2089,7 +2171,6 @@ entities:
             2586: 3,29
             2587: 3,24
             2589: 3,10
-            2590: 3,8
             2591: 3,5
             2592: 3,3
             2617: 1,-4
@@ -2978,8 +3059,6 @@ entities:
             id: HalfTileOverlayGreyscale180
           decals:
             922: 9,12
-            923: 8,12
-            924: 7,12
             925: 6,12
             926: 5,12
             946: 6,3
@@ -2988,9 +3067,9 @@ entities:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale180
           decals:
-            829: -33,19
             1496: -9,29
             1498: -6,29
+            3421: -33,19
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale270
@@ -3338,6 +3417,18 @@ entities:
             336: 29,57
             337: 29,58
         - node:
+            angle: -6.283185307179586 rad
+            color: '#DE3A3A96'
+            id: MiniTileInnerOverlayNE
+          decals:
+            3448: 7,10
+        - node:
+            angle: -6.283185307179586 rad
+            color: '#DE3A3A96'
+            id: MiniTileInnerOverlayNW
+          decals:
+            3449: 8,10
+        - node:
             zIndex: 5
             color: '#DE3A3A96'
             id: MiniTileInnerOverlayNW
@@ -3346,6 +3437,13 @@ entities:
             1055: 31,12
             1187: 7,10
         - node:
+            angle: -6.283185307179586 rad
+            color: '#DE3A3A96'
+            id: MiniTileInnerOverlaySE
+          decals:
+            3444: 7,12
+            3445: 8,12
+        - node:
             zIndex: 5
             color: '#DE3A3A96'
             id: MiniTileInnerOverlaySE
@@ -3353,6 +3451,13 @@ entities:
             1029: 16,11
             1056: 30,4
             1112: 15,4
+        - node:
+            angle: -6.283185307179586 rad
+            color: '#DE3A3A96'
+            id: MiniTileInnerOverlaySW
+          decals:
+            3442: 7,12
+            3443: 8,12
         - node:
             zIndex: 5
             color: '#DE3A3A96'
@@ -3529,12 +3634,10 @@ entities:
           decals:
             820: -28,15
         - node:
-            color: '#EFB34126'
+            color: '#EFB34155'
             id: QuarterTileOverlayGreyscale180
           decals:
-            832: -32,19
-            833: -32,19
-            834: -32,19
+            3423: -32,19
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale270
@@ -3551,7 +3654,7 @@ entities:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale270
           decals:
-            831: -32,19
+            3422: -32,19
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale90
@@ -4072,7 +4175,6 @@ entities:
           decals:
             795: -41,23
             810: -34,21
-            811: -33,19
             812: -27,15
             813: -27,17
             3382: -20,8
@@ -4094,6 +4196,7 @@ entities:
             3388: -17,3
             3389: -19,-2
             3390: -19,-4
+            3424: -32,19
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -4101,6 +4204,7 @@ entities:
           decals:
             793: -41,21
             815: -26,14
+            3425: -33,19
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -4153,6 +4257,22 @@ entities:
             id: rockrmc9
           decals:
             2951: 8.617577,-16.237408
+        - node:
+            cleanable: True
+            color: '#9D9D97BF'
+            id: shortline
+          decals:
+            3420: -36,18
+        - node:
+            cleanable: True
+            color: '#9D9D97BF'
+            id: thinline
+          decals:
+            3403: -36,12
+            3404: -36,13
+            3406: -36,16
+            3407: -36,17
+            3414: -28,13
     - type: GridAtmosphere
       version: 2
       data:
@@ -4511,16 +4631,18 @@ entities:
           -4,6:
             0: 61166
           -5,6:
-            0: 65294
+            0: 65288
+            4: 2
+            5: 4
           -5,7:
             0: 65391
           -3,6:
             0: 48050
           -3,4:
-            4: 14
-            5: 3584
-          -3,5:
             6: 14
+            7: 3584
+          -3,5:
+            8: 14
             0: 60928
           -2,5:
             0: 65358
@@ -4683,10 +4805,10 @@ entities:
           3,17:
             0: 272
             2: 18560
-            4: 32768
+            6: 32768
           3,19:
             2: 3252
-            4: 64
+            6: 64
           3,18:
             2: 19592
           4,16:
@@ -4758,13 +4880,13 @@ entities:
             2: 4385
             0: 16
           7,16:
-            4: 4
+            6: 4
             2: 35008
           7,15:
-            4: 53152
+            6: 53152
             2: 8192
           8,16:
-            4: 11
+            6: 11
             2: 17600
           5,13:
             0: 4080
@@ -4785,15 +4907,15 @@ entities:
           8,14:
             0: 62399
           8,15:
-            4: 64624
+            6: 64624
           -8,16:
-            4: 5
+            6: 5
             2: 8800
           -8,15:
-            4: 32432
+            6: 32432
             2: 32768
           -9,16:
-            4: 10
+            6: 10
             2: 17504
           -6,16:
             0: 1
@@ -4824,7 +4946,7 @@ entities:
           -9,14:
             0: 65487
           -9,15:
-            4: 59344
+            6: 59344
             2: 4096
           -7,12:
             0: 4912
@@ -4835,7 +4957,7 @@ entities:
             0: 307
             2: 8
           -7,15:
-            4: 256
+            6: 256
             2: 128
           -7,11:
             0: 13107
@@ -4962,22 +5084,22 @@ entities:
           -11,13:
             2: 11810
           -10,12:
-            4: 16
+            6: 16
             2: 257
             0: 3276
           -10,13:
-            4: 256
+            6: 256
             2: 4112
             0: 49356
           -11,15:
             2: 2184
           -10,14:
             2: 4352
-            4: 8192
+            6: 8192
             0: 76
           -10,15:
             2: 4371
-            4: 2048
+            6: 2048
           -10,16:
             2: 305
           -12,8:
@@ -5047,7 +5169,7 @@ entities:
             0: 4189
             2: 32768
           9,15:
-            4: 784
+            6: 784
             2: 4096
           9,11:
             0: 9830
@@ -5151,21 +5273,21 @@ entities:
             2: 4352
           8,-4:
             2: 48
-            4: 65280
+            6: 65280
           7,-4:
-            4: 52224
+            6: 52224
             2: 4130
           8,-3:
-            4: 61175
+            6: 61175
           7,-3:
-            4: 249
+            6: 249
             0: 57344
           8,-2:
             0: 54744
           7,-2:
             0: 65534
           9,-3:
-            4: 4978
+            6: 4978
             2: 1152
           9,-2:
             0: 12832
@@ -5202,7 +5324,7 @@ entities:
             2: 28672
           6,-3:
             2: 2112
-            4: 128
+            6: 128
           0,-3:
             0: 47324
           0,-2:
@@ -5357,6 +5479,16 @@ entities:
             Nitrogen: 103.92799
         - volume: 2500
           temperature: 293.15
+          moles:
+            Oxygen: 21.6852
+            Nitrogen: 81.57766
+        - volume: 2500
+          temperature: 293.14948
+          moles:
+            Oxygen: 18.472576
+            Nitrogen: 69.49208
+        - volume: 2500
+          temperature: 293.15
           moles: {}
         - volume: 2500
           temperature: 293.15
@@ -5370,6 +5502,25 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ExplosionAirtightGrid
+  - uid: 3715
+    mapInit: true
+    paused: true
+    components:
+    - type: MetaData
+      name: solution - food
+    - type: Transform
+      parent: 3714
+    - type: Solution
+      solution:
+        maxVol: 1
+        name: food
+        reagents:
+        - data: []
+          ReagentId: Fiber
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: food
+      container: 3714
 - proto: ActionToggleInternals
   entities:
   - uid: 714
@@ -6289,15 +6440,6 @@ entities:
     - type: Transform
       pos: -8.5,-4.5
       parent: 2
-- proto: AirlockChapelGlassLocked
-  entities:
-  - uid: 6352
-    components:
-    - type: MetaData
-      name: chapel
-    - type: Transform
-      pos: 17.5,44.5
-      parent: 2
 - proto: AirlockChapelLocked
   entities:
   - uid: 3939
@@ -6581,20 +6723,6 @@ entities:
     - type: Transform
       pos: -6.5,34.5
       parent: 2
-  - uid: 6185
-    components:
-    - type: MetaData
-      name: telecomms
-    - type: Transform
-      pos: -17.5,29.5
-      parent: 2
-  - uid: 6186
-    components:
-    - type: MetaData
-      name: telecomms
-    - type: Transform
-      pos: -18.5,29.5
-      parent: 2
   - uid: 6187
     components:
     - type: MetaData
@@ -6618,6 +6746,16 @@ entities:
       parent: 2
 - proto: AirlockEngineeringGlassLocked
   entities:
+  - uid: 2626
+    components:
+    - type: Transform
+      pos: -18.5,29.5
+      parent: 2
+  - uid: 2686
+    components:
+    - type: Transform
+      pos: -17.5,29.5
+      parent: 2
   - uid: 6177
     components:
     - type: MetaData
@@ -6968,7 +7106,7 @@ entities:
       pos: -3.5,-17.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -87789.61
+      secondsUntilStateChange: -91514.69
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -6999,9 +7137,9 @@ entities:
     - type: Transform
       pos: 13.5,-17.5
       parent: 2
-- proto: AirlockExternalGlassShuttleMining
+- proto: AirlockExternalGlassShuttleMiningFilled
   entities:
-  - uid: 4374
+  - uid: 2797
     components:
     - type: Transform
       pos: 42.5,-4.5
@@ -7099,6 +7237,11 @@ entities:
     components:
     - type: Transform
       pos: 26.5,53.5
+      parent: 2
+  - uid: 1987
+    components:
+    - type: Transform
+      pos: 17.5,44.5
       parent: 2
   - uid: 6124
     components:
@@ -11679,11 +11822,6 @@ entities:
     - type: Transform
       pos: -2.5,60.5
       parent: 2
-  - uid: 7000
-    components:
-    - type: Transform
-      pos: 33.5,62.5
-      parent: 2
   - uid: 7001
     components:
     - type: Transform
@@ -11693,16 +11831,6 @@ entities:
     components:
     - type: Transform
       pos: 33.5,64.5
-      parent: 2
-  - uid: 7004
-    components:
-    - type: Transform
-      pos: 34.5,62.5
-      parent: 2
-  - uid: 7005
-    components:
-    - type: Transform
-      pos: 33.5,61.5
       parent: 2
   - uid: 7006
     components:
@@ -20334,11 +20462,6 @@ entities:
     - type: Transform
       pos: -27.5,46.5
       parent: 2
-  - uid: 13161
-    components:
-    - type: Transform
-      pos: -28.5,46.5
-      parent: 2
   - uid: 13162
     components:
     - type: Transform
@@ -20498,6 +20621,11 @@ entities:
     components:
     - type: Transform
       pos: 31.5,49.5
+      parent: 2
+  - uid: 13327
+    components:
+    - type: Transform
+      pos: -25.5,21.5
       parent: 2
 - proto: CableApcStack1
   entities:
@@ -21185,30 +21313,15 @@ entities:
     - type: Transform
       pos: -37.5,29.5
       parent: 2
-  - uid: 3714
-    components:
-    - type: Transform
-      pos: -31.5,31.5
-      parent: 2
-  - uid: 3715
-    components:
-    - type: Transform
-      pos: -30.5,31.5
-      parent: 2
-  - uid: 3716
-    components:
-    - type: Transform
-      pos: -29.5,31.5
-      parent: 2
   - uid: 3717
     components:
     - type: Transform
-      pos: -28.5,31.5
+      pos: -30.5,30.5
       parent: 2
   - uid: 3718
     components:
     - type: Transform
-      pos: -27.5,31.5
+      pos: -27.5,32.5
       parent: 2
   - uid: 3734
     components:
@@ -21249,6 +21362,11 @@ entities:
     components:
     - type: Transform
       pos: -9.5,25.5
+      parent: 2
+  - uid: 4374
+    components:
+    - type: Transform
+      pos: -28.5,32.5
       parent: 2
   - uid: 4554
     components:
@@ -23099,6 +23217,121 @@ entities:
     components:
     - type: Transform
       pos: 38.5,52.5
+      parent: 2
+  - uid: 6185
+    components:
+    - type: Transform
+      pos: -29.5,32.5
+      parent: 2
+  - uid: 6186
+    components:
+    - type: Transform
+      pos: -30.5,32.5
+      parent: 2
+  - uid: 13328
+    components:
+    - type: Transform
+      pos: -29.5,30.5
+      parent: 2
+  - uid: 13329
+    components:
+    - type: Transform
+      pos: -28.5,30.5
+      parent: 2
+  - uid: 13330
+    components:
+    - type: Transform
+      pos: -27.5,33.5
+      parent: 2
+  - uid: 13331
+    components:
+    - type: Transform
+      pos: -27.5,34.5
+      parent: 2
+  - uid: 13332
+    components:
+    - type: Transform
+      pos: -27.5,35.5
+      parent: 2
+  - uid: 13333
+    components:
+    - type: Transform
+      pos: -27.5,36.5
+      parent: 2
+  - uid: 13334
+    components:
+    - type: Transform
+      pos: -26.5,36.5
+      parent: 2
+  - uid: 13335
+    components:
+    - type: Transform
+      pos: -26.5,37.5
+      parent: 2
+  - uid: 13336
+    components:
+    - type: Transform
+      pos: -26.5,38.5
+      parent: 2
+  - uid: 13337
+    components:
+    - type: Transform
+      pos: -26.5,39.5
+      parent: 2
+  - uid: 13338
+    components:
+    - type: Transform
+      pos: -26.5,40.5
+      parent: 2
+  - uid: 13339
+    components:
+    - type: Transform
+      pos: -26.5,41.5
+      parent: 2
+  - uid: 13340
+    components:
+    - type: Transform
+      pos: -26.5,42.5
+      parent: 2
+  - uid: 13341
+    components:
+    - type: Transform
+      pos: -26.5,43.5
+      parent: 2
+  - uid: 13342
+    components:
+    - type: Transform
+      pos: -26.5,44.5
+      parent: 2
+  - uid: 13343
+    components:
+    - type: Transform
+      pos: -27.5,44.5
+      parent: 2
+  - uid: 13344
+    components:
+    - type: Transform
+      pos: -27.5,45.5
+      parent: 2
+  - uid: 13345
+    components:
+    - type: Transform
+      pos: -27.5,46.5
+      parent: 2
+  - uid: 13346
+    components:
+    - type: Transform
+      pos: -28.5,46.5
+      parent: 2
+  - uid: 13347
+    components:
+    - type: Transform
+      pos: -29.5,46.5
+      parent: 2
+  - uid: 13348
+    components:
+    - type: Transform
+      pos: -30.5,46.5
       parent: 2
 - proto: CableHVStack1
   entities:
@@ -27466,6 +27699,11 @@ entities:
     - type: Transform
       pos: 35.5,0.5
       parent: 2
+  - uid: 12783
+    components:
+    - type: Transform
+      pos: 33.5,62.5
+      parent: 2
   - uid: 13274
     components:
     - type: Transform
@@ -27510,6 +27748,16 @@ entities:
     components:
     - type: Transform
       pos: 38.5,48.5
+      parent: 2
+  - uid: 13324
+    components:
+    - type: Transform
+      pos: 33.5,60.5
+      parent: 2
+  - uid: 13325
+    components:
+    - type: Transform
+      pos: 33.5,61.5
       parent: 2
 - proto: CableMVStack1
   entities:
@@ -32999,6 +33247,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 15.5,-12.5
       parent: 2
+- proto: ComputerShuttleMining
+  entities:
+  - uid: 12953
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 41.5,-3.5
+      parent: 2
 - proto: ComputerSolarControl
   entities:
   - uid: 2598
@@ -33747,7 +34003,7 @@ entities:
   - uid: 9371
     components:
     - type: Transform
-      pos: 10.5,49.5
+      pos: 10.5,50.5
       parent: 2
   - uid: 10475
     components:
@@ -33822,16 +34078,16 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 8941
           - 9363
+          - 8941
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -34101,6 +34357,33 @@ entities:
           showEnts: False
           occludes: True
           ent: null
+- proto: CrateGenericSteel
+  entities:
+  - uid: 7000
+    components:
+    - type: Transform
+      pos: -17.5,24.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1462
+        moles:
+          Oxygen: 1.606311
+          Nitrogen: 6.042789
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 7004
+          - 7005
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: CrateHydroponicsSeeds
   entities:
   - uid: 3482
@@ -34122,11 +34405,6 @@ entities:
       parent: 2
 - proto: CrateMaterialRandom
   entities:
-  - uid: 2797
-    components:
-    - type: Transform
-      pos: -17.5,24.5
-      parent: 2
   - uid: 3356
     components:
     - type: Transform
@@ -34188,10 +34466,10 @@ entities:
           ent: null
 - proto: CrateScienceSecure
   entities:
-  - uid: 1987
+  - uid: 6352
     components:
     - type: Transform
-      pos: 10.5,50.5
+      pos: 10.5,49.5
       parent: 2
 - proto: CrateSecurityNonlethal
   entities:
@@ -56227,6 +56505,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-14.5
       parent: 2
+  - uid: 12777
+    components:
+    - type: Transform
+      pos: 41.5,-4.5
+      parent: 2
   - uid: 12960
     components:
     - type: Transform
@@ -60347,15 +60630,15 @@ entities:
       parent: 2
 - proto: LootSpawnerRandomCrateEngineering
   entities:
-  - uid: 2626
-    components:
-    - type: Transform
-      pos: -4.5,35.5
-      parent: 2
   - uid: 3239
     components:
     - type: Transform
       pos: -37.5,7.5
+      parent: 2
+  - uid: 12776
+    components:
+    - type: Transform
+      pos: -4.5,35.5
       parent: 2
 - proto: LootSpawnerRoboticsBorgModule
   entities:
@@ -61340,6 +61623,91 @@ entities:
       parent: 2
 - proto: PaperDyedYellow
   entities:
+  - uid: 3714
+    mapInit: true
+    paused: true
+    components:
+    - type: MetaData
+      name: engineering notice
+    - type: Transform
+      pos: -32.31817,25.470943
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-signature
+      stampedBy:
+      - stampLargeIcon: null
+        stampedColor: '#2F4F4FFF'
+        stampedName: Maïka Bellsford
+      content: >-
+        ◥S◣ [mono]Syndicate Engineering Specialists[/mono]
+
+        ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+
+        |            OFFICIAL ENGINEERING NOTICE            |
+
+        ——————————————————————
+
+
+        The old generator is completely... I don't even know what you'd try to repair! But, we asked science to do a bunch of math and they told us that using a singularity to get rid of all the junk in the way IS a viable strategy and WON'T make it get so big and round that it eats its containment and also everything else. But we didn't even get to finish it...
+
+
+        We were gonna just leave it to y'all to figure out what to do, but boss said I gotta write this note. It's not that hard really, we did most of the work, and I spraypainted a bunch of stuff so you know what can go where. Oh, and did you know those emitter bolts go through even plasma glass? And the PA goes through that and reinforced walls!
+
+
+        [color=red]So... emitters on grey squares, generators on yellow squares, field should go over the lines. Clear out anything in the way of the fields, should only be girders, grilles, and maybe that old pod. Throw the singularity generator anywhere in the containment area, even with the extra food it'll stay contained. [/color]
+
+
+        And for the rest... all the shredded walls should do a nice job of protecting everything, but there should be plenty of surplus materials. Whole area is going to be a huge radiation hazard but just let everyone know and it'll be alright!
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - food
+    - type: EmitSoundOnCollide
+      nextSound: -3522.4964775
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.25
+            - 0.25,-0.25
+            - 0.25,0.25
+            - -0.25,0.25
+          mask:
+          - Impassable
+          - HighImpassable
+          layer: []
+          density: 20
+          hard: True
+          restitution: 0.3
+          friction: 0.2
+        flammable:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+            position: 0,0
+          mask:
+          - TableLayer
+          - HighImpassable
+          - LowImpassable
+          - BulletImpassable
+          - InteractImpassable
+          - Opaque
+          layer: []
+          density: 0
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        solution@food: !type:ContainerSlot
+          ent: 3715
+    - type: Forensics
+      residues: []
+      dnas: []
+      fibers:
+      - Tyrian purple durathread fibers ; BE76CDE9CB5F9A
+      fingerprints: []
   - uid: 9349
     components:
     - type: Transform
@@ -61889,6 +62257,10 @@ entities:
     - type: Transform
       pos: 19.5,9.5
       parent: 2
+    - type: TriggerOnProximity
+      shape: !type:PhysShapeCircle
+        radius: 1.5
+        position: 0,0
 - proto: PortableGeneratorJrPacman
   entities:
   - uid: 3170
@@ -63317,6 +63689,11 @@ entities:
     components:
     - type: Transform
       pos: -26.5,9.5
+      parent: 2
+  - uid: 13326
+    components:
+    - type: Transform
+      pos: -25.5,21.5
       parent: 2
 - proto: PoweredLightPostSmallRedAmbient
   entities:
@@ -66644,6 +67021,11 @@ entities:
     - type: Transform
       pos: -4.5,35.5
       parent: 2
+  - uid: 3669
+    components:
+    - type: Transform
+      pos: 43.5,-0.5
+      parent: 2
   - uid: 10484
     components:
     - type: Transform
@@ -66663,11 +67045,6 @@ entities:
     components:
     - type: Transform
       pos: 44.5,6.5
-      parent: 2
-  - uid: 12953
-    components:
-    - type: Transform
-      pos: 41.5,-3.5
       parent: 2
 - proto: RandomSpawner100
   entities:
@@ -68403,10 +68780,10 @@ entities:
       parent: 2
 - proto: SheetPlasma10
   entities:
-  - uid: 2686
+  - uid: 12782
     components:
     - type: Transform
-      pos: -19.597233,34.66762
+      pos: -19.546223,34.67601
       parent: 2
 - proto: SheetPlastic
   entities:
@@ -68422,6 +68799,22 @@ entities:
     - type: Transform
       pos: 12.440855,49.5008
       parent: 2
+  - uid: 7004
+    components:
+    - type: Transform
+      parent: 7000
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 7000
+  - uid: 7005
+    components:
+    - type: Transform
+      parent: 7000
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 7000
 - proto: SheetSteel1
   entities:
   - uid: 2017
@@ -71205,10 +71598,10 @@ entities:
       parent: 2
 - proto: SpawnMobBarPet
   entities:
-  - uid: 12777
+  - uid: 13161
     components:
     - type: Transform
-      pos: 7.5,25.5
+      pos: 13.5,25.5
       parent: 2
 - proto: SpawnMobBunnyStarbuck
   entities:
@@ -71233,10 +71626,10 @@ entities:
       parent: 2
 - proto: SpawnMobEngineeringPet
   entities:
-  - uid: 12776
+  - uid: 3716
     components:
     - type: Transform
-      pos: -30.5,32.5
+      pos: -7.5,31.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:
@@ -71251,27 +71644,6 @@ entities:
     components:
     - type: Transform
       pos: -14.5,54.5
-      parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 3669
-    components:
-    - type: Transform
-      pos: 13.5,25.5
-      parent: 2
-- proto: SpawnMobPossumMorty
-  entities:
-  - uid: 12783
-    components:
-    - type: Transform
-      pos: -6.5,44.5
-      parent: 2
-- proto: SpawnMobRaccoonMorticia
-  entities:
-  - uid: 12782
-    components:
-    - type: Transform
-      pos: 10.5,-8.5
       parent: 2
 - proto: SpawnMobSciencePet
   entities:
@@ -74657,6 +75029,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,10.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - GenpopLeave
+      - - Security
 - proto: UniformPrinterFilled
   entities:
   - uid: 743

--- a/Resources/Maps/_starcup/freighter.yml
+++ b/Resources/Maps/_starcup/freighter.yml
@@ -34429,7 +34429,7 @@ entities:
     - type: Transform
       pos: 8.5,-6.5
       parent: 2
-- proto: CratePlasma
+- proto: CrateMaterialPlasma
   entities:
   - uid: 2629
     components:

--- a/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
+++ b/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
@@ -31,6 +31,16 @@
   showRoundEnd: false
 
 - type: feedbackPopup
+  id: FeedbackPopupMapFreighter
+  popupOrigin: starcup
+  title: "[bold]Map Feedback: Freighter[/bold]"
+  description: |-
+    If you have any thoughts on this map or noticed something wrong, let us know on our forum!
+  responseType: "Forum Thread"
+  responseLink: "https://forum.starcup.cc/t/trimaran-freighter-feedback-thread/444"
+  showRoundEnd: true
+
+- type: feedbackPopup
   id: FeedbackPopupMapGlacier
   popupOrigin: starcup
   title: "[bold]Map Feedback: Glacier[/bold]"
@@ -132,4 +142,4 @@
     And if you encountered any bugs or frustrations during play, please let us know so we can fix them!
   responseType: "Forum Thread"
   responseLink: "https://forum.starcup.cc/t/mkc-feedback-thread/413"
-  showRoundEnd: true
+  showRoundEnd: false


### PR DESCRIPTION
Addresses feedback from [the forum thread](https://forum.starcup.cc/t/trimaran-freighter-feedback-thread/444), and my own notes. Gravity should be more stable now, slightly more decals for the singularity setup, slightly more leniency overall. Adds a note explaining the easiest (and intended) approach to it. 

Adds warp points to the cargo and evac shuttles.

Adds a feedback thread popup and disables the MKC one.

**Changelog**
:cl:
- fix: Minor bugs and issues with Freighter have been resolved. Keep submitting feedback on the forums!
