### PR TITLE
feat: adds more locked windoors and cleans up airlocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -8,7 +8,7 @@
   id: WindoorSecure
   parent: BaseSecureWindoor
   name: secure windoor
-  description: It's a sturdy window and a sliding door. Wow!
+  description: It's a sturdy window and a sliding door that stays open when activated. Wow! # starcup - clarify functionality
 
 - type: entity
   id: WindoorClockwork
@@ -26,7 +26,7 @@
   id: WindoorSecurePlasma
   parent: BaseSecurePlasmaWindoor
   name: secure plasma windoor
-  description: It's a sturdy purple window *and* a sliding door. Spectacular!
+  description: It's a sturdy purple window *and* a sliding door that stays open when activated. Spectacular! # starcup - clarify functionality
 
 - type: entity
   id: WindoorUranium
@@ -38,7 +38,7 @@
   id: WindoorSecureUranium
   parent: BaseSecureUraniumWindoor
   name: secure uranium windoor
-  description: It's a sturdy window and a sliding door. It's so neon green, it might even taste like limes!
+  description: It's a sturdy window and a sliding door that stays open when activated. It's so neon green, it might even taste like limes! # starcup - clarify functionality
 
 # TODO remove these with parameterized prototypes/whatever we end up doing
 # Windoors (alphabetical)

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/Windoors/windoor.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/Windoors/windoor.yml
@@ -50,16 +50,6 @@
     containers:
       board: [ DoorElectronicsQuartermaster ]
 
-## RD
-- type: entity
-  parent: WindoorSecureCommandLocked
-  id: WindoorSecureResearchDirectorLocked
-  suffix: ResearchDirector, Locked
-  components:
-  - type: ContainerFill
-    containers:
-      board: [ DoorElectronicsResearchDirector ]
-
   # Medical
 
 ## Paramedic

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/Windoors/windoor.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/Windoors/windoor.yml
@@ -1,66 +1,68 @@
+  # Command
+
+## Captain
 - type: entity
-  parent: WindoorSecureServiceLocked
-  id: WindoorSecureBoxerLocked
-  suffix: Boxer, Locked
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureCaptainLocked
+  suffix: Captain, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsBoxer ]
+      board: [ DoorElectronicsCaptain ]
 
+## Chief Engineer
 - type: entity
-  parent: WindoorSecureSecurityLocked
-  id: WindoorSecureBrigmedicLocked
-  suffix: Combat Medic, Locked
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureChiefEngineerLocked
+  suffix: ChiefEngineer, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsBrigmedic ]
+      board: [ DoorElectronicsChiefEngineer ]
 
+## CMO
 - type: entity
-  parent: WindoorSecureServiceLocked
-  id: WindoorSecureClownLocked
-  suffix: Clown, Locked
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureChiefMedicalOfficerLocked
+  suffix: ChiefMedicalOfficer, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsClown ]
+      board: [ DoorElectronicsChiefMedicalOfficer ]
 
+## HoS
 - type: entity
-  parent: WindoorSecureServiceLocked
-  id: WindoorSecureHydroponicsLocked
-  suffix: Hydroponics, Locked
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureHeadOfSecurityLocked
+  suffix: HeadOfSecurity, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsHydroponics ]
+      board: [ DoorElectronicsHeadOfSecurity ]
 
+## Chief Engineer
 - type: entity
-  parent: WindoorSecureServiceLocked
-  id: WindoorSecureLibraryLocked
-  suffix: Library, Locked
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureQuartermasterLocked
+  suffix: Quartermaster, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsLibrary ]
+      board: [ DoorElectronicsQuartermaster ]
 
+## RD
 - type: entity
-  parent: WindoorSecureServiceLocked
-  id: WindoorSecureMimeLocked
-  suffix: Mime, Locked
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureResearchDirectorLocked
+  suffix: ResearchDirector, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsMime ]
+      board: [ DoorElectronicsResearchDirector ]
 
-- type: entity
-  parent: WindoorSecureServiceLocked
-  id: WindoorSecureMusicianLocked
-  suffix: Musician, Locked
-  components:
-  - type: ContainerFill
-    containers:
-      board: [ DoorElectronicsMusician ]
+  # Medical
 
+## Paramedic
 - type: entity
   parent: WindoorSecureSecurityLocked
   id: WindoorSecureParamedicLocked
@@ -70,6 +72,7 @@
     containers:
       board: [ DoorElectronicsParamedic ]
 
+## Psychologist
 - type: entity
   parent: WindoorSecureMedicalLocked
   id: WindoorSecurePsychologistLocked
@@ -79,6 +82,81 @@
     containers:
       board: [ DoorElectronicsPsychologist ]
 
+  # Security
+
+## Combat Medic
+- type: entity
+  parent: WindoorSecureSecurityLocked
+  id: WindoorSecureBrigmedicLocked
+  suffix: Combat Medic, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBrigmedic ]
+
+  # Service
+
+## Boxer
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureBoxerLocked
+  suffix: Boxer, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
+
+## Clown
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureClownLocked
+  suffix: Clown, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
+
+## Botanist
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureHydroponicsLocked
+  suffix: Hydroponics, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsHydroponics ]
+
+## Librarian
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureLibraryLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+
+## Mime
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureMimeLocked
+  suffix: Mime, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
+
+## Musician
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureMusicianLocked
+  suffix: Musician, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
+
+## Reporter
 - type: entity
   parent: WindoorSecureServiceLocked
   id: WindoorSecureReporterLocked
@@ -88,6 +166,7 @@
     containers:
       board: [ DoorElectronicsReporter ]
 
+  # SyndComm
 - type: entity
   parent: WindoorSecureCommandLocked
   id: WindoorSecureSyndicateCommunicationsLocked

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
@@ -73,7 +73,7 @@
     containers:
       board: [ DoorElectronicsParamedic ]
   - type: Sprite
-    sprite: _starcup/Structures/Doors/Airlocks/Standard/paramedic.rsi
+    sprite: _starcup/Structures/Doors/Airlocks/Glass/paramedic.rsi
 
 - type: entity
   parent: AirlockMedicalLocked

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -269,7 +269,7 @@
       sprite: _starcup/Structures/Doors/Airlocks/Standard/unpainted.rsi
 
 - type: entity
-  parent: Airlock
+  parent: AirlockGlass
   id: AirlockUnpaintedGlass
   suffix: Unpainted
   description: It opens, it closes, and maybe crushes you. This one seems to be unpainted.
@@ -282,7 +282,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintCargo
-  suffix: Logistics, Maintenance
+  suffix: Logistics, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_cargo.rsi
@@ -292,7 +292,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintCommand
-  suffix: Command, Maintenance
+  suffix: Command, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_command.rsi
@@ -300,7 +300,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintEngineering
-  suffix: Engineering, Maintenance
+  suffix: Engineering, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_engineering.rsi
@@ -310,7 +310,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintMedical
-  suffix: Maintenance, Medical
+  suffix: Medical, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_medical.rsi
@@ -320,7 +320,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintScience
-  suffix: Maintenance, Science
+  suffix: Science, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_science.rsi
@@ -330,7 +330,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintSecurity
-  suffix: Maintenance, Security
+  suffix: Security, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_security.rsi
@@ -340,7 +340,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintService
-  suffix: Maintenance, Service
+  suffix: Service, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_service.rsi
@@ -350,7 +350,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintJustice
-  suffix: Justice, Maintenance
+  suffix: Justice, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_justice.rsi
@@ -360,7 +360,7 @@
 - type: entity
   parent: AirlockSyndicate
   id: AirlockMaintSyndicate
-  suffix: Maintenance, Syndicate
+  suffix: Syndicate, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_syndicate.rsi
@@ -368,7 +368,7 @@
 - type: entity
   parent: AirlockMaintScience
   id: AirlockMaintRnDMed
-  suffix: Maintenance, Medical, Science # ??
+  suffix: Medical/Science, Unlocked
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_medical.rsi
@@ -428,6 +428,7 @@
 - type: entity
   parent: AirlockCommandGlass
   id: AirlockChiefMedicalOfficerGlass
+  suffix: ChiefMedicalOfficer
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Glass/command_cmo.rsi
@@ -435,6 +436,7 @@
 - type: entity
   parent: AirlockCommandGlass
   id: AirlockChiefEngineerGlass
+  suffix: ChiefEngineer
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Glass/command_ce.rsi
@@ -442,6 +444,7 @@
 - type: entity
   parent: AirlockCommandGlass
   id: AirlockHeadOfSecurityGlass
+  suffix: HeadOfSecurity
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Glass/command_hos.rsi
@@ -449,6 +452,7 @@
 - type: entity
   parent: AirlockCommandGlass
   id: AirlockResearchDirectorGlass
+  suffix: ResearchDirector
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Glass/command_rd.rsi
@@ -456,6 +460,7 @@
 - type: entity
   parent: AirlockCommandGlass
   id: AirlockHeadOfPersonnelGlass
+  suffix: HeadOfPersonnel
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Glass/command_hop.rsi
@@ -463,6 +468,7 @@
 - type: entity
   parent: AirlockCommandGlass
   id: AirlockQuartermasterGlass
+  suffix: Quartermaster
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Glass/command_qm.rsi

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -282,7 +282,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintCargo
-  name: logistics maintenance access
+  suffix: Logistics, Maintenance
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_cargo.rsi
@@ -292,7 +292,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintCommand
-  name: command maintenance access
+  suffix: Command, Maintenance
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_command.rsi
@@ -300,7 +300,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintEngineering
-  name: engineering maintenance access
+  suffix: Engineering, Maintenance
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_engineering.rsi
@@ -310,7 +310,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintMedical
-  name: medical maintenance access
+  suffix: Maintenance, Medical
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_medical.rsi
@@ -320,7 +320,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintScience
-  name: science maintenance access
+  suffix: Maintenance, Science
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_science.rsi
@@ -330,7 +330,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintSecurity
-  name: security maintenance access
+  suffix: Maintenance, Security
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_security.rsi
@@ -340,7 +340,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintService
-  name: service maintenance access
+  suffix: Maintenance, Service
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_service.rsi
@@ -350,7 +350,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintJustice
-  name: justice maintenance access
+  suffix: Justice, Maintenance
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_justice.rsi
@@ -360,7 +360,7 @@
 - type: entity
   parent: AirlockSyndicate
   id: AirlockMaintSyndicate
-  name: syndicate maintenance access
+  suffix: Maintenance, Syndicate
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_syndicate.rsi
@@ -368,7 +368,7 @@
 - type: entity
   parent: AirlockMaintScience
   id: AirlockMaintRnDMed
-  name: RD/medical maintenance access
+  suffix: Maintenance, Medical, Science # ??
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/maint_medical.rsi
@@ -378,6 +378,7 @@
 - type: entity
   parent: AirlockCommand
   id: AirlockChiefMedicalOfficer
+  suffix: ChiefMedicalOfficer
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/command_cmo.rsi
@@ -385,6 +386,7 @@
 - type: entity
   parent: AirlockCommand
   id: AirlockChiefEngineer
+  suffix: ChiefEngineer
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/command_ce.rsi
@@ -392,6 +394,7 @@
 - type: entity
   parent: AirlockCommand
   id: AirlockHeadOfSecurity
+  suffix: HeadOfSecurity
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/command_hos.rsi
@@ -399,6 +402,7 @@
 - type: entity
   parent: AirlockCommand
   id: AirlockResearchDirector
+  suffix: ResearchDirector
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/command_rd.rsi
@@ -406,6 +410,7 @@
 - type: entity
   parent: AirlockCommand
   id: AirlockHeadOfPersonnel
+  suffix: HeadOfPersonnel
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/command_hop.rsi
@@ -413,6 +418,7 @@
 - type: entity
   parent: AirlockCommand
   id: AirlockQuartermaster
+  suffix: Quartermaster
   components:
     - type: Sprite
       sprite: _starcup/Structures/Doors/Airlocks/Standard/command_qm.rsi


### PR DESCRIPTION
This PR adds new secure windoor prototypes for the various command members, who formerly had to rely on the blanket Command windoor or else go without.

It also changes the examinetext of the three secure windoors to note that the door stays open when activated.

Finally, it renames various unlocked maintenance airlocks, adds suffixes where they were missing, and reparents the unpainted glass airlock to be transparent.

## Why / Balance
Because mapped access modifications don't tend to stick around, department heads' offices just weren't able to use windoors without giving every other member of Command access. Head of Personnel and RD were the sole exceptions, which is a pairing I don't fully understand. It feels like it probably wasn't deliberate.

Regardless, I think it unnecessarily limits mappers' options, particularly for maps like Crux in which department heads might have a front "meeting room" and a rear bedroom with the secure stuff.

As for the description, I've spoken with a lot of people who don't realize secure windoors will stay open if you click on them rather than opening via bumping. I'm still not sure my new text makes it 100% clear, but at least it hints at the functionality.

**Changelog**
:cl:
- tweak: Clarified the descriptions for secure windoors.
- fix: Unpainted glass airlocks are no longer opaque.
- fix: Paramedic's glass airlock now has the right sprite.

**Non-Player-Facing Changelog**
- add: Added secure windoors for all department heads!