### PR TITLE
map(EventCharonEpsilon): adds evac/ATS, tweaks planet entities

### DIFF
--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml
@@ -50,7 +50,7 @@ entities:
     - type: SpreaderGrid
     - type: Shuttle
       dampingModifier: 0.25
-    - type: ImplicitRoof
+    - type: Roof
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -111,6 +111,7 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: TradeStation
 - proto: APCBasic
   entities:
   - uid: 2

--- a/Resources/Maps/_starcup/Events/silent_moon_surface_station.yml
+++ b/Resources/Maps/_starcup/Events/silent_moon_surface_station.yml
@@ -1521,7 +1521,7 @@ entities:
     - type: Transform
       pos: 13.5,13.5
       parent: 2
-- proto: AirlockExternalGlassShuttleCharonEpsilonFilled
+- proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
   - uid: 36
     components:
@@ -6514,7 +6514,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.76737,-21.819317
       parent: 2
-- proto: ChemistryBottleNecrosol
+- proto: ChemistryBottleSigynate
   entities:
   - uid: 954
     components:
@@ -6876,7 +6876,7 @@ entities:
     - type: Transform
       pos: 20.5,-0.5
       parent: 2
-- proto: ComputerShuttleMiningGlacier
+- proto: ComputerBroken
   entities:
   - uid: 1006
     components:
@@ -14433,7 +14433,7 @@ entities:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-- proto: SpawnMobSmile
+- proto: SpawnMobSlimeGloom
   entities:
   - uid: 2114
     components:
@@ -17059,7 +17059,7 @@ entities:
       pos: 12.5,-1.5
       parent: 2
     - type: WarpPoint
-      location: Glacier Surface Outpost
+      location: Charon-Epsilon Surface Outpost
 - proto: WaterTankFull
   entities:
   - uid: 2510

--- a/Resources/Maps/_starcup/Shuttles/silent_moon_surface_shuttle.yml
+++ b/Resources/Maps/_starcup/Shuttles/silent_moon_surface_shuttle.yml
@@ -401,7 +401,7 @@ entities:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-- proto: ComputerShuttleMiningGlacier
+- proto: ComputerEmergencyShuttle
   entities:
   - uid: 48
     components:

--- a/Resources/Prototypes/_starcup/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/_starcup/Entities/Effects/mobspawn.yml
@@ -105,8 +105,8 @@
       - id: MobRandomCargoCorpse
 
     # dangerous effects
-    - id: Kudzu
-      weight: 0.03
+#    - id: Kudzu
+#      weight: 0.03
 
     - id: MobSpawnCharonicSlime
       weight: 0.02
@@ -121,8 +121,8 @@
     - !type:GroupSelector
       weight: 0.004
       children:
-      - id: AnomalyShadow
-      - id: AnomalyFlora
+      - id: AnomalyInjectionShadow
+      - id: AnomalyInjectionFlora
         weight: 0.2
 
 - type: entity

--- a/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
+++ b/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
@@ -54,3 +54,25 @@
   - BaseStationEvacuation
   - BaseStationAllEventsEligible
   categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: StandardTerrestrialStationTradingCharonic
+  parent:
+  - StandardTerrestrialStation
+  - BaseTerrestrialStationTradingCharonic
+  - BaseStationExpeditions
+  categories: [ HideSpawnMenu ]
+
+# Terrestrial Stations with a surface trading outpost
+- type: entity
+  id: BaseTerrestrialStationTradingCharonic
+  abstract: true
+  components:
+  - type: GridSpawn
+    groups:
+      trade: !type:GridSpawnGroup
+        addComponents:
+        - type: ProtectedGrid
+        - type: TradeStation
+        paths:
+        - /Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml

--- a/Resources/Prototypes/_starcup/Entities/Tiles/mute_water.yml
+++ b/Resources/Prototypes/_starcup/Entities/Tiles/mute_water.yml
@@ -9,7 +9,7 @@
   components:
   - type: StepTrigger
     requiredTriggeredSpeed: 0
-    intersectRatio: 0.1
+    intersectRatio: 0.25 # more forgiving than lava/plasma since it's less visually obvious
     blacklist:
       tags:
         - Catwalk

--- a/Resources/Prototypes/_starcup/Maps/Event/event-silent-moon.yml
+++ b/Resources/Prototypes/_starcup/Maps/Event/event-silent-moon.yml
@@ -8,13 +8,15 @@
   maxPlayers: 60
   stations:
     EventSilentMoon:
-      stationProto: StandardTerrestrialStationNoEvac
+      stationProto: StandardTerrestrialStationTradingCharonic
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Charon-Epsilon Surface Outpost'
       - type: StationBiome
         biome: Charonic
         mapLightColor: "#2B3153"
+      - type: StationEmergencyShuttle
+        emergencyShuttlePath: /Maps/_starcup/Shuttles/silent_moon_surface_shuttle.yml
       - type: StationJobs
         availableJobs:
           #Command


### PR DESCRIPTION
This PR makes a handful of small tweaks to the Charon-Epsilon event map and various Charon-Epsilon threats.
- Increased dark water's intersectRatio from 0.1 to 0.25
- Hollow trees now only spawn infection-type anomalies, instead of normal ones.
- Hollow trees no longer spawn kudzu.
- Took away Chemistry's necrosol and gave them some sigynate
- **Gave Charon-Epsilon Surface Station a standard Automated Trade Outpost.**
- **Made the surface shuttle function like an evac shuttle.** The Bridge still lacks a communications console.
- Replaced Smile with Gloom.

## Why / Balance
Charon-Epsilon is a very dangerous and stressful planet, so these changes are aimed at dialing a few mechanics back. Dark water should be _slightly_ more forgiving now, hollow trees will only produce anomalies you can relocate to somewhere powered, and kudzu (extremely disruptive on a wide-open planet) is gone. Sigynate helps with dark water's unusual damage type, and Gloom is important for morale.

The ATO change should be uncontroversial--it's basically what we intended, we just didn't have it set up yet. We might want to give Cargo a mass scanner or two to help them find it, but heck, they'll figure it out, they're smart cookies.

*The grids do still need to get their names fixed and stuff, but this is a bare-bones patch for events only.*

The evac shuttle is probably the hardest call here--it means we can't as easily do things like "recover an ftl disk and stick it in the surface shuttle", and it eliminates the "orbital station" idea. On the other hand, it greatly simplifies the matter of escape from the admin side of things, since we no longer have to worry about providing an FTL disk and helping the crew dock at SyndComm.

*The shuttle will sometimes spawn in trees and/or dark water and/or decals, since the StationBiome system doesn't have the planetary grid protection code. GMs can fix that manually.*

## Technical details
Adds new terrestrial station prototypes for spawning the ATS. This might do with more refinement when more "proper" terrestrial station maps come out.

## Media
:jack_o_lantern: :jack_o_lantern: :jack_o_lantern: 

**Changelog**
No player-facing changes, as this is purely an event map.