### PR TITLE
fix: harpys can now host an anomaly

### DIFF
--- a/Resources/Prototypes/_DV/Body/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Species/harpy.yml
@@ -246,7 +246,7 @@
     - CanPilot
     - FootstepSound
     - DoorBumpOpener
-    - AnomalyHost
+    - AnomalyHost # starcup: added anomaly host
   - type: FootprintOwner # starcup
     footprint: lizardFootprint # starcup
 

--- a/Resources/Prototypes/_DV/Body/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Species/harpy.yml
@@ -246,6 +246,7 @@
     - CanPilot
     - FootstepSound
     - DoorBumpOpener
+    - AnomalyHost
   - type: FootprintOwner # starcup
     footprint: lizardFootprint # starcup
 


### PR DESCRIPTION
Fixes the tags on the Harpy race so that they can now also host anomaly's

## Why / Balance
Harpies should also be able to host anomaly's it doesnt make sense that they can't.

**Changelog**
:cl:
- fix: gave harpy's the AnomalyHost tag
