### PR TITLE
feat: breaks the Trinkets loadout category up a bit

### DIFF
--- a/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_starcup/preferences/loadout-groups.ftl
@@ -103,3 +103,4 @@ loadout-group-prisoner-outerclothing = Prisoner outer clothing
 loadout-group-plushies = Plushies
 loadout-group-survival-brigmedic = Combat Medic Survival Box
 loadout-group-accessibility = Accessibility
+loadout-group-cosmetics = Cosmetics

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -2,14 +2,14 @@
 - type: loadoutGroup
   # begin starcup: use parenting for our additions
   parent:
-  - Plushies
+#  - Plushies
   - TrinketsBureaucracy
   - TrinketsLighter
   - TrinketsUtility
   - TrinketsTreat
   - TrinketsToy
-  - TrinketsCosmetic
-  - TrinketsTowel
+#  - TrinketsCosmetic
+#  - TrinketsTowel
   - TrinketsInstrument
   # end starcup
   id: Trinkets
@@ -17,49 +17,53 @@
   minLimit: 0
   maxLimit: 3
   loadouts:
-  - FlowerWreath
-  - Hairflower
-  - Headphones
-  - PlushieLizard
-  - PlushieSpaceLizard
+# begin starcup: moved to Cosmetics/Plushies
+#  - FlowerWreath
+#  - Hairflower
+#  - Headphones
+#  - PlushieLizard
+#  - PlushieSpaceLizard
   - ThreeCandles
   - Lighter
-  - CigPackGreen
-  - CigPackRed
-  - CigPackBlue
-  - CigPackBlack
-  - CigarCase
-  - CigarGold
-  #- BoxFolderBaseThreePapers # starcup: replaced with specific colored folders by TrinketsBureaucracy
+# begin starcup: moved to Accessibility
+#  - CigPackGreen
+#  - CigPackRed
+#  - CigPackBlue
+#  - CigPackBlack
+#  - CigarCase
+#  - CigarGold
+#  - BoxFolderBaseThreePapers # replaced with specific colored folders by TrinketsBureaucracy
+# end starcup
   - BoxFolderPlasticClipboardThreePapers
   - BoxFolderClipboardThreePapers
-  - ClothingNeckLGBTPin
-  - ClothingNeckAllyPin
-  - ClothingNeckAromanticPin
-  - ClothingNeckAsexualPin
-  - ClothingNeckAroacePin
-  - ClothingNeckBisexualPin
-  - ClothingNeckGayPin
-  - ClothingNeckIntersexPin
-  - ClothingNeckLesbianPin
-  - ClothingNeckNonBinaryPin
-  - ClothingNeckPansexualPin
-  - ClothingNeckPluralPin
-  - ClothingNeckOmnisexualPin
-  - ClothingNeckGenderqueerPin
-  - ClothingNeckGenderfluidPin
-  - ClothingNeckTransPin
-  - ClothingNeckAutismPin
-  - ClothingNeckGoldAutismPin
-  # begin starcup: moved to Accessibility
+# begin starcup: moved to Cosmetics
+#  - ClothingNeckLGBTPin
+#  - ClothingNeckAllyPin
+#  - ClothingNeckAromanticPin
+#  - ClothingNeckAsexualPin
+#  - ClothingNeckAroacePin
+#  - ClothingNeckBisexualPin
+#  - ClothingNeckGayPin
+#  - ClothingNeckIntersexPin
+#  - ClothingNeckLesbianPin
+#  - ClothingNeckNonBinaryPin
+#  - ClothingNeckPansexualPin
+#  - ClothingNeckPluralPin
+#  - ClothingNeckOmnisexualPin
+#  - ClothingNeckGenderqueerPin
+#  - ClothingNeckGenderfluidPin
+#  - ClothingNeckTransPin
+#  - ClothingNeckAutismPin
+#  - ClothingNeckGoldAutismPin
+# moved to Accessibility
   #- OffsetCane
   #- OffsetCaneWood
   #- OffsetCaneClown
   #- OffsetCaneMime
   #- OffsetCaneNT
   #- Cane
-  # end starcup
-  - TowelColorWhite
+#  - TowelColorWhite # starcup: moved to Cosmetics
+# end starcup
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -11,8 +11,10 @@
 # - Eyewear/Glasses
 # - PDA
 # - Accessibility
+# - Cosmetics
 # - Trinkets
 # - Job Trinkets
+# - Plushies
 # - Other Job Items (golden plunger, instruments, janitor flashlight, etc)
 # - Survival
 # - GroupSpeciesBreathTool
@@ -31,8 +33,10 @@
   - CommandEyewear # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - CaptainJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -47,8 +51,10 @@
   - CommandEyewear # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - HoPJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -79,8 +85,10 @@
   - PassengerID # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - PassengerJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   # - GroupTankHarness # starcup: removed for conflicting with new outer clothing options
 
@@ -96,8 +104,10 @@
   - BartenderEyewear # starcup
   - BartenderID # starcup
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - BartenderJobTrinkets
+  - Plushies # starcup
   - Survival
   - GroupSpeciesBreathTool
   - GroupTankHarness
@@ -114,8 +124,10 @@
   - ServiceWorkerEyewear # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ServiceWorkerJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -133,8 +145,10 @@
   - ChefID # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ChefJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -149,8 +163,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - LibrarianJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -165,8 +181,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - LawyerJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -185,8 +203,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ChaplainJobTrinkets # starcup
+  - Plushies # starcup
   - ChaplainRelic # starcup
   #- ChaplainBible # starcup: removed due to bible rework
   - GroupSpeciesBreathTool
@@ -206,8 +226,10 @@
   - Glasses
   - JanitorID # starcup
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - JanitorJobTrinkets
+  - Plushies # starcup
   - JanitorLight # starcup: adds a choice between flashlights/lanterns. who goers there
   - Survival
   - GroupSpeciesBreathTool
@@ -225,8 +247,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - BotanistJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -244,8 +268,10 @@
   - Glasses
   - ClownID # starcup
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ClownJobTrinkets
+  - Plushies # starcup
   - SurvivalClown
   - GroupTankHarness
 
@@ -264,8 +290,10 @@
   - Glasses
   - SurvivalMime
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - MimeJobTrinkets # starcup
+  - Plushies # starcup
   - GroupTankHarness
 
 - type: roleLoadout
@@ -280,8 +308,10 @@
   - MusicianEyewear # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - MusicianJobTrinkets # starcup
+  - Plushies # starcup
   - Instruments
   - GroupSpeciesBreathTool
   - GroupTankHarness
@@ -299,8 +329,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - LogisticsOfficerJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -317,8 +349,10 @@
   - CargoTechnicianID
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - CargoTechnicianJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -333,8 +367,10 @@
   - SalvageSpecialistID # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - SalvageSpecialistJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -350,8 +386,10 @@
   - ChiefEngineerShoes
   - SurvivalExtended
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ChiefEngineerJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -366,8 +404,10 @@
   - Glasses # starcup
   - SurvivalExtended
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - TechnicalAssistantJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -383,8 +423,10 @@
   - StationEngineerID
   - SurvivalExtended
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - StationEngineerJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -400,8 +442,10 @@
   - AtmosphericTechnicianID # starcup
   - SurvivalExtended
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - AtmosphericTechnicianJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -419,8 +463,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ResearchDirectorJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -438,8 +484,10 @@
   - ScientistPDA
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ScientistJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -454,8 +502,10 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ResearchAssistantJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -475,8 +525,10 @@
   - SecurityEyewear # starcup
   - SurvivalSecurity
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - HeadofSecurityJobTrinkets
+  - Plushies # starcup
   - SecurityAllFirearm # starcup
   - SecurityAllAmmo # starcup
   - GroupSpeciesBreathToolSecurity
@@ -495,8 +547,10 @@
   - SecurityEyewear # starcup
   - SurvivalSecurity
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - WardenJobTrinkets
+  - Plushies # starcup
   - SecurityAllFirearm # starcup
   - SecurityAllAmmo # starcup
   - GroupSpeciesBreathToolSecurity
@@ -516,8 +570,10 @@
   - SecurityPDA
   - SurvivalSecurity
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - SecurityJobTrinkets
+  - Plushies # starcup
   - SecurityFirearm # starcup
   - SecurityFirearmAmmo # starcup
   - GroupSpeciesBreathToolSecurity
@@ -535,8 +591,10 @@
   - SecurityEyewear # starcup
   - SurvivalSecurity
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - DetectiveJobTrinkets
+  - Plushies # starcup
   - SecurityRevolverFirearm # starcup
   - SecurityRevolverAmmo # starcup
   - GroupSpeciesBreathToolSecurity
@@ -554,8 +612,10 @@
   - SecurityEyewear # starcup
   - SurvivalSecurity
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - SecurityCadetJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathToolSecurity
 
 # Wildcards
@@ -571,8 +631,10 @@
   - ReporterEyewear # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - ReporterJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -587,8 +649,10 @@
   - PsychologistID # starcup
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - PsychologistJobTrinkets # starcup
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -11,8 +11,10 @@
 # - PDA
 # - Survival
 # - Accessibility
+# - Cosmetics
 # - Trinkets
 # - Job Trinkets
+# - Plushies
 # - Other Job Items (golden plunger, instruments, janitor flashlight, etc)
 # - GroupSpeciesBreathTool
 # - GroupTankHarness
@@ -31,7 +33,9 @@
   - Glasses # starcup
   - CourierPDA
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
+  - Plushies # starcup
   - Survival
   - GroupSpeciesBreathTool
   - GroupTankHarness
@@ -48,7 +52,9 @@
   - Glasses
   - Survival
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
+  - Plushies # starcup
   - GroupSpeciesBreathTool
   - GroupTankHarness
 
@@ -66,8 +72,10 @@
   - RoboticsEyewear # starcup
   - RoboticistPDA # starcup
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
   - RoboticsJobTrinkets # starcup
+  - Plushies
   - Survival
   - GroupSpeciesBreathTool
   - GroupTankHarness

--- a/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
@@ -35,6 +35,7 @@
   loadouts:
   - AACTablet
   - HandheldStationMap
+  - NoviceMark
   - OffsetCane
   - OffsetCaneWood
   - OffsetCaneClown
@@ -53,7 +54,6 @@
   - CigPackBlack
   - CigarCase
   - CigarGold
-  - NoviceMark
 
 - type: loadoutGroup
   parent:

--- a/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
@@ -63,7 +63,7 @@
   id: Cosmetics
   name: loadout-group-cosmetics
   minLimit: 0
-  maxLimit: 4
+  maxLimit: 3
   loadouts:
   - FlowerWreath
   - Hairflower

--- a/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
@@ -47,9 +47,50 @@
   - PillCanisterCalmafluxineLoadout
   - PillCanisterEthyloxyephedrineLoadout
   - PillCanisterAgonolexyneLoadout
+  - CigPackGreen
+  - CigPackRed
+  - CigPackBlue
+  - CigPackBlack
+  - CigarCase
+  - CigarGold
+  - NoviceMark
+
+- type: loadoutGroup
+  parent:
+  - CosmeticsPridePin
+  - CosmeticsJewelry
+  - CosmeticsTowel
+  id: Cosmetics
+  name: loadout-group-cosmetics
+  minLimit: 0
+  maxLimit: 4
+  loadouts:
+  - FlowerWreath
+  - Hairflower
+  - Headphones
 
 # Abstract Groups (for parenting purposes)
-## Trinkets
+## Plushies
+- type: loadoutGroup
+  abstract: true
+  id: PlushiesWorn
+  loadouts:
+  - PlushieLizardWorn
+  - PlushieSpaceLizardWorn
+  - PlushieLizardInversedWorn
+  - PlushieBeeWorn
+  - PlushieExperimentWorn
+  - PlushieHampterWorn
+  - PlushiePenguinWorn
+  - PlushieArachnidWorn
+  - PlushieDionaWorn
+  - PlushieMothWorn
+  - PlushieSlimeWorn
+  - PlushieVoxWorn
+  - PlushieVulpWorn
+  - PlushieRounyWorn
+  - PlushieXenoWorn
+  - PlushieZetan
 
 - type: loadoutGroup
   abstract: true
@@ -76,27 +117,7 @@
   - PlushieXeno
   - PlushieZetan
 
-- type: loadoutGroup
-  abstract: true
-  id: PlushiesWorn
-  loadouts:
-  - PlushieLizardWorn
-  - PlushieSpaceLizardWorn
-  - PlushieLizardInversedWorn
-  - PlushieBeeWorn
-  - PlushieExperimentWorn
-  - PlushieHampterWorn
-  - PlushiePenguinWorn
-  - PlushieArachnidWorn
-  - PlushieDionaWorn
-  - PlushieMothWorn
-  - PlushieSlimeWorn
-  - PlushieVoxWorn
-  - PlushieVulpWorn
-  - PlushieRounyWorn
-  - PlushieXenoWorn
-  - PlushieZetan
-
+## Trinkets
 - type: loadoutGroup
   abstract: true
   id: TrinketsBureaucracy
@@ -131,7 +152,6 @@
   id: TrinketsUtility
   loadouts:
   - TapeRecorder
-  - NoviceMark
 
 - type: loadoutGroup
   abstract: true
@@ -147,7 +167,21 @@
 
 - type: loadoutGroup
   abstract: true
-  id: TrinketsCosmetic
+  id: TrinketsInstrument
+  loadouts:
+  - AcousticGuitar
+  - Flute
+  - PanFlute
+  - Ocarina
+  - Harmonica
+  - MusicBox
+  - Kalimba
+  - Woodblock
+
+## Cosmetics (primarily worn trinkets)
+- type: loadoutGroup
+  abstract: true
+  id: CosmeticsJewelry
   loadouts:
   - CDDogtags
   - HeartLocket
@@ -156,7 +190,30 @@
 
 - type: loadoutGroup
   abstract: true
-  id: TrinketsTowel
+  id: CosmeticsPridePin
+  loadouts:
+  - ClothingNeckLGBTPin
+  - ClothingNeckAllyPin
+  - ClothingNeckAromanticPin
+  - ClothingNeckAsexualPin
+  - ClothingNeckAroacePin
+  - ClothingNeckBisexualPin
+  - ClothingNeckGayPin
+  - ClothingNeckIntersexPin
+  - ClothingNeckLesbianPin
+  - ClothingNeckNonBinaryPin
+  - ClothingNeckPansexualPin
+  - ClothingNeckPluralPin
+  - ClothingNeckOmnisexualPin
+  - ClothingNeckGenderqueerPin
+  - ClothingNeckGenderfluidPin
+  - ClothingNeckTransPin
+  - ClothingNeckAutismPin
+  - ClothingNeckGoldAutismPin
+
+- type: loadoutGroup
+  abstract: true
+  id: CosmeticsTowel
   loadouts:
   - TowelColorGray
   - TowelColorBlack
@@ -173,19 +230,7 @@
   - TowelColorMime
   - TowelColorSilver
   - TowelColorGold
-
-- type: loadoutGroup
-  abstract: true
-  id: TrinketsInstrument
-  loadouts:
-  - AcousticGuitar
-  - Flute
-  - PanFlute
-  - Ocarina
-  - Harmonica
-  - MusicBox
-  - Kalimba
-  - Woodblock
+  - TowelColorWhite
 
 ## Clothes
 - type: loadoutGroup

--- a/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
@@ -96,6 +96,8 @@
   abstract: true
   id: Plushies
   loadouts:
+  - PlushieLizard
+  - PlushieSpaceLizard
   - PlushieLizardInversed
   - PlushieBee
   - PlushieSnake

--- a/Resources/Prototypes/_starcup/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/role_loadouts.yml
@@ -11,8 +11,10 @@
 # - PDA
 # - Survival
 # - Accessibility
+# - Cosmetics
 # - Trinkets
 # - Job Trinkets
+# - Plushies
 # - Other Job Items (golden plunger, instruments, janitor flashlight, etc)
 # - GroupSpeciesBreathTool
 # - GroupTankHarness
@@ -29,7 +31,9 @@
   - AdminAssistantShoes
   - CommandEyewear
   - Accessibility
+  - Cosmetics
   - Trinkets
+  - Plushies
   - Survival
   - GroupSpeciesBreathTool
 
@@ -46,7 +50,9 @@
   - BrigmedicGloves
   - BrigmedicShoes
   - Accessibility
+  - Cosmetics
   - Trinkets
+  - Plushies
   - SecurityFirearm
   - SecurityFirearmAmmo
   - SurvivalBrigmedic
@@ -64,8 +70,10 @@
   - BoxerShoes
   - Glasses
   - Accessibility
+  - Cosmetics
   - Trinkets
   - BoxerJobTrinkets
+  - Plushies
   - BoxerWeapon
   - Survival
   - GroupSpeciesBreathTool
@@ -83,6 +91,7 @@
   - Glasses
   - Survival
   - Accessibility
+  - Cosmetics
   - Trinkets
   - PrisonerJobTrinkets
   - Plushies


### PR DESCRIPTION
This PR aggressively splits up the Trinkets category, moving many of its items to Plushies, Accessibility, and a new category, Cosmetics.

All jobs now have Plushies and Cosmetics tabs in their loadouts.

Notably, the novice mark and all smokeables have been moved to Accessibility, 
**Cosmetics** - 0-3 slots
- Jewelry (dogtags, heart locket, rings)
- Worn flowers (hairflower, wreath)
- Pride Pins
- Towels
- Headphones

## Why / Balance
The Trinkets tab's 3-slot limit has long hindered characters who have complex ensembles or need their favorite brand of cigarettes. If you smoke, you're basically 2 slots down automatically (cigarette + lighter). While the limitations to trinkets are important, the point of the limitation is not to inhibit customization of appearance.

Personally, when I go out someplace, my "personal trinkets" are my ipod, a book to read on the way, and sometimes a notebook or the like. I might also wear a hair scrunchy or a pretty facemask or a hat, but I don't really consider those "trinkets", they're just part of my look. I don't think it makes as much sense to limit cosmetics under the same umbrella.

As for smokeables, those are obviously Accessibility items, as much as the medications. Not much else to say. Dependencies are what they are.

Novice badges follow the same logic as maps. The point of a badge is to convey that you might need special assistance or patience. You could debate this one, though.

## Technical details
The new Cosmetics tab should be placed under the Accessibility tab in loadouts. Plushies goes under JobTrinkets.

Characters will need to redo their Trinkets!

**Changelog**
:cl:
- tweak: Many trinkets have been moved to the Cosmetics and Accessibility tabs.
- add: All jobs now have Plushies and Cosmetics tabs in loadouts.