### PR TITLE
fix: tile stacking for starcup planet tiles

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -25,6 +25,8 @@
   - PlatingRCD
   - FloorHullReinforced
   # begin starcup
+  - FloorCave
+  - FloorCaveDrought
   - FloorPlanetGrassCold
   - FloorPlanetGrassSnowy
   - FloorPlanetGrassGolden

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -39,6 +39,7 @@
   - FloorPlanetDirtGrassy
   - FloorPlanetDirtGrassyCold
   - FloorPlanetDirtGrassyGolden
+  - FloorPlanetGrassyDirtTwilight
   - FloorPlanetDirtTwilight
   - FloorPlanetDirtSnowy
   # end starcup

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -24,6 +24,14 @@
   - FloorDirt
   - PlatingRCD
   - FloorHullReinforced
+  # begin starcup
+  - FloorPlanetGrassCold
+  - FloorPlanetGrassSnowy
+  - FloorPlanetGrassGolden
+  - FloorPlanetGrassBlue
+  - FloorPlanetGrassDarkEdges
+  - FloorPlanetGrassLightEdges
+  # end starcup
 
 - type: tile
   id: FloorSteel

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -31,6 +31,16 @@
   - FloorPlanetGrassBlue
   - FloorPlanetGrassDarkEdges
   - FloorPlanetGrassLightEdges
+  - FloorPlanetDirtPale
+  - FloorPlanetDirtPaleGrassy
+  - FloorPlanetDirtPaleGrassyCold
+  - FloorPlanetDirtPaleGrassyGolden
+  - FloorPlanetDirtPaleSnowy
+  - FloorPlanetDirtGrassy
+  - FloorPlanetDirtGrassyCold
+  - FloorPlanetDirtGrassyGolden
+  - FloorPlanetDirtTwilight
+  - FloorPlanetDirtSnowy
   # end starcup
 
 - type: tile

--- a/Resources/Prototypes/_starcup/Tiles/dirt.yml
+++ b/Resources/Prototypes/_starcup/Tiles/dirt.yml
@@ -1,5 +1,6 @@
 - type: tile
   id: FloorPlanetDirtPale
+  parent: BaseFloorPlanet
   name: pale dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale.rsi/dirt.png
   variants: 5
@@ -18,16 +19,11 @@
     East: /Textures/_starcup/Tiles/Planet/dirt_pale.rsi/double_edge.png
     North: /Textures/_starcup/Tiles/Planet/dirt_pale.rsi/double_edge.png
     West: /Textures/_starcup/Tiles/Planet/dirt_pale.rsi/double_edge.png
-  isSubfloor: true
-  footstepSounds:
-    collection: FootstepAsteroid
-  heatCapacity: 10000
-  indestructible: true
 
 - type: tile
   id: FloorPlanetDirtPaleGrassy
-  name: grassy pale dirt
   parent: FloorPlanetDirtPale
+  name: grassy pale dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale_grassy.rsi/dirt.png
   variants: 8
   placementVariants:
@@ -44,20 +40,20 @@
 
 - type: tile
   id: FloorPlanetDirtPaleGrassyCold
-  name: cold grassy pale dirt
   parent: FloorPlanetDirtPaleGrassy
+  name: cold grassy pale dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale_grassy_cold.rsi/dirt.png
 
 - type: tile
   id: FloorPlanetDirtPaleGrassyGolden
-  name: golden grassy pale dirt
   parent: FloorPlanetDirtPaleGrassy
+  name: golden grassy pale dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale_grassy_golden.rsi/dirt.png
 
 - type: tile
   id: FloorPlanetDirtPaleSnowy
-  name: snowy pale dirt
   parent: FloorPlanetDirtPale
+  name: snowy pale dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale_snow.rsi/dirt.png
   variants: 8
   placementVariants:
@@ -74,8 +70,8 @@
 
 - type: tile
   id: FloorPlanetDirtGrassy
-  name: grassy dirt
   parent: FloorPlanetDirtPaleGrassy
+  name: grassy dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_grassy.rsi/dirt.png
   edgeSprites:
     SouthEast: /Textures/_starcup/Tiles/Planet/dirt_grassy.rsi/single_edge.png
@@ -89,18 +85,19 @@
 
 - type: tile
   id: FloorPlanetDirtGrassyCold
-  name: cold grassy dirt
   parent: FloorPlanetDirtGrassy
+  name: cold grassy dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_grassy_cold.rsi/dirt.png
 
 - type: tile
   id: FloorPlanetDirtGrassyGolden
-  name: cold grassy dirt
   parent: FloorPlanetDirtGrassy
+  name: cold grassy dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_grassy_golden.rsi/dirt.png
 
 - type: tile
   id: FloorPlanetDirtTwilight
+  parent: FloorPlanetDirtPale
   name: twilight dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_twilight.rsi/dirt.png
   variants: 8
@@ -122,11 +119,6 @@
     East: /Textures/_starcup/Tiles/Planet/dirt_twilight.rsi/double_edge.png
     North: /Textures/_starcup/Tiles/Planet/dirt_twilight.rsi/double_edge.png
     West: /Textures/_starcup/Tiles/Planet/dirt_twilight.rsi/double_edge.png
-  isSubfloor: true
-  footstepSounds:
-    collection: FootstepAsteroid
-  heatCapacity: 10000
-  indestructible: true
 
 - type: tile
   id: FloorPlanetGrassyDirtTwilight
@@ -148,6 +140,7 @@
 
 - type: tile
   id: FloorPlanetDirtSnowy
+  parent: BaseFloorPlanet
   name: snowy dirt
   sprite: /Textures/_starcup/Tiles/Planet/dirt_snowy.rsi/dirt.png
   variants: 8
@@ -160,8 +153,5 @@
   - 1.0
   - 1.0
   - 1.0
-  isSubfloor: true
-  heatCapacity: 10000
-  indestructible: true
   footstepSounds:
     collection: FootstepSnow

--- a/Resources/Prototypes/_starcup/Tiles/dirt.yml
+++ b/Resources/Prototypes/_starcup/Tiles/dirt.yml
@@ -49,7 +49,7 @@
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale_grassy_cold.rsi/dirt.png
 
 - type: tile
-  id: FloorPlanetDirtPaleeGrassyGolden
+  id: FloorPlanetDirtPaleGrassyGolden
   name: golden grassy pale dirt
   parent: FloorPlanetDirtPaleGrassy
   sprite: /Textures/_starcup/Tiles/Planet/dirt_pale_grassy_golden.rsi/dirt.png

--- a/Resources/Prototypes/_starcup/Tiles/grass.yml
+++ b/Resources/Prototypes/_starcup/Tiles/grass.yml
@@ -60,6 +60,7 @@
 - type: tile
   id: FloorPlanetGrassBlue
   name: twilight grass
+  parent: FloorPlanetGrass
   sprite: /Textures/_starcup/Tiles/Planet/grass_twilight/grass.png
   variants: 4
   placementVariants:
@@ -77,11 +78,6 @@
     East: /Textures/_starcup/Tiles/Planet/grass_twilight/double_edge.png
     North: /Textures/_starcup/Tiles/Planet/grass_twilight/double_edge.png
     West: /Textures/_starcup/Tiles/Planet/grass_twilight/double_edge.png
-  isSubfloor: true
-  footstepSounds:
-    collection: FootstepGrass
-  heatCapacity: 10000
-  indestructible: true
 
 - type: tile
   id: FloorPlanetGrassDarkEdges


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14/pull/42543 introduced tile stacking, primarily used for construction on planet surfaces. I don't think this will fix grid connection issues for our surface bases, but at least people will be able to place tiles on charon-epsilon or anywhere that uses our custom tiles. 

## Technical details
Adds our tiles to the `baseWhitelist` of `BaseStationTile` and shuffles some parenting around (including putting parent before name for some dirt tiles) to ensure all of our planet tiles parent from `BaseFloorPlanet`.

**Changelog**
- fix: tiles can be placed (stacked) on cave floor and various starcup-created planet tiles
