### PR TITLE
fix: loadout change fixes

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -34,14 +34,12 @@
   storage:
     back:
     - PlushieLizard
-  groupBy: "plushie" # starcup
 
 - type: loadout
   id: PlushieSpaceLizard
   storage:
     back:
     - PlushieSpaceLizard
-  groupBy: "plushie" # starcup
 
 - type: loadout
   id: ThreeCandles

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
@@ -34,8 +34,10 @@
   - Glasses
   - SurvivalMedical
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
-#  - ChiefMedicalOfficerJobTrinkets
+  - ChiefMedicalOfficerJobTrinkets
+  - Plushies # starcup
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -53,8 +55,10 @@
   - MedicalDoctorPDA
   - SurvivalMedical
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
-#  - MedicalDoctorJobTrinkets
+  - MedicalDoctorJobTrinkets
+  - Plushies # starcup
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -70,9 +74,11 @@
   - Glasses
   - MedicalInternID # starcup
   - Accessibility # starcup
+  - Cosmetics # starcup
   - SurvivalMedical
   - Trinkets
-#  - MedicalInternJobTrinkets
+  - MedicalInternJobTrinkets
+  - Plushies # starcup
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -89,8 +95,10 @@
   - ChemistPDA # starcup
   - SurvivalMedical
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
-#  - ChemistJobTrinkets
+  - ChemistJobTrinkets
+  - Plushies # starcup
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -107,6 +115,8 @@
   - Glasses
   - SurvivalMedical
   - Accessibility # starcup
+  - Cosmetics # starcup
   - Trinkets
-#  - ParamedicJobTrinkets
+  - ParamedicJobTrinkets
+  - Plushies # starcup
   - GroupSpeciesBreathToolMedical

--- a/Resources/Prototypes/_DV/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -46,7 +46,7 @@
 
 # Senior Officer uniform
 - type: entity
-  parent: ClothingUniformFoldableBase
+  parent: [ClothingUniformBase, ClothingUniformFoldableBase] # starcup: ClothingUniformBase parent
   id: ClothingUniformJumpskirtSecTurtle
   name: senior officer's turtleneck
   description: A comfortable and tight-fitting turtleneck for those with the resolve to reach the position of Senior Officer.

--- a/Resources/Prototypes/_DV/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -66,7 +66,7 @@
 
 # Senior Officer
 - type: entity
-  parent: ClothingUniformFoldableBase
+  parent: [ClothingUniformBase, ClothingUniformFoldableBase] # starcup: ClothingUniformBase parent
   id: ClothingUniformJumpsuitSecTurtle
   name: senior officer's turtleneck
   description: A comfortable and tight-fitting turtleneck for those with the resolve to reach the position of Senior Officer.

--- a/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/LoadoutGroups/general.yml
@@ -93,8 +93,10 @@
   - PlushieZetan
 
 - type: loadoutGroup
-  abstract: true
   id: Plushies
+  name: loadout-group-plushies
+  minLimit: 0
+  maxLimit: 3
   loadouts:
   - PlushieLizard
   - PlushieSpaceLizard

--- a/Resources/Prototypes/_starcup/Loadouts/Trinkets/plushies.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Trinkets/plushies.yml
@@ -4,234 +4,198 @@
   storage:
     back:
     - PlushieLizardInversed
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieBee
   storage:
     back:
     - PlushieBee
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSnake
   storage:
     back:
     - PlushieSnake
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieCarp
   storage:
     back:
     - PlushieCarp
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieHolocarp
   storage:
     back:
     - PlushieHolocarp
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieExperiment
   storage:
     back:
     - PlushieExperiment
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSharkBlue
   storage:
     back:
     - PlushieSharkBlue
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSharkPink
   storage:
     back:
     - PlushieSharkPink
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSharkGrey
   storage:
     back:
     - PlushieSharkGrey
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieHampter
   storage:
     back:
     - PlushieHampter
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushiePenguin
   storage:
     back:
     - PlushiePenguin
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieArachnid
   storage:
     back:
     - PlushieArachind # upstream typoed this and fixing it would require replacing it in a bunch of other places
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieDiona
   storage:
     back:
     - PlushieDiona
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieMoth
   storage:
     back:
     - PlushieMoth
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSlime
   storage:
     back:
     - PlushieSlime
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieVox
   storage:
     back:
     - PlushieVox
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieVulp
   storage:
     back:
     - PlushieVulp
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieRouny
   storage:
     back:
     - PlushieRouny
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieXeno
   storage:
     back:
     - PlushieXeno
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieZetan
   storage:
     back:
     - PlushieZetan
-  groupBy: "plushie"
 
 # Worn
 - type: loadout
   id: PlushieLizardWorn
   equipment:
     head: PlushieLizard
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSpaceLizardWorn
   equipment:
     head: PlushieSpaceLizard
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieLizardInversedWorn
   equipment:
     head: PlushieLizardInversed
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieBeeWorn
   equipment:
     head: PlushieBee
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieExperimentWorn
   equipment:
     head: PlushieExperiment
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieHampterWorn
   equipment:
     head: PlushieHampter
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushiePenguinWorn
   equipment:
     head: PlushiePenguin
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieArachnidWorn
   equipment:
     head: PlushieArachind # upstream typoed this and fixing it would require replacing it in a bunch of other places
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieDionaWorn
   equipment:
     head: PlushieDiona
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieMothWorn
   equipment:
     head: PlushieMoth
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSlimeWorn
   equipment:
     head: PlushieSlime
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieVoxWorn
   equipment:
     head: PlushieVox
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieVulpWorn
   equipment:
     head: PlushieVulp
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieRounyWorn
   equipment:
     head: PlushieRouny
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieXenoWorn
   equipment:
     head: PlushieXeno
-  groupBy: "plushie"
 
 - type: loadout
   id: PlushieSnakeWorn
   equipment:
     neck: PlushieSnake
-  groupBy: "plushie"


### PR DESCRIPTION
Adds `ClothingUniformBase` to the senior officer's turtlenecks to make them no longer invalid entities, adds some missing categories to medical loadouts (why did upstream put them in a different file??), and makes the plushies group no longer abstract, since it wasn't being inherited from. Removes the `groupBy` on all plushie trinkets as they have their own page now.

**Changelog**
:cl:
- fix: Medical has the new loadout options.
- fix: Plushies are once again selectable in loadouts.
