### PR TITLE
Increased sustenance vendor usability

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -97,3 +97,13 @@
   cost: 2000
   category: cargoproduct-category-name-food
   group: market
+
+- type: cargoProduct
+  id: CrateFoodSustenance
+  icon:
+    sprite: Objects/Consumable/Food/mre.rsi
+    state: cone
+  product: VendingMachineRestockSustenanceVendor
+  cost: 500
+  category: cargoproduct-category-name-food
+  group: market

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -1,25 +1,26 @@
 - type: vendingMachineInventory
   id: SustenanceInventory
   startingInventory:
-    DrinkMREFlask: 3
+    DrinkMREFlask: 5 # starcup: increased MRE flasks in hopes of making sustenance vendor not be consistently empty
     FoodSnackNutribrick: 5
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
     # Begin DeltaV Additions
-    ReagentTinPowderedMilk: 2
-    ReagentTinPowderedMilkSoy: 2
-    ReagentTinPowderedJuiceOrange: 1
-    ReagentTinPowderedJuiceLime: 1
-    ReagentTinPowderedJuiceWatermelon: 1
-    ReagentTinPowderedJuiceApple: 1
-    ReagentTinPowderedJuiceBerry: 1
-    ReagentTinPowderedJuicePineapple: 1
-    ReagentTinPowderedJuiceTomato: 1
-    ReagentTinPowderedJuiceBanana: 1
-    ReagentTinPowderedJuiceCarrot: 1
-    ReagentTinPowderedJuiceCherry: 1
-    ReagentTinPowderedJuiceGrape: 1
-    ReagentTinPowderedJuiceLemon: 1
+    # starcup: increased orange juice to lemon juice to three from one can, milk and soy doubled (from 2 to 4)
+    ReagentTinPowderedMilk: 4
+    ReagentTinPowderedMilkSoy: 4
+    ReagentTinPowderedJuiceOrange: 3
+    ReagentTinPowderedJuiceLime: 3
+    ReagentTinPowderedJuiceWatermelon: 3
+    ReagentTinPowderedJuiceApple: 3
+    ReagentTinPowderedJuiceBerry: 3
+    ReagentTinPowderedJuicePineapple: 3
+    ReagentTinPowderedJuiceTomato: 3
+    ReagentTinPowderedJuiceBanana: 3
+    ReagentTinPowderedJuiceCarrot: 3
+    ReagentTinPowderedJuiceCherry: 3
+    ReagentTinPowderedJuiceGrape: 3
+    ReagentTinPowderedJuiceLemon: 3
     # End DeltaV Additions
   contrabandInventory:
     FoodTinMRE: 3

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -494,3 +494,20 @@
     - state: green_bit
       shader: unshaded
     - state: refill_medical
+
+# starcup: added sustenance vendor restock
+- type: entity
+  parent: BaseVendingMachineRestock
+  id: VendingMachineRestockSustenanceVendor
+  name: Sustenance Vendor restock box
+  description: A box loaded with the worst of the worst ingredients, food, and drinks for prisoners. So many corners were cut, that they reused an old snack vendor box.
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - SustenanceInventory
+  - type: Sprite
+    layers:
+    - state: base
+    - state: green_bit
+      shader: unshaded
+    - state: refill_snack


### PR DESCRIPTION
## Why / Balance
The sustenance vendor is horrible in the current state. Almost all of the objects in it are inaccessible because of the horrible rate that they spawn (due to most being at 1 or 2 count) as well as it lacking a restock. Now prisoners can eat.

## Technical details
Added a restock in the restock file, increased the count of most sustenance vendor items, and added a listing to the cargo purchases to be able to buy it.

## Media
Sorry, no media. I know my changes almost certainly SHOULD work, but I can't figure out how to actually open it in a debug environment. Running RUN_THIS.py doesn't help.

**Changelog**
:cl:
- add: Added a restock for the Sustenance Vendor, purchased for 500 spesos in cargo.
- tweak: Adjusted the amount of items in the Sustenance Vendor roundstart.
