### PR TITLE
tweak: Increased usability of sustenance vendor

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -102,7 +102,7 @@
   id: CrateFoodSustenance
   icon:
     sprite: Objects/Consumable/Food/mre.rsi
-    state: cone
+    state: mre-closed
   product: VendingMachineRestockSustenanceVendor
   cost: 500
   category: cargoproduct-category-name-food

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -97,3 +97,13 @@
   cost: 2000
   category: cargoproduct-category-name-food
   group: market
+
+- type: cargoProduct
+  id: CrateFoodSustenance
+  icon:
+    sprite: Objects/Consumable/Food/mre.rsi
+    state: cone
+  product: VendingMachineRestockSustenanceVendor
+  cost: 500
+  category: cargoproduct-category-name-food
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -104,6 +104,6 @@
     sprite: Objects/Consumable/Food/mre.rsi
     state: mre-closed
   product: VendingMachineRestockSustenanceVendor
-  cost: 700
+  cost: 800
   category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -104,6 +104,6 @@
     sprite: Objects/Consumable/Food/mre.rsi
     state: mre-closed
   product: VendingMachineRestockSustenanceVendor
-  cost: 500
+  cost: 700
   category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -323,3 +323,17 @@
   cost: 600
   category: cargoproduct-category-name-service
   group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockSustenance
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: VendingMachineRestockSustenanceVendor
+  container:
+    entity: WrappedParcel
+    containerId: contents
+  cost: 600
+  category: cargoproduct-category-name-service
+  group: market
+  

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -333,7 +333,7 @@
   container:
     entity: WrappedParcel
     containerId: contents
-  cost: 700
+  cost: 800
   category: cargoproduct-category-name-service
   group: market
   

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -333,7 +333,7 @@
   container:
     entity: WrappedParcel
     containerId: contents
-  cost: 600
+  cost: 700
   category: cargoproduct-category-name-service
   group: market
   

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -1,26 +1,25 @@
 - type: vendingMachineInventory
   id: SustenanceInventory
   startingInventory:
-    DrinkMREFlask: 5 # starcup: increased MRE flasks in hopes of making sustenance vendor not be consistently empty
+    DrinkMREFlask: 3
     FoodSnackNutribrick: 5
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
     # Begin DeltaV Additions
-    # starcup: increased orange juice to lemon juice to three from one can, milk and soy doubled (from 2 to 4)
-    ReagentTinPowderedMilk: 4
-    ReagentTinPowderedMilkSoy: 4
-    ReagentTinPowderedJuiceOrange: 3
-    ReagentTinPowderedJuiceLime: 3
-    ReagentTinPowderedJuiceWatermelon: 3
-    ReagentTinPowderedJuiceApple: 3
-    ReagentTinPowderedJuiceBerry: 3
-    ReagentTinPowderedJuicePineapple: 3
-    ReagentTinPowderedJuiceTomato: 3
-    ReagentTinPowderedJuiceBanana: 3
-    ReagentTinPowderedJuiceCarrot: 3
-    ReagentTinPowderedJuiceCherry: 3
-    ReagentTinPowderedJuiceGrape: 3
-    ReagentTinPowderedJuiceLemon: 3
+    ReagentTinPowderedMilk: 2
+    ReagentTinPowderedMilkSoy: 2
+    ReagentTinPowderedJuiceOrange: 1
+    ReagentTinPowderedJuiceLime: 1
+    ReagentTinPowderedJuiceWatermelon: 1
+    ReagentTinPowderedJuiceApple: 1
+    ReagentTinPowderedJuiceBerry: 1
+    ReagentTinPowderedJuicePineapple: 1
+    ReagentTinPowderedJuiceTomato: 1
+    ReagentTinPowderedJuiceBanana: 1
+    ReagentTinPowderedJuiceCarrot: 1
+    ReagentTinPowderedJuiceCherry: 1
+    ReagentTinPowderedJuiceGrape: 1
+    ReagentTinPowderedJuiceLemon: 1
     # End DeltaV Additions
   contrabandInventory:
     FoodTinMRE: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -1,25 +1,26 @@
 - type: vendingMachineInventory
   id: SustenanceInventory
   startingInventory:
-    DrinkMREFlask: 3
+    DrinkMREFlask: 5 # starcup: increased MRE flasks in hopes of making sustenance vendor not be consistently empty
     FoodSnackNutribrick: 5
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
     # Begin DeltaV Additions
-    ReagentTinPowderedMilk: 2
-    ReagentTinPowderedMilkSoy: 2
-    ReagentTinPowderedJuiceOrange: 1
-    ReagentTinPowderedJuiceLime: 1
-    ReagentTinPowderedJuiceWatermelon: 1
-    ReagentTinPowderedJuiceApple: 1
-    ReagentTinPowderedJuiceBerry: 1
-    ReagentTinPowderedJuicePineapple: 1
-    ReagentTinPowderedJuiceTomato: 1
-    ReagentTinPowderedJuiceBanana: 1
-    ReagentTinPowderedJuiceCarrot: 1
-    ReagentTinPowderedJuiceCherry: 1
-    ReagentTinPowderedJuiceGrape: 1
-    ReagentTinPowderedJuiceLemon: 1
+    # starcup: increased orange juice to lemon juice to three from one can, milk and soy doubled (from 2 to 4)
+    ReagentTinPowderedMilk: 4
+    ReagentTinPowderedMilkSoy: 4
+    ReagentTinPowderedJuiceOrange: 3
+    ReagentTinPowderedJuiceLime: 3
+    ReagentTinPowderedJuiceWatermelon: 3
+    ReagentTinPowderedJuiceApple: 3
+    ReagentTinPowderedJuiceBerry: 3
+    ReagentTinPowderedJuicePineapple: 3
+    ReagentTinPowderedJuiceTomato: 3
+    ReagentTinPowderedJuiceBanana: 3
+    ReagentTinPowderedJuiceCarrot: 3
+    ReagentTinPowderedJuiceCherry: 3
+    ReagentTinPowderedJuiceGrape: 3
+    ReagentTinPowderedJuiceLemon: 3
     # End DeltaV Additions
   contrabandInventory:
     FoodTinMRE: 3

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -494,3 +494,20 @@
     - state: green_bit
       shader: unshaded
     - state: refill_medical
+
+# starcup: added sustenance vendor restock
+- type: entity
+  parent: BaseVendingMachineRestock
+  id: VendingMachineRestockSustenanceVendor
+  name: Sustenance Vendor restock box
+  description: A box loaded with the worst of the worst ingredients, food, and drinks for prisoners. So many corners were cut, that they reused an old snack vendor box.
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - SustenanceInventory
+  - type: Sprite
+    layers:
+    - state: base
+    - state: green_bit
+      shader: unshaded
+    - state: refill_snack

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -500,7 +500,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockSustenanceVendor
   name: Sustenance Vendor restock box
-  description: A box loaded with the worst of the worst ingredients, food, and drinks for prisoners. So many corners were cut, that they reused an old snack vendor box.
+  description: A box loaded with the worst of the worst in terms of... "sustenance." They couldn't even bother to paint anything unique on the box. Load it into a Sustenance Vendor to begin.
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1140,6 +1140,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    initialStockQuality: 0.8
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/sustenance.rsi
     layers:


### PR DESCRIPTION
## Why / Balance
The sustenance vendor's inventory is pitiful, being empty save for about three items total. You also can't restock it. This fixes that.

## Technical details
Added restock just for sustenance vendor, added purchase listing for restock, increased counts of most items in vendor
(all my homies hate git bot)

## Media
RUN_THIS.py doesn't do anything useful. It should work!

**Changelog**
:cl:
- add: Added a Sustenance Vendor restock, which can be purchased for 500 spesos by cargo. Starve no more, prisoners!
- tweak: Sustenance Vendors come with more items at roundstart.