### PR TITLE
map(freighter): fix arrivals spacing itself, other tweaks

### DIFF
--- a/Resources/Maps/_starcup/freighter.yml
+++ b/Resources/Maps/_starcup/freighter.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 272.0.0
+  engineVersion: 275.2.0
   forkId: ""
   forkVersion: ""
-  time: 04/28/2026 00:28:20
-  entityCount: 13348
+  time: 05/18/2026 15:39:56
+  entityCount: 13369
 maps:
 - 1
 grids:
@@ -124,7 +124,7 @@ entities:
           version: 7
         1,0:
           ind: 1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAIAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAQAAAAAAAAAABgAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAgAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAA7AAAAAAAAOwAAAAACADsAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAQABAAAAAAEAAwAAAAACAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAAAAAAAAAAOwAAAAABADsAAAAAAQA7AAAAAAAAAwAAAAACAAEAAAAAAQABAAAAAAMAAQAAAAACAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAACEAAAAAAgAhAAAAAAAAIQAAAAAAAAAAAAAAAAABAAAAAAMAAQAAAAABAAEAAAAAAwAAAAAAAAAAAAAAAAAAAAMAAAAAAgAAAAAAAAAAAAAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABAAEAAAAAAAABAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAIAAAAAAAABwAAAAAAAAgAAAAAAAAAAAAAAAAAIQAAAAACACEAAAAAAwAhAAAAAAMAAwAAAAABAAEAAAAAAwABAAAAAAAAAQAAAAADAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACEAAAAAAQAhAAAAAAIAIQAAAAACAAAAAAAAAAABAAAAAAEAAQAAAAABAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAgADAAAAAAIAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAADAAEAAAAAAQABAAAAAAEAAQAAAAACAAEAAAAAAwABAAAAAAIAAQAAAAAAAAIAAAAAAAABAAAAAAMAAQAAAAAAAAEAAAAAAQACAAAAAAAAAQAAAAACAAEAAAAAAgABAAAAAAMAAQAAAAACAAEAAAAAAQABAAAAAAEAAQAAAAAAAAEAAAAAAgABAAAAAAIAAQAAAAADAAEAAAAAAQACAAAAAAAAAQAAAAADAAEAAAAAAAABAAAAAAIAAgAAAAAAAAEAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAEAAQAAAAABAAMAAAAAAQAAAAAAAAAAAAAAAAAAAAMAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAACAC4AAAAAAAAvAAAAAAIAAwAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuAAAAAAEALwAAAAADAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAIAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAEAAAAAAQAAAAAAAAAABgAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAgAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAA7AAAAAAAAOwAAAAACADsAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAQABAAAAAAEAAwAAAAACAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAAAAAAAAAAOwAAAAABADsAAAAAAQA7AAAAAAAAAwAAAAACAAEAAAAAAQABAAAAAAMAAQAAAAACAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAACEAAAAAAgAhAAAAAAAAIQAAAAAAAAAAAAAAAAABAAAAAAMAAQAAAAABAAEAAAAAAwAAAAAAAAAAAAAAAAAAAAMAAAAAAgAAAAAAAAAAAAAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAABAAEAAAAAAAABAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAIAAAAAAAABwAAAAAAAAgAAAAAAAAAAAAAAAAAIQAAAAACACEAAAAAAwAhAAAAAAMAAwAAAAABAAEAAAAAAwABAAAAAAAAAQAAAAADAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACEAAAAAAQAhAAAAAAIAIQAAAAACAAAAAAAAAAABAAAAAAEAAQAAAAABAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAgADAAAAAAIAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAADAAEAAAAAAQABAAAAAAEAAQAAAAACAAEAAAAAAwABAAAAAAIAAQAAAAAAAAIAAAAAAAABAAAAAAMAAQAAAAAAAAEAAAAAAQACAAAAAAAAAQAAAAACAAEAAAAAAgABAAAAAAMAAQAAAAACAAEAAAAAAQABAAAAAAEAAQAAAAAAAAEAAAAAAgABAAAAAAIAAQAAAAADAAEAAAAAAQACAAAAAAAAAQAAAAADAAEAAAAAAAABAAAAAAIAAgAAAAAAAAEAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAEAAQAAAAABAAMAAAAAAQAAAAAAAAAAAAAAAAAAAAMAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAACAC4AAAAAAAAvAAAAAAIAAwAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuAAAAAAEALwAAAAADAA==
           version: 7
         1,1:
           ind: 1,1
@@ -7106,7 +7106,7 @@ entities:
       pos: -3.5,-17.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -91514.69
+      secondsUntilStateChange: -92546.43
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -7770,6 +7770,16 @@ entities:
       parent: 2
 - proto: AirlockMaintSecLocked
   entities:
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: 30.5,3.5
+      parent: 2
+  - uid: 1019
+    components:
+    - type: Transform
+      pos: 35.5,5.5
+      parent: 2
   - uid: 6166
     components:
     - type: MetaData
@@ -7790,18 +7800,6 @@ entities:
       name: security maintenance access
     - type: Transform
       pos: 15.5,3.5
-      parent: 2
-- proto: AirlockMaintSecurity
-  entities:
-  - uid: 3348
-    components:
-    - type: Transform
-      pos: 35.5,5.5
-      parent: 2
-  - uid: 3931
-    components:
-    - type: Transform
-      pos: 30.5,3.5
       parent: 2
 - proto: AirlockMaintServiceLocked
   entities:
@@ -8166,20 +8164,6 @@ entities:
     - type: Transform
       pos: 25.5,12.5
       parent: 2
-  - uid: 3933
-    components:
-    - type: MetaData
-      name: locker room
-    - type: Transform
-      pos: 21.5,11.5
-      parent: 2
-  - uid: 3934
-    components:
-    - type: MetaData
-      name: locker room
-    - type: Transform
-      pos: 21.5,12.5
-      parent: 2
   - uid: 3936
     components:
     - type: MetaData
@@ -8239,6 +8223,16 @@ entities:
       parent: 2
 - proto: AirlockSecurityLocked
   entities:
+  - uid: 953
+    components:
+    - type: Transform
+      pos: 21.5,11.5
+      parent: 2
+  - uid: 954
+    components:
+    - type: Transform
+      pos: 21.5,12.5
+      parent: 2
   - uid: 3961
     components:
     - type: MetaData
@@ -9005,6 +8999,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 4.5,38.5
       parent: 2
+  - uid: 3934
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 45.5,39.5
+      parent: 2
   - uid: 7597
     components:
     - type: Transform
@@ -9057,6 +9057,24 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,56.5
+      parent: 2
+  - uid: 13352
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 45.5,37.5
+      parent: 2
+  - uid: 13353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 45.5,24.5
+      parent: 2
+  - uid: 13354
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 45.5,22.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:
@@ -11153,6 +11171,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -7.5,42.5
       parent: 2
+  - uid: 13350
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,28.5
+      parent: 2
 - proto: ButtonFrameCautionSecurity
   entities:
   - uid: 2047
@@ -11291,6 +11315,26 @@ entities:
     components:
     - type: Transform
       pos: 17.5,23.5
+      parent: 2
+  - uid: 3147
+    components:
+    - type: Transform
+      pos: -37.5,17.5
+      parent: 2
+  - uid: 3151
+    components:
+    - type: Transform
+      pos: -37.5,18.5
+      parent: 2
+  - uid: 3267
+    components:
+    - type: Transform
+      pos: -37.5,19.5
+      parent: 2
+  - uid: 3268
+    components:
+    - type: Transform
+      pos: -37.5,16.5
       parent: 2
   - uid: 3359
     components:
@@ -11541,16 +11585,6 @@ entities:
     components:
     - type: Transform
       pos: -36.5,16.5
-      parent: 2
-  - uid: 3828
-    components:
-    - type: Transform
-      pos: -36.5,17.5
-      parent: 2
-  - uid: 3829
-    components:
-    - type: Transform
-      pos: -36.5,18.5
       parent: 2
   - uid: 3830
     components:
@@ -20627,6 +20661,11 @@ entities:
     - type: Transform
       pos: -25.5,21.5
       parent: 2
+  - uid: 13365
+    components:
+    - type: Transform
+      pos: -36.5,41.5
+      parent: 2
 - proto: CableApcStack1
   entities:
   - uid: 12638
@@ -20672,11 +20711,6 @@ entities:
     components:
     - type: Transform
       pos: -39.5,29.5
-      parent: 2
-  - uid: 954
-    components:
-    - type: Transform
-      pos: -37.5,18.5
       parent: 2
   - uid: 1029
     components:
@@ -21058,6 +21092,16 @@ entities:
     - type: Transform
       pos: -40.5,22.5
       parent: 2
+  - uid: 3106
+    components:
+    - type: Transform
+      pos: -36.5,17.5
+      parent: 2
+  - uid: 3146
+    components:
+    - type: Transform
+      pos: -37.5,18.5
+      parent: 2
   - uid: 3296
     components:
     - type: Transform
@@ -21081,12 +21125,7 @@ entities:
   - uid: 3301
     components:
     - type: Transform
-      pos: -36.5,17.5
-      parent: 2
-  - uid: 3302
-    components:
-    - type: Transform
-      pos: -36.5,18.5
+      pos: -37.5,16.5
       parent: 2
   - uid: 3303
     components:
@@ -21127,11 +21166,6 @@ entities:
     components:
     - type: Transform
       pos: -37.5,19.5
-      parent: 2
-  - uid: 3312
-    components:
-    - type: Transform
-      pos: -37.5,17.5
       parent: 2
   - uid: 3313
     components:
@@ -21362,6 +21396,11 @@ entities:
     components:
     - type: Transform
       pos: -9.5,25.5
+      parent: 2
+  - uid: 3828
+    components:
+    - type: Transform
+      pos: -37.5,17.5
       parent: 2
   - uid: 4374
     components:
@@ -23449,16 +23488,6 @@ entities:
     - type: Transform
       pos: -36.5,16.5
       parent: 2
-  - uid: 3267
-    components:
-    - type: Transform
-      pos: -36.5,17.5
-      parent: 2
-  - uid: 3268
-    components:
-    - type: Transform
-      pos: -36.5,18.5
-      parent: 2
   - uid: 3269
     components:
     - type: Transform
@@ -23593,6 +23622,11 @@ entities:
     components:
     - type: Transform
       pos: -27.5,9.5
+      parent: 2
+  - uid: 3302
+    components:
+    - type: Transform
+      pos: -37.5,18.5
       parent: 2
   - uid: 3399
     components:
@@ -23729,15 +23763,30 @@ entities:
     - type: Transform
       pos: 35.5,-2.5
       parent: 2
+  - uid: 3829
+    components:
+    - type: Transform
+      pos: -37.5,17.5
+      parent: 2
   - uid: 3843
     components:
     - type: Transform
       pos: -36.5,31.5
       parent: 2
+  - uid: 3900
+    components:
+    - type: Transform
+      pos: -37.5,16.5
+      parent: 2
   - uid: 3991
     components:
     - type: Transform
       pos: 35.5,-4.5
+      parent: 2
+  - uid: 4057
+    components:
+    - type: Transform
+      pos: -37.5,19.5
       parent: 2
   - uid: 5030
     components:
@@ -28943,25 +28992,10 @@ entities:
     - type: Transform
       pos: -36.5,20.5
       parent: 2
-  - uid: 3146
-    components:
-    - type: Transform
-      pos: -36.5,19.5
-      parent: 2
-  - uid: 3147
-    components:
-    - type: Transform
-      pos: -36.5,18.5
-      parent: 2
   - uid: 3148
     components:
     - type: Transform
       pos: -35.5,20.5
-      parent: 2
-  - uid: 3151
-    components:
-    - type: Transform
-      pos: -36.5,16.5
       parent: 2
   - uid: 3152
     components:
@@ -28987,6 +29021,12 @@ entities:
     components:
     - type: Transform
       pos: -35.5,15.5
+      parent: 2
+  - uid: 3201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -36.5,19.5
       parent: 2
   - uid: 3205
     components:
@@ -29018,6 +29058,12 @@ entities:
     - type: Transform
       pos: -28.5,11.5
       parent: 2
+  - uid: 3222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,16.5
+      parent: 2
   - uid: 3247
     components:
     - type: Transform
@@ -29042,6 +29088,12 @@ entities:
     components:
     - type: Transform
       pos: -27.5,20.5
+      parent: 2
+  - uid: 3348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,17.5
       parent: 2
   - uid: 3517
     components:
@@ -29112,6 +29164,12 @@ entities:
     components:
     - type: Transform
       pos: 33.5,5.5
+      parent: 2
+  - uid: 4045
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,19.5
       parent: 2
   - uid: 4360
     components:
@@ -33360,9 +33418,10 @@ entities:
     - type: Transform
       pos: -27.5,11.5
       parent: 2
-  - uid: 4057
+  - uid: 13364
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -35.5,11.5
       parent: 2
 - proto: ConveyorBelt
@@ -34403,6 +34462,13 @@ entities:
     - type: Transform
       pos: 8.5,-8.5
       parent: 2
+- proto: CrateMaterialPlasma
+  entities:
+  - uid: 2629
+    components:
+    - type: Transform
+      pos: -8.5,36.5
+      parent: 2
 - proto: CrateMaterialRandom
   entities:
   - uid: 3356
@@ -34428,13 +34494,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-6.5
-      parent: 2
-- proto: CrateMaterialPlasma
-  entities:
-  - uid: 2629
-    components:
-    - type: Transform
-      pos: -8.5,36.5
       parent: 2
 - proto: CrateScience
   entities:
@@ -42664,16 +42723,6 @@ entities:
     - type: Transform
       pos: 27.5,41.5
       parent: 2
-- proto: GasCanisterBrokenBase
-  entities:
-  - uid: 3201
-    components:
-    - type: Transform
-      anchored: True
-      pos: -37.5,15.5
-      parent: 2
-    - type: Physics
-      bodyType: Static
 - proto: GasFilter
   entities:
   - uid: 2007
@@ -58318,6 +58367,11 @@ entities:
     - type: Transform
       pos: -8.5,82.5
       parent: 2
+  - uid: 12535
+    components:
+    - type: Transform
+      pos: -34.5,21.5
+      parent: 2
   - uid: 12571
     components:
     - type: Transform
@@ -61632,6 +61686,8 @@ entities:
     - type: Transform
       pos: -32.31817,25.470943
       parent: 2
+    - type: Flammable
+      nextUpdate: -25.957253
     - type: Paper
       stampState: paper_stamp-signature
       stampedBy:
@@ -61659,7 +61715,13 @@ entities:
 
         And for the rest... all the shredded walls should do a nice job of protecting everything, but there should be plenty of surplus materials. Whole area is going to be a huge radiation hazard but just let everyone know and it'll be alright!
     - type: SolutionContainerManager
-      solutions: null
+      solutions:
+        food:
+          temperature: 293.15
+          canReact: True
+          maxVol: 0
+          name: food
+          reagents: []
       containers:
       - food
     - type: EmitSoundOnCollide
@@ -61850,6 +61912,11 @@ entities:
     components:
     - type: Transform
       pos: -7.606901,33.635128
+      parent: 2
+  - uid: 13356
+    components:
+    - type: Transform
+      pos: -32.45872,21.577065
       parent: 2
 - proto: PartRodMetal1
   entities:
@@ -64851,21 +64918,6 @@ entities:
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 953
-    components:
-    - type: Transform
-      pos: -37.5,18.5
-      parent: 2
-  - uid: 1010
-    components:
-    - type: Transform
-      pos: -37.5,19.5
-      parent: 2
-  - uid: 1019
-    components:
-    - type: Transform
-      pos: -37.5,17.5
-      parent: 2
   - uid: 1022
     components:
     - type: Transform
@@ -64876,10 +64928,20 @@ entities:
     - type: Transform
       pos: -26.5,11.5
       parent: 2
+  - uid: 3130
+    components:
+    - type: Transform
+      pos: -36.5,16.5
+      parent: 2
   - uid: 3351
     components:
     - type: Transform
       pos: -25.5,18.5
+      parent: 2
+  - uid: 13355
+    components:
+    - type: Transform
+      pos: -36.5,17.5
       parent: 2
 - proto: RadioHandheld
   entities:
@@ -65003,6 +65065,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,63.5
+      parent: 2
+  - uid: 3312
+    components:
+    - type: Transform
+      pos: -34.5,20.5
       parent: 2
   - uid: 3350
     components:
@@ -65580,6 +65647,63 @@ entities:
     components:
     - type: Transform
       pos: 41.5,1.5
+      parent: 2
+  - uid: 13357
+    components:
+    - type: Transform
+      pos: -28.5,20.5
+      parent: 2
+  - uid: 13358
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,17.5
+      parent: 2
+  - uid: 13359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -36.5,13.5
+      parent: 2
+  - uid: 13360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -36.5,18.5
+      parent: 2
+  - uid: 13361
+    components:
+    - type: Transform
+      pos: -29.5,20.5
+      parent: 2
+  - uid: 13362
+    components:
+    - type: Transform
+      pos: -33.5,20.5
+      parent: 2
+  - uid: 13363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -36.5,14.5
+      parent: 2
+  - uid: 13367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,18.5
+      parent: 2
+  - uid: 13368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,13.5
+      parent: 2
+  - uid: 13369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,14.5
       parent: 2
 - proto: RailingCorner
   entities:
@@ -66535,6 +66659,12 @@ entities:
       parent: 2
 - proto: RandomPosterContrabandSyndie
   entities:
+  - uid: 3931
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,44.5
+      parent: 2
   - uid: 12430
     components:
     - type: Transform
@@ -66584,11 +66714,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,63.5
-      parent: 2
-  - uid: 12535
-    components:
-    - type: Transform
-      pos: -17.5,44.5
       parent: 2
   - uid: 12536
     components:
@@ -69203,6 +69328,16 @@ entities:
     - type: Transform
       pos: -29.5,22.5
       parent: 2
+  - uid: 3933
+    components:
+    - type: Transform
+      pos: -23.5,28.5
+      parent: 2
+  - uid: 13349
+    components:
+    - type: Transform
+      pos: -22.5,28.5
+      parent: 2
 - proto: ShuttersWindow
   entities:
   - uid: 1953
@@ -69249,6 +69384,22 @@ entities:
     - type: Transform
       pos: 30.5,-2.5
       parent: 2
+- proto: SignalButton
+  entities:
+  - uid: 13351
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,28.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        13349:
+        - - Pressed
+          - Toggle
+        3933:
+        - - Pressed
+          - Toggle
 - proto: SignalButtonDirectional
   entities:
   - uid: 2005
@@ -71190,6 +71341,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,19.5
+      parent: 2
+  - uid: 13366
+    components:
+    - type: Transform
+      pos: -5.5,58.5
       parent: 2
 - proto: SinkWide
   entities:
@@ -74867,20 +75023,6 @@ entities:
     components:
     - type: Transform
       pos: 36.540134,37.748253
-      parent: 2
-- proto: TowelColorBlack
-  entities:
-  - uid: 3900
-    components:
-    - type: Transform
-      pos: 37.602806,10.641293
-      parent: 2
-- proto: TowelColorTeal
-  entities:
-  - uid: 4045
-    components:
-    - type: Transform
-      pos: -26.339977,49.65186
       parent: 2
 - proto: TowelColorWhite
   entities:
@@ -80140,11 +80282,6 @@ entities:
     - type: Transform
       pos: -39.5,13.5
       parent: 2
-  - uid: 3106
-    components:
-    - type: Transform
-      pos: -38.5,15.5
-      parent: 2
   - uid: 3107
     components:
     - type: Transform
@@ -80195,11 +80332,6 @@ entities:
     - type: Transform
       pos: -37.5,10.5
       parent: 2
-  - uid: 3130
-    components:
-    - type: Transform
-      pos: -37.5,14.5
-      parent: 2
   - uid: 3162
     components:
     - type: Transform
@@ -80214,11 +80346,6 @@ entities:
     components:
     - type: Transform
       pos: -24.5,14.5
-      parent: 2
-  - uid: 3222
-    components:
-    - type: Transform
-      pos: -34.5,21.5
       parent: 2
   - uid: 3240
     components:


### PR DESCRIPTION
Adds missing directional fans to arrivals, radiation shutters to the engineering hall, and adds a partially complete suggestion for how to handle the tight space of the singulo without getting flung (sorry onis!). Also adds a sink to the chemistry lab.

**Changelog**
:cl:
- fix: Freighter's arrivals will no longer space itself, and has received a few other minor tweaks.
