### PR TITLE
fix: pills work for narcolepsy again

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -999,6 +999,13 @@
         messages: ["ethyloxyephedrine-effect-feeling-awake", "ethyloxyephedrine-effect-clear-mind"]
         type: Local
         probability: 0.1
+    Digestion: # starcup: make ethyloxyephedrine pills treat narcolepsy
+      effects:
+      - !type:ResetNarcolepsy
+        conditions:
+        - !type:ReagentCondition
+          reagent: Ethyloxyephedrine
+          min: 10
 
 - type: reagent
   id: Diphenylmethylamine
@@ -1025,6 +1032,13 @@
         messages: ["ethyloxyephedrine-effect-feeling-awake", "ethyloxyephedrine-effect-clear-mind"]
         type: Local
         probability: 0.1
+    Digestion: # starcup: make diphenylmethylamine pills treat narcolepsy
+      effects:
+      - !type:ResetNarcolepsy
+        conditions:
+        - !type:ReagentCondition
+          reagent: Diphenylmethylamine
+          min: 10
 
 - type: reagent
   id: Sigynate


### PR DESCRIPTION
Metabolism tweaks made it so that there is never 0.25u of narcolepsy medication in the bloodstream when taken by pill. This makes it so that >= 10u in the stomach will reset narcolepsy. Direct injection only requires 5u, so it's technically more efficient.

**Changelog**
:cl:
- fix: Narcolepsy meds effectively delay narcolepsy again.
