### PR TITLE
fix: synthetics no longer have one blood

### DIFF
--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Body.Systems;
 using Content.Server.Database;
+using Content.Shared.Body.Components;
 using Content.Shared.Chat.TypingIndicator;
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Prototypes;
@@ -30,7 +31,12 @@ public sealed class SynthSystem : EntitySystem
             Dirty(uid, indicator);
         }
 
-        // Give them synth blood. Ion storm notif is handled in that system
-        _bloodstream.ChangeBloodReagent(uid, SynthBloodReagent); // DeltaV - make strings static readonly
+        // Begin DeltaV - Change blood amount according to original BloodstreamCompoent.ReferenceSolution volume
+        if (TryComp<BloodstreamComponent>(uid, out var bloodstream))
+        {
+            // Give them synth blood. Ion storm notif is handled in that system
+            _bloodstream.ChangeBloodReagents((uid, bloodstream), new([new(SynthBloodReagent, bloodstream.BloodReferenceSolution.Volume)]));
+        }
+        // End DeltaV
     }
 }


### PR DESCRIPTION
Port of https://github.com/DeltaV-Station/Delta-v/pull/5685.

The synth trait no longer makes the player's blood tick down from 300u to 1u. 

## Technical details
Copied from the PR:

> Get the original BloodReferenceSolution and set the volume of the SynthBlood accordingly.
> Don't do anything if the entity doesn't have BloodstreamComponent

**Changelog**
:cl:
- fix: Synths no longer have One drop of blood.
