### PR TITLE
feat: glowing markings for nubody

### DIFF
--- a/Content.Client/Body/VisualBodySystem.cs
+++ b/Content.Client/Body/VisualBodySystem.cs
@@ -199,6 +199,15 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
                     _sprite.LayerSetColor(target, layerId, marking.MarkingColors[i]);
                 else
                     _sprite.LayerSetColor(target, layerId, Color.White);
+
+                // MACRO START - marking layer shaders
+                if (proto.Shaders is not null &&
+                    proto.Shaders.TryGetValue(rsi.RsiState, out var shader))
+                {
+                    EnsureComp<SpriteComponent>(target, out var spriteComp); // why is this method in the component?????
+                    spriteComp.LayerSetShader(index + i + 1, shader);
+                }
+                // MACRO END
             }
 
             applied.Add(marking);

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -36,10 +36,13 @@ namespace Content.Shared.Humanoid.Markings
         [DataField("sprites", required: true)]
         public List<SpriteSpecifier> Sprites { get; private set; } = default!;
 
-        // impstation edit - allow markings to support shaders
-        [DataField("shader")]
-        public string? Shader { get; private set; } = null;
-        // end impstation edit
+        // MACRO ADDITION
+        /// <summary>
+        ///     Optional dictionary allowing assignment of shaders to sprite layers in a marking.
+        ///     This implementation is very messy but unfortunately Robust doesn't like shaders in SpriteSpecifiers.
+        /// </summary>
+        [DataField]
+        public Dictionary<string, string>? Shaders { get; private set; }
 
         public Marking AsMarking()
         {

--- a/Resources/Locale/en-US/_starcup/markings/humanoid.ftl
+++ b/Resources/Locale/en-US/_starcup/markings/humanoid.ftl
@@ -1,0 +1,12 @@
+# Eyes
+marking-EyesGlowing = Eyes (Glowing)
+marking-EyesGlowing-eyes = Eyes
+
+marking-TattooEyeLeftGlowing = Left Eye (Glowing)
+marking-TattooEyeLeftGlowing-tattoo_eye_l = Left Eye
+
+marking-TattooEyeRightGlowing = Right Eye (Glowing)
+marking-TattooEyeRightGlowing-tattoo_eye_r = Right Eye
+
+marking-MakeupBlushGlowing = Blush (Glowing)
+marking-MakeupBlushGLowing-blush = Blush

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/diona.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/diona.yml
@@ -7,7 +7,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/Diona/chest.rsi
     state: firefly
-  shader: unshaded
+  shaders:
+    firefly: unshaded
 
 - type: marking
   id: DionaLivingNymph
@@ -32,7 +33,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/Diona/head.rsi
     state: bigfirefly
-  shader: unshaded
+  shaders:
+    bigfirefly: unshaded
 
 - type: marking
   id: DionaPollenDust
@@ -51,4 +53,5 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/Diona/headtop.rsi
     state: moonbloom
-  shader: unshaded
+  shaders:
+    moonbloom: unshaded

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/moth.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/moth.yml
@@ -441,7 +441,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/headtop.rsi
     state: glowantenna
-  shader: unshaded
+  shaders:
+   glowantenna: unshaded
 
 # Tail
 
@@ -476,15 +477,10 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
     state: firefly2
-
-- type: marking
-  id: MothFireflyOverlay
-  bodyPart: Tail
-  groupWhitelist: [ Moth ]
-  sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
     state: firefly1
-  shader: unshaded
+  shaders:
+    firefly1: unshaded
 
 - type: marking
   id: MothGlasswing

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/slimeperson.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/slimeperson.yml
@@ -54,7 +54,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/SlimePerson/chest.rsi
     state: core
-  shader: unshaded
+  shaders:
+    core: unshaded
 
 - type: marking
   id: SlimeLungs
@@ -77,7 +78,10 @@
     state: fadingstars2
   - sprite: _Impstation/Mobs/Customization/SlimePerson/head.rsi
     state: fadingstars3
-  shader: unshaded
+  shaders:
+    fadingstars1: unshaded
+    fadingstars2: unshaded
+    fadingstars3: unshaded
 
 - type: marking
   id: fizz
@@ -152,7 +156,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/SlimePerson/eyes.rsi
     state: glow
-  shader: unshaded
+  shaders:
+    glow: unshaded
 
 - type: marking
   id: SlimeEyesDroopy
@@ -179,7 +184,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/SlimePerson/eyes.rsi
     state: droopyglow
-  shader: unshaded
+  shaders:
+    droopyglow: unshaded
 
 - type: marking
   id: SlimeEyesCyclops
@@ -206,7 +212,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/SlimePerson/eyes.rsi
     state: cyclopsglow
-  shader: unshaded
+  shaders:
+    cyclopsglow: unshaded
 
 # RArm
 

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/vox.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/vox.yml
@@ -565,7 +565,8 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/Vox/tail.rsi
     state: lantern
-  shader: unshaded
+  shaders:
+    lantern: unshaded
 
 - type: marking
   id: VoxTailSmallPlume

--- a/Resources/Prototypes/_starcup/Entities/Mobs/Customization/Markings/humanoid.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/Customization/Markings/humanoid.yml
@@ -1,0 +1,59 @@
+# Eyes
+- type: marking
+  id: EyesGlowing
+  bodyPart: Eyes
+  groupWhitelist: [Human, Oni, Rodentia, Felinid, Vulpkanin, Reptilian, Harpy]
+  sprites:
+  - sprite: Mobs/Customization/eyes.rsi
+    state: eyes
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+  shaders:
+    eyes: unshaded
+
+- type: marking
+  id: TattooEyeRightGlowing
+  bodyPart: Eyes
+  groupWhitelist: [Human, Oni, Rodentia, Felinid, Vulpkanin, Reptilian, Harpy]
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true
+  sprites:
+  - sprite: Mobs/Customization/tattoos.rsi
+    state: tattoo_eye_r
+  shaders:
+    tattoo_eye_r: unshaded
+
+- type: marking
+  id: TattooEyeLeftGlowing
+  bodyPart: Eyes
+  groupWhitelist: [Human, Oni, Rodentia, Felinid, Vulpkanin, Reptilian, Harpy]
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true
+  sprites:
+  - sprite: Mobs/Customization/tattoos.rsi
+    state: tattoo_eye_l
+  shaders:
+    tattoo_eye_l: unshaded
+
+- type: marking
+  id: MakeupBlushGlowing
+  bodyPart: Head
+  groupWhitelist: [Human, Oni, Rodentia, Felinid, Vulpkanin, Reptilian, Slime, Harpy]
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+          color: "#d39394"
+  sprites:
+  - sprite: _DV/Mobs/Customization/makeup.rsi
+    state: blush
+  shaders:
+    blush: unshaded


### PR DESCRIPTION
Ports functionality from Macrocosm for markings to have shaders, and in particular, unshaded layers, letting markings glow in the dark! Other shaders should be possible too. 

Slimes, moths, diona, and vox's glowing markings will now glow again, and general glowing eyes and blush markings have been added. 

Future PRs can expand glowing marking possiblities, potentially including making MKC screens glow in the dark.

## Why / Balance
Flexibility in character customization that was originally lost to nubody/upmerges.

## Technical details
Port of https://github.com/syndicate-ss14/macrocosm/pull/2.
Resolves https://github.com/teamstarcup/starcup/issues/750.

The change to the moth markings are uncommented, but I think once Imp upmerges to macrocosm they will make the same change. 

I also think that a little check box in the color selection UI would also be great to have more flexiblity in making markings shaded/unshaded and reducing the number of prototypes, but that's a thing for later.

## Media
<img width="101" height="167" alt="maddoxlight" src="https://github.com/user-attachments/assets/0895cce9-c3b2-4096-bcdc-ceb5aa911304" />
<img width="124" height="169" alt="maddoxdark" src="https://github.com/user-attachments/assets/6f0726a6-5477-403d-a62d-29dc6ae6c102" />
<img width="149" height="174" alt="tricheyesglowlight" src="https://github.com/user-attachments/assets/c844e6a8-51e7-40bd-8c55-faa7679a2f29" />
<img width="145" height="191" alt="tricheyesglowdark" src="https://github.com/user-attachments/assets/aa48f161-a1ba-4e93-bad7-a08477d63401" />

Special glowing slime markings and the general glowing blush/eyes.

**Changelog**
:cl:
- add: Added glowing eyes and blush markings!
- fix: Moth, slime, vox, and diona markings that were intended to glow will now glow again.
