### PR TITLE
feat: flora 2.5 add bloodstream to trees, various tree and stump fixes

### DIFF
--- a/Resources/Locale/en-US/_starcup/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/biological.ftl
@@ -1,4 +1,4 @@
 reagent-desc-blood-starcup = This probably shouldn't be outside of somebody.
 
-reagent-name-resin = Resin
+reagent-name-resin = resin
 reagent-desc-resin = Bitter, woody, dense lifeblood of the soil.

--- a/Resources/Locale/en-US/_starcup/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_starcup/reagents/meta/biological.ftl
@@ -1,1 +1,4 @@
 reagent-desc-blood-starcup = This probably shouldn't be outside of somebody.
+
+reagent-name-resin = Resin
+reagent-desc-resin = Bitter, woody, dense lifeblood of the soil.

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -112,7 +112,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Resin
-        Quantity: 250
+        Quantity: 50
     # end starcup
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -215,7 +215,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Resin
-        Quantity: 350
+        Quantity: 70
     # end starcup
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -42,6 +42,7 @@
           acts: [ "Destruction" ]
 
 - type: entity
+  parent: MobBloodstream # starcup: add bloodstream to trees
   id: BaseTree
   description: Yep, it's a tree.
   abstract: true
@@ -106,6 +107,13 @@
           # end starcup
   - type: TypingIndicator # Add diona typing indicator here so that diona players keep the same typing bubble when polymorphed into a tree.
     proto: diona
+    # begin starcup: add bloodstream to trees
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 250
+    # end starcup
 
 - type: entity
   parent: BaseTree
@@ -173,7 +181,7 @@
         density: 2000
         layer:
         - WallLayer
-  # begin starcup: add stumps
+  # begin starcup: add stumps and bloodstream to trees
   - type: Destructible
     thresholds:
     - trigger:
@@ -203,7 +211,12 @@
             min: 1
             max: 1
         offset: 0
-  # end starcup
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 350
+    # end starcup
 
 - type: entity
   parent: BaseTree

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -111,7 +111,7 @@
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:
-      - ReagentId: Sap
+      - ReagentId: Resin
         Quantity: 250
     # end starcup
 
@@ -214,7 +214,7 @@
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:
-      - ReagentId: Sap
+      - ReagentId: Resin
         Quantity: 350
     # end starcup
 

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
@@ -38,4 +38,4 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Honey
-        Quantity: 100
+        Quantity: 60

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
@@ -38,4 +38,4 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Honey
-        Quantity: 60
+        Quantity: 40

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
@@ -1,6 +1,8 @@
 # Re-parented, modified RMC prototype
 - type: entity
-  parent: FloraPlantBaseStarcup
+  parent:
+  - FloraPlantBaseStarcup
+  - MobBloodstream
   id: FloraAlienPlant
   description: Pox Polyps, commonly known as honeybulb and lamptrap, is a predatory plant whose glowing, sweet nectar is deadly to the insects it lures.
   name: lamptrap
@@ -32,3 +34,8 @@
     radius: 2.0
     energy: 1.5
     color: "#ecca87"
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Honey
+        Quantity: 100

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
@@ -160,7 +160,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Sap
-        Quantity: 100
+        Quantity: 25
 
 - type: entity
   parent: BaseStumpStarcup
@@ -267,7 +267,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Resin
-        Quantity: 100
+        Quantity: 15
 
 - type: entity
   parent: BaseTreeLarge
@@ -331,7 +331,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Resin
-        Quantity: 100
+        Quantity: 25
 
 - type: entity
   parent: BaseStumpStarcup

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
@@ -266,7 +266,7 @@
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:
-      - ReagentId: Sap
+      - ReagentId: Resin
         Quantity: 100
 
 - type: entity
@@ -321,12 +321,17 @@
           Log:
             min: 1
             max: 2
-          AjoraxStump:
+          AjoraxStumpLarge:
             min: 1
             max: 1
         offset: 0
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Resin
+        Quantity: 100
 
 - type: entity
   parent: BaseStumpStarcup
@@ -334,7 +339,7 @@
   components:
   - type: Sprite
     sprite: _starcup/Structures/Nature/Flora/Trees/AlienTrees/flora_ajorax_trees.rsi
-    offset: 0,0.7
+    offset: 0,0
     layers:
     - state: treestump1
       map: ["random"]
@@ -364,7 +369,7 @@
   components:
   - type: Sprite
     sprite: _starcup/Structures/Nature/Flora/Trees/AlienTrees/flora_ajorax_trees_large.rsi
-    offset: 0,0.7
+    offset: 0,1.5
     layers:
     - state: treestump1
       map: ["random"]

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
@@ -156,6 +156,11 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 100
 
 - type: entity
   parent: BaseStumpStarcup
@@ -258,6 +263,11 @@
         offset: 0
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 100
 
 - type: entity
   parent: BaseTreeLarge

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/conifer_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/conifer_trees.yml
@@ -186,6 +186,11 @@
             min: 1
             max: 1
         offset: 0
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 500
 
 - type: entity
   parent: BaseStumpStarcup

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/conifer_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/conifer_trees.yml
@@ -186,11 +186,6 @@
             min: 1
             max: 1
         offset: 0
-  - type: Bloodstream
-    bloodReferenceSolution:
-      reagents:
-      - ReagentId: Sap
-        Quantity: 500
 
 - type: entity
   parent: BaseStumpStarcup

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/deciduous_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/deciduous_trees.yml
@@ -324,6 +324,11 @@
             min: 1
             max: 1
         offset: 0
+  - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 250
 
 - type: entity
   parent: BaseStumpStarcup
@@ -331,6 +336,7 @@
   suffix: aspen
   components:
   - type: Sprite
+    offset: 0,1
     sprite: _starcup/Structures/Nature/Flora/Trees/DeciduousTrees/flora_aspen_birches.rsi
     layers:
     - state: treestump1
@@ -411,18 +417,27 @@
         treestump2: ""
 
 - type: entity
-  parent: BaseTreeLarge
+  parent: BaseTree
   id: FloraTreeLargeTeal
   name: large tree
   suffix: teal
   description: A large, curiously shaped tree. Could it hear the thoughts of those pondering in its shade?
   components:
   - type: Sprite
-    offset: 0,0
+    offset: 0,1.5
     sprite: _starcup/Structures/Nature/Flora/Trees/DeciduousTrees/flora_treeslarge_teal.rsi
     layers:
     - state: treelarge01
       map: ["random"]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.3,-0.4,0.3,0.4"
+        density: 1000
+        layer:
+        - WallLayer
   - type: RandomSprite
     available:
     - random:
@@ -470,6 +485,15 @@
     layers:
     - state: treestump1
       map: ["random"]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.03,-0.05,0.03,0.05"
+        density: 1000
+        layer:
+        - WallLayer
   - type: RandomSprite
     available:
     - random:
@@ -529,6 +553,7 @@
   suffix: cherry
   components:
   - type: Sprite
+    offset: 0,0.95
     sprite: _starcup/Structures/Nature/Flora/Trees/DeciduousTrees/flora_cherry_trees.rsi
     layers:
     - state: treestump1
@@ -592,6 +617,7 @@
   suffix: juniper
   components:
   - type: Sprite
+    offset: 0,1
     sprite: _starcup/Structures/Nature/Flora/Trees/DeciduousTrees/flora_juniper_trees.rsi
     state: treestump
     layers:

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/deciduous_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/deciduous_trees.yml
@@ -328,7 +328,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: Sap
-        Quantity: 250
+        Quantity: 50
 
 - type: entity
   parent: BaseStumpStarcup

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/stump.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/stump.yml
@@ -56,6 +56,7 @@
   suffix: deciduous
   components:
   - type: Sprite
+    offset: 0,0.9
     sprite: _starcup/Structures/Nature/Flora/Trees/DeciduousTrees/flora_autumn_trees.rsi
     layers:
     - state: treestump1

--- a/Resources/Prototypes/_starcup/Reagents/resin.yml
+++ b/Resources/Prototypes/_starcup/Reagents/resin.yml
@@ -10,14 +10,6 @@
   viscosity: 0.30
   tileReactions:
   - !type:SpillTileReaction
-  metabolisms:
-    Digestion:
-      # Sweet!
-      effects:
-      - !type:SatiateHunger
-        factor: 0
-      - !type:SatiateThirst
-        factor: 0
   footstepSound:
     collection: FootstepSlime
     params:

--- a/Resources/Prototypes/_starcup/Reagents/resin.yml
+++ b/Resources/Prototypes/_starcup/Reagents/resin.yml
@@ -1,0 +1,24 @@
+- type: reagent
+  id: Resin
+  name: reagent-name-resin
+  group: Biological
+  desc: reagent-desc-resin
+  flavor: bitter
+  color: "#cd7314"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-sticky
+  viscosity: 0.30
+  tileReactions:
+  - !type:SpillTileReaction
+  metabolisms:
+    Digestion:
+      # Sweet!
+      effects:
+      - !type:SatiateHunger
+        factor: 1
+      - !type:SatiateThirst
+        factor: 1
+  footstepSound:
+    collection: FootstepSlime
+    params:
+      volume: 6

--- a/Resources/Prototypes/_starcup/Reagents/resin.yml
+++ b/Resources/Prototypes/_starcup/Reagents/resin.yml
@@ -15,9 +15,9 @@
       # Sweet!
       effects:
       - !type:SatiateHunger
-        factor: 1
+        factor: 0
       - !type:SatiateThirst
-        factor: 1
+        factor: 0
   footstepSound:
     collection: FootstepSlime
     params:

--- a/Resources/Prototypes/_starcup/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_starcup/Recipes/Reactions/chemicals.yml
@@ -1,0 +1,10 @@
+- type: reaction
+  id: ResinGlue
+  minTemp: 370
+  reactants:
+    Resin:
+      amount: 1
+    Charcoal:
+      amount: 1
+  products:
+    SpaceGlue: 1


### PR DESCRIPTION
**THIS IS A MISTAKE. MobBloodstream has the MapSave variable turned off. It will make your trees unsavable. Do not do this.**

If you wish to have this, take only the resin reagent and go to https://github.com/teamstarcup/starcup/pull/881 instead.
______________________________________________________________________________________________

Gives trees a bloodstream with a new reagent, resin, for blood. This PR paves the way for the introduction of cacti in flora 3, that will have a mix of sugar and water for their bloodstream.

## Why / Balance
Giving trees a bloodstream opens up a lot of new possibilities, as certain species or even rare specimens can have different chemicals that can be sampled by botanists or scientists for round objectives or story purposes. Giving them the existing sap reagent wasn't deemed a good idea, as sap can be consumed to satiate hunger or thirst, that's why we made resin. There are some trees (notably the reeds of paradise) that do have easily consumable sap. The lamptrap plant also now comes with honey.

## Technical details
- Added resin, a new reagent.
- Parented BaseTree to MobBloodstream and gave them resin for blood.
- Added a chemical reaction to make resin mixed with charcoal and heated up turn into space glue.
- Gave aspen birches and reeds of paradise a sap bloodstream instead of resin.
- Gave lamptraps a honey bloodstream.
- Fixed several collision and sprite offset errors on various trees and stumps.

**Changelog**

:cl:
- add: Trees now have resin that can be extracted and used to make glue. Some species may have other substances instead...