### PR TITLE
feat: Add ability to use custom sounds for vent hordes

### DIFF
--- a/Content.Server/StationEvents/Components/VentHordeRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentHordeRuleComponent.cs
@@ -1,5 +1,6 @@
-﻿using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Events;
 using Content.Shared.EntityTable.EntitySelectors;
+using Robust.Shared.Audio; // starcup
 
 namespace Content.Server.StationEvents.Components;
 
@@ -23,4 +24,16 @@ public sealed partial class VentHordeRuleComponent : Component
     /// </summary>
     [DataField]
     public EntityUid? ChosenVent;
+
+    /// <summary>
+    /// starcup: Sound that will be used by <see cref="VentHordeSpawnerComponent"/> after the chosen vent is selected
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? PassiveSound;
+
+    /// <summary>
+    /// starcup: Sound that will play when entities are spawned by the <see cref="VentHordeSpawnerComponent"/>
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? EndSound;
 }

--- a/Content.Server/StationEvents/Events/VentHordeRule.cs
+++ b/Content.Server/StationEvents/Events/VentHordeRule.cs
@@ -83,7 +83,7 @@ public sealed class VentHordeRule : StationEventSystem<VentHordeRuleComponent>
         // And start the spawn at the chosen vent.
         // The duration is the same as the time until expected gamerule end time, but that is only for convenience.
         // The spawn can happen early in certain circumstances anyway.
-        _horde.StartHordeSpawn(component.ChosenVent.Value, spawns.ToList(), duration);
+        _horde.StartHordeSpawn(component.ChosenVent.Value, spawns.ToList(), duration, passiveSound: component.PassiveSound, endSound: component.EndSound); // starcup: Pass sounds
     }
 
     private EntityUid? ChooseVent()

--- a/Content.Server/VentHorde/Systems/VentHordeSystem.cs
+++ b/Content.Server/VentHorde/Systems/VentHordeSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.VentHorde.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Jittering;
 using Content.Shared.Throwing;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -62,7 +63,9 @@ public sealed class VentHordeSystem : EntitySystem
     /// <param name="spawns">List of entities to spawn.</param>
     /// <param name="spawnDelay">Time after which to spawn the entities.</param>
     /// <param name="append">If an already active spawner is selected, will add entities to its list. Otherwise, will fail.</param>
-    public void StartHordeSpawn(EntityUid uid, List<EntProtoId> spawns, TimeSpan spawnDelay, bool append = true)
+    /// starcup: <param name="passiveSound">Will override the default sound in VentHordeSpawnerComponent if provided.</param>
+    /// starcup: <param name="endSound">Will override the default sound in VentHordSpawnerComponent if provided.</param>
+    public void StartHordeSpawn(EntityUid uid, List<EntProtoId> spawns, TimeSpan spawnDelay, bool append = true, SoundSpecifier? passiveSound = null, SoundSpecifier? endSound = null)
     {
         if (TryComp<VentHordeSpawnerComponent>(uid, out var hordeSpawner))
         {
@@ -75,6 +78,14 @@ public sealed class VentHordeSystem : EntitySystem
         }
 
         hordeSpawner = EnsureComp<VentHordeSpawnerComponent>(uid);
+
+        // begin starcup: allow rules to set custom sounds
+        if (passiveSound is not null)
+            hordeSpawner.PassiveSound = passiveSound;
+
+        if (endSound is not null)
+            hordeSpawner.EndSound = endSound;
+        // end starcup
 
         hordeSpawner.AudioStream = _audio.PlayPvs(hordeSpawner.PassiveSound, uid, hordeSpawner.PassiveSound.Params.WithLoop(true))?.Entity;
 


### PR DESCRIPTION
## Why / Balance
Requested by @Psymbiote. 
Allows different critters to have their own sounds for the vents.

## Technical details
Adds the sound specifiers to the rule so they can be set on the spawner once the rule runs

## Media
https://github.com/user-attachments/assets/28916a51-7a34-4cc0-8342-0f4cad6a8c30

**Changelog**
Not player facing, no changelog