### PR TITLE
fix: chaplain's cyan crystal relic is now the item and not the structure

### DIFF
--- a/Resources/Prototypes/_starcup/Loadouts/Jobs/Service/chaplain.yml
+++ b/Resources/Prototypes/_starcup/Loadouts/Jobs/Service/chaplain.yml
@@ -131,4 +131,4 @@
   id: CrystalCyan
   storage:
     back:
-    - CrystalCyan
+    - ShardCrystalCyan


### PR DESCRIPTION
Oops!

## Why / Balance
The "sugar crystals" come in both shard form and structure form. I forgot to test the relics out after adding them.

## Media
This is wrong:
<img width="645" height="90" alt="image" src="https://github.com/user-attachments/assets/13906be2-1711-420e-a378-60f43d4d4056" />

**Changelog**
:cl:
- fix: Chaplain's cyan crystal relic is now the shard item, as intended.