### PR TITLE
fix: change discord invite link on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # starcup
 [![Static Badge](https://img.shields.io/badge/nightly-releases?label=releases)](https://builds.starcup.cc/fork/starcup)
 
-[Forum](https://forum.starcup.cc/) | [Wiki](https://wiki.starcup.cc/) | [Discord](https://discord.gg/5pC525RYbw)
+[Forum](https://forum.starcup.cc/) | [Wiki](https://wiki.starcup.cc/) | [Discord](https://discord.gg/PZFSQU93ES)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/F1F31BQOU8)
 


### PR DESCRIPTION
We believe it might've been a timed invitation, which accounted for all the people that joined the server only to find themselves randomly kicked out without warning.

## Technical details
Changed Discord invite link at meowmeow's behest.
