### PR TITLE
map(banana): various fixes and tweaks

### DIFF
--- a/Resources/Maps/_starcup/banana.yml
+++ b/Resources/Maps/_starcup/banana.yml
@@ -8591,7 +8591,7 @@ entities:
   - uid: 1194
     components:
     - type: Transform
-      rot: -3.1 rad
+      rot: 3.141592653589793 rad
       pos: -43.56247,-3.3
       parent: 2
   - uid: 1195
@@ -8600,8 +8600,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -29.5,8.5
       parent: 2
-    - type: Pullable
-      prevFixedRotation: True
   - uid: 1196
     components:
     - type: Transform

--- a/Resources/Maps/_starcup/banana.yml
+++ b/Resources/Maps/_starcup/banana.yml
@@ -8591,8 +8591,8 @@ entities:
   - uid: 1194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -43.56247,-4.3052955
+      rot: -3.1 rad
+      pos: -43.56247,-3.3
       parent: 2
   - uid: 1195
     components:
@@ -9188,8 +9188,7 @@ entities:
   - uid: 1274
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -44.5,-4.5
+      pos: -44.5,-2.5
       parent: 2
   - uid: 1275
     components:
@@ -10594,7 +10593,7 @@ entities:
   - uid: 1494
     components:
     - type: Transform
-      pos: -44.5,-2.5
+      pos: -44.5,-4.5
       parent: 2
 - proto: ExtinguisherCabinetFilled
   entities:

--- a/Resources/Maps/_starcup/banana.yml
+++ b/Resources/Maps/_starcup/banana.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 272.0.0
+  engineVersion: 275.2.0
   forkId: ""
   forkVersion: ""
-  time: 02/25/2026 03:36:48
-  entityCount: 3774
+  time: 06/01/2026 05:22:58
+  entityCount: 3747
 maps:
 - 1
 grids:
 - 2
-- 3684
+- 3746
 orphans: []
 nullspace: []
 tilemap:
@@ -70,7 +70,7 @@ entities:
           version: 7
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAACAAAAAAAACQAAAAAAAAoAAAAAAgAJAAAAAAEACgAAAAAAAAkAAAAAAwAKAAAAAAMAAgAAAAAAAAYAAAAAAgAGAAAAAAIABgAAAAAAAAYAAAAAAQAEAAAAAAMABAAAAAADAAsAAAAAAAALAAAAAAAAAgAAAAAAAAoAAAAAAQAJAAAAAAAACgAAAAAAAAkAAAAAAgAKAAAAAAAACQAAAAADAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAgACAAAAAAAAAgAAAAAAAAIAAAAAAAALAAAAAAAACwAAAAAAAAAAAAAAAQAJAAAAAAAACgAAAAADAAkAAAAAAgAKAAAAAAIACQAAAAAAAAoAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAADAAIAAAAAAAADAAAAAAAACwAAAAAAAAsAAAAAAAACAAAAAAAACgAAAAACAAkAAAAAAQAKAAAAAAIACQAAAAABAAoAAAAAAwAJAAAAAAIAAgAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAACAAAAAAAAAwACAAAAAAAAAQAAAAAAAAsAAAAAAAALAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAEAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAEAAwAAAAAAAAMAAAAAAAALAAAAAAAACwAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAwAAAAAAAAMAAAAAAAAAgAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAAMAAAAAAAADAAAAAAAAAIAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAACAAAAAAAACQAAAAAAAAoAAAAAAgAJAAAAAAEACgAAAAAAAAkAAAAAAwAKAAAAAAMAAgAAAAAAAAYAAAAAAgAGAAAAAAIABgAAAAAAAAYAAAAAAQAEAAAAAAMABAAAAAADAAsAAAAAAAALAAAAAAAAAAAAAAAAAAoAAAAAAQAJAAAAAAAACgAAAAAAAAkAAAAAAgAKAAAAAAAACQAAAAADAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAgACAAAAAAAAAgAAAAAAAAIAAAAAAAALAAAAAAAACwAAAAAAAAAAAAAAAQAJAAAAAAAACgAAAAADAAkAAAAAAgAKAAAAAAIACQAAAAAAAAoAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAADAAIAAAAAAAADAAAAAAAACwAAAAAAAAsAAAAAAAACAAAAAAAACgAAAAACAAkAAAAAAQAKAAAAAAIACQAAAAABAAoAAAAAAwAJAAAAAAIAAgAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAACAAAAAAAAAwACAAAAAAAAAQAAAAAAAAsAAAAAAAALAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAEAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAEAAwAAAAAAAAMAAAAAAAALAAAAAAAACwAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAwAAAAAAAAMAAAAAAAAAgAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAAMAAAAAAAADAAAAAAAAAIAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
           version: 7
         -2,-1:
           ind: -2,-1
@@ -86,7 +86,7 @@ entities:
           version: 7
         -3,-1:
           ind: -3,-1
-          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAgAAAAAAAAYAAAAAAQAGAAAAAAEABgAAAAADAAIAAAAAAAACAAAAAAAAAAAAAAACAAEAAAAAAAAAAAAAAAIAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAAAGAAAAAAMABgAAAAABAAYAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAwADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAQACAAAAAAAABgAAAAADAAYAAAAAAwAGAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAYAAAAAAAAGAAAAAAEABgAAAAACAAIAAAAAAAAAAAAAAAAAAAAAAAADAAMAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAIAAAAAAAAGAAAAAAEABgAAAAADAAYAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwACAAAAAAAABgAAAAABAAYAAAAAAAAGAAAAAAIAAAAAAAABAAAAAAAAAwAAAAAAAAEAAwAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAwACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAMABgAAAAADAAYAAAAAAAAGAAAAAAEABgAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAMAAAAAAAADAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAGAAAAAAEABgAAAAACAAYAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAAABgAAAAABAAYAAAAAAgAGAAAAAAMAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAIAAgAAAAAAAAYAAAAAAQAGAAAAAAMABgAAAAADAAAAAAAAAQAQAAAAAAAAEAAAAAACAAMAAAAAAAABAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAABAAIAAAAAAAAGAAAAAAMABgAAAAABAAYAAAAAAAAAAAAAAAIAEAAAAAABABAAAAAAAQADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAACAAAAAAAABgAAAAACAAYAAAAAAAAGAAAAAAMAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAwAAAAAAAAIAAgAAAAAAAAYAAAAAAQAGAAAAAAEABgAAAAACAAYAAAAAAwAGAAAAAAAABgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAGAAAAAAIABgAAAAACAAYAAAAAAwAGAAAAAAMABgAAAAADAAYAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABgAAAAAAAAYAAAAAAwAGAAAAAAMABgAAAAABAAYAAAAAAAAGAAAAAAIAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAADAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAYAAAAAAAAGAAAAAAIABgAAAAABAAYAAAAAAAAGAAAAAAEABgAAAAADAA==
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAgAAAAAAAAYAAAAAAQAGAAAAAAEABgAAAAADAAIAAAAAAAACAAAAAAAAAAAAAAACAAEAAAAAAAAAAAAAAAIAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAAAGAAAAAAMABgAAAAABAAYAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAwADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAQACAAAAAAAABgAAAAADAAYAAAAAAwAGAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAYAAAAAAAAGAAAAAAEABgAAAAACAAIAAAAAAAAAAAAAAAAAAAAAAAADAAMAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAIAAAAAAAAGAAAAAAEABgAAAAADAAYAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwACAAAAAAAABgAAAAABAAYAAAAAAAAGAAAAAAIAAAAAAAABAAAAAAAAAwAAAAAAAAEAAwAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAwACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAMABgAAAAADAAYAAAAAAAAGAAAAAAEABgAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAMAAAAAAAADAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAGAAAAAAEABgAAAAACAAYAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAAABgAAAAABAAYAAAAAAgAGAAAAAAMAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAIAAgAAAAAAAAYAAAAAAQAGAAAAAAMABgAAAAADAAAAAAAAAQAQAAAAAAAAEAAAAAACAAMAAAAAAAABAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAABAAIAAAAAAAAGAAAAAAMABgAAAAABAAYAAAAAAAAAAAAAAAIAEAAAAAABABAAAAAAAQADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAACAAAAAAAABgAAAAACAAYAAAAAAAAGAAAAAAMAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAwAAAAAAAAIAAgAAAAAAAAYAAAAAAQAGAAAAAAEABgAAAAACAAYAAAAAAwAGAAAAAAAABgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAGAAAAAAIABgAAAAACAAYAAAAAAwAGAAAAAAMABgAAAAADAAYAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABgAAAAAAAAYAAAAAAwAGAAAAAAMABgAAAAABAAYAAAAAAAAGAAAAAAIAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAADAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAYAAAAAAAAGAAAAAAIABgAAAAABAAYAAAAAAAAGAAAAAAEABgAAAAADAA==
           version: 7
         -3,-2:
           ind: -3,-2
@@ -150,16 +150,33 @@ entities:
         version: 2
         nodes:
         - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteCornerNe
+            color: '#D381C996'
+            id: BrickCornerOverlayNE
           decals:
-            212: -43,-28
-            230: -43,-23
-            235: -40,-23
-            242: -36,-26
-            246: -31,-27
-            271: -32,-22
-            272: -31,-24
+            700: -40,-3
+        - node:
+            color: '#D381C996'
+            id: BrickCornerOverlayNW
+          decals:
+            701: -45,-3
+        - node:
+            color: '#D381C996'
+            id: BrickLineOverlayE
+          decals:
+            707: -40,-4
+        - node:
+            color: '#D381C996'
+            id: BrickLineOverlayN
+          decals:
+            702: -44,-3
+            703: -43,-3
+            704: -42,-3
+            705: -41,-3
+        - node:
+            color: '#D381C996'
+            id: BrickLineOverlayW
+          decals:
+            706: -45,-4
         - node:
             color: '#3C44AA96'
             id: BrickTileWhiteCornerNe
@@ -182,6 +199,16 @@ entities:
             482: -35,6
             524: -25,7
         - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteCornerNe
+          decals:
+            640: -32,-22
+            641: -31,-24
+            642: -31,-27
+            643: -43,-28
+            653: -36,-26
+            670: -43,-23
+        - node:
             color: '#8C347F96'
             id: BrickTileWhiteCornerNe
           decals:
@@ -203,11 +230,6 @@ entities:
           decals:
             442: -7,-8
         - node:
-            color: '#D381C996'
-            id: BrickTileWhiteCornerNe
-          decals:
-            333: -40,-4
-        - node:
             color: '#D4D4D428'
             id: BrickTileWhiteCornerNe
           decals:
@@ -224,15 +246,6 @@ entities:
           decals:
             351: -35,2
             354: -42,11
-        - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteCornerNw
-          decals:
-            211: -44,-28
-            229: -44,-23
-            234: -41,-23
-            241: -38,-26
-            270: -34,-22
         - node:
             color: '#3C44AA96'
             id: BrickTileWhiteCornerNw
@@ -259,6 +272,15 @@ entities:
             510: -33,2
             523: -27,7
         - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteCornerNw
+          decals:
+            645: -41,-23
+            646: -44,-23
+            647: -44,-28
+            648: -34,-22
+            654: -38,-26
+        - node:
             color: '#8C347F96'
             id: BrickTileWhiteCornerNw
           decals:
@@ -280,11 +302,6 @@ entities:
           decals:
             441: -14,-8
         - node:
-            color: '#D381C996'
-            id: BrickTileWhiteCornerNw
-          decals:
-            332: -45,-4
-        - node:
             color: '#D4D4D428'
             id: BrickTileWhiteCornerNw
           decals:
@@ -300,14 +317,6 @@ entities:
             id: BrickTileWhiteCornerNw
           decals:
             353: -45,11
-        - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteCornerSe
-          decals:
-            208: -43,-30
-            225: -43,-26
-            249: -31,-30
-            273: -31,-25
         - node:
             color: '#3C44AA96'
             id: BrickTileWhiteCornerSe
@@ -328,6 +337,14 @@ entities:
             480: -35,4
             498: -29,1
             525: -25,1
+        - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteCornerSe
+          decals:
+            649: -43,-30
+            650: -43,-26
+            651: -31,-25
+            652: -31,-30
         - node:
             color: '#8C347F96'
             id: BrickTileWhiteCornerSe
@@ -373,14 +390,6 @@ entities:
             349: -40,-1
             350: -35,1
         - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteCornerSw
-          decals:
-            206: -41,-30
-            209: -44,-30
-            226: -44,-26
-            269: -34,-25
-        - node:
             color: '#3C44AA96'
             id: BrickTileWhiteCornerSw
           decals:
@@ -402,6 +411,14 @@ entities:
             491: -33,4
             511: -33,1
             522: -27,1
+        - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteCornerSw
+          decals:
+            656: -41,-30
+            657: -44,-30
+            658: -44,-26
+            659: -34,-25
         - node:
             color: '#8C347F96'
             id: BrickTileWhiteCornerSw
@@ -447,16 +464,6 @@ entities:
           decals:
             352: -45,-1
         - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteInnerNe
-          decals:
-            214: -43,-29
-            231: -43,-24
-            260: -40,-27
-            261: -36,-27
-            262: -33,-27
-            278: -32,-24
-        - node:
             color: '#474F52FF'
             id: BrickTileWhiteInnerNe
           decals:
@@ -472,6 +479,16 @@ entities:
             483: -35,5
             516: -29,3
         - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteInnerNe
+          decals:
+            671: -36,-27
+            672: -40,-27
+            673: -32,-24
+            674: -33,-27
+            675: -43,-29
+            687: -43,-24
+        - node:
             color: '#DE3A3A96'
             id: BrickTileWhiteInnerNe
           decals:
@@ -482,14 +499,6 @@ entities:
           decals:
             393: -46,7
             395: -42,2
-        - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteInnerNw
-          decals:
-            216: -41,-29
-            233: -41,-24
-            259: -38,-27
-            263: -33,-27
         - node:
             color: '#474F52FF'
             id: BrickTileWhiteInnerNw
@@ -510,6 +519,14 @@ entities:
             512: -30,2
             517: -27,3
         - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteInnerNw
+          decals:
+            676: -41,-29
+            677: -38,-27
+            678: -33,-27
+            679: -41,-24
+        - node:
             color: '#DE3A3A96'
             id: BrickTileWhiteInnerNw
           decals:
@@ -519,13 +536,6 @@ entities:
             id: BrickTileWhiteInnerNw
           decals:
             392: -45,7
-        - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteInnerSe
-          decals:
-            213: -43,-29
-            223: -43,-24
-            267: -33,-25
         - node:
             color: '#474F52FF'
             id: BrickTileWhiteInnerSe
@@ -539,6 +549,14 @@ entities:
           decals:
             485: -35,5
             518: -29,3
+        - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteInnerSe
+          decals:
+            680: -43,-29
+            681: -33,-25
+            685: -40,-24
+            686: -43,-24
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteInnerSe
@@ -556,13 +574,6 @@ entities:
             373: -40,1
             394: -46,7
         - node:
-            color: '#334E6DC8'
-            id: BrickTileWhiteInnerSw
-          decals:
-            207: -41,-29
-            221: -41,-24
-            266: -33,-25
-        - node:
             color: '#474F52FF'
             id: BrickTileWhiteInnerSw
           decals:
@@ -578,6 +589,13 @@ entities:
             486: -33,5
             514: -30,4
             515: -27,3
+        - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteInnerSw
+          decals:
+            682: -41,-29
+            683: -41,-24
+            684: -33,-25
         - node:
             color: '#D381C996'
             id: BrickTileWhiteInnerSw
@@ -597,14 +615,7 @@ entities:
             color: '#334E6DC8'
             id: BrickTileWhiteLineE
           decals:
-            224: -43,-25
-            236: -40,-24
-            237: -40,-25
-            238: -40,-26
-            247: -31,-28
-            248: -31,-29
             265: -33,-26
-            274: -32,-23
         - node:
             color: '#3C44AA96'
             id: BrickTileWhiteLineE
@@ -668,6 +679,16 @@ entities:
             530: -25,6
             608: -25,2
             609: -25,3
+        - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteLineE
+          decals:
+            616: -40,-25
+            617: -40,-26
+            618: -31,-29
+            619: -31,-28
+            620: -43,-25
+            622: -32,-23
         - node:
             color: '#8C347F96'
             id: BrickTileWhiteLineE
@@ -739,12 +760,6 @@ entities:
           decals:
             215: -42,-29
             232: -42,-24
-            239: -39,-27
-            240: -37,-26
-            243: -35,-27
-            244: -34,-27
-            245: -32,-27
-            277: -33,-22
         - node:
             color: '#3C44AA96'
             id: BrickTileWhiteLineN
@@ -821,6 +836,17 @@ entities:
             520: -28,3
             531: -26,7
         - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteLineN
+          decals:
+            634: -33,-22
+            635: -32,-27
+            636: -34,-27
+            637: -35,-27
+            638: -39,-27
+            639: -37,-26
+            688: -40,-23
+        - node:
             color: '#8C347F96'
             id: BrickTileWhiteLineN
           decals:
@@ -851,14 +877,6 @@ entities:
             456: -10,-8
             457: -9,-8
             458: -8,-8
-        - node:
-            color: '#D381C996'
-            id: BrickTileWhiteLineN
-          decals:
-            345: -44,-4
-            346: -43,-4
-            347: -42,-4
-            348: -41,-4
         - node:
             color: '#D4D4D428'
             id: BrickTileWhiteLineN
@@ -892,16 +910,6 @@ entities:
             id: BrickTileWhiteLineS
           decals:
             222: -42,-24
-            250: -32,-30
-            251: -33,-30
-            252: -34,-30
-            253: -35,-30
-            254: -36,-30
-            255: -37,-30
-            256: -38,-30
-            257: -39,-30
-            258: -40,-30
-            268: -32,-25
             553: -42,-29
         - node:
             color: '#3C44AA96'
@@ -985,6 +993,20 @@ entities:
             497: -30,1
             519: -28,3
         - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteLineS
+          decals:
+            655: -32,-25
+            660: -32,-30
+            661: -33,-30
+            662: -34,-30
+            663: -35,-30
+            664: -36,-30
+            665: -37,-30
+            666: -38,-30
+            667: -40,-30
+            668: -39,-30
+        - node:
             color: '#8C347F96'
             id: BrickTileWhiteLineS
           decals:
@@ -1052,16 +1074,7 @@ entities:
             color: '#334E6DC8'
             id: BrickTileWhiteLineW
           decals:
-            210: -44,-29
-            217: -41,-28
-            218: -41,-27
-            219: -41,-26
-            220: -41,-25
-            227: -44,-25
-            228: -44,-24
             264: -33,-26
-            275: -34,-24
-            276: -34,-23
         - node:
             color: '#3C44AA96'
             id: BrickTileWhiteLineW
@@ -1116,6 +1129,19 @@ entities:
             532: -27,4
             533: -27,5
             534: -27,6
+        - node:
+            color: '#66244AB2'
+            id: BrickTileWhiteLineW
+          decals:
+            623: -34,-23
+            624: -34,-24
+            626: -41,-28
+            628: -41,-25
+            629: -41,-26
+            630: -41,-27
+            631: -44,-29
+            632: -44,-25
+            633: -44,-24
         - node:
             color: '#8C347F96'
             id: BrickTileWhiteLineW
@@ -1286,7 +1312,7 @@ entities:
           -5,-3:
             0: 65532
           -4,-2:
-            0: 52429
+            0: 52301
             2: 13056
           -5,-2:
             0: 14
@@ -1296,7 +1322,7 @@ entities:
           -5,-1:
             0: 61439
           -4,0:
-            0: 49147
+            0: 49083
           -3,-3:
             0: 65525
           -3,-2:
@@ -1312,15 +1338,16 @@ entities:
           -2,-1:
             0: 65535
           -2,0:
-            0: 57117
+            0: 40733
+            4: 16384
           -5,0:
-            0: 65520
+            0: 65504
           -4,1:
-            0: 51
+            0: 307
             3: 12288
             1: 34944
           -5,1:
-            0: 31672
+            0: 29624
             3: 32768
           -4,2:
             3: 3
@@ -1348,7 +1375,8 @@ entities:
           -1,3:
             1: 56
           -8,-4:
-            0: 65521
+            0: 57329
+            4: 8192
           -8,-5:
             0: 65535
           -9,-4:
@@ -1382,7 +1410,7 @@ entities:
           -6,-1:
             0: 65535
           -6,0:
-            0: 61428
+            0: 61412
           -6,-4:
             0: 34944
           -9,0:
@@ -1401,7 +1429,7 @@ entities:
             1: 34944
             0: 13104
           -7,0:
-            0: 65504
+            0: 65248
           -7,1:
             0: 61183
           -7,3:
@@ -1435,7 +1463,7 @@ entities:
           -13,3:
             1: 13538
           -12,-1:
-            0: 41512
+            0: 41640
           -12,4:
             0: 142
             1: 61728
@@ -1448,25 +1476,25 @@ entities:
           -11,3:
             0: 65524
           -11,-1:
-            0: 61455
+            0: 61695
           -11,4:
             1: 61953
             0: 110
           -10,0:
             0: 4089
           -10,1:
-            4: 3
-            5: 768
+            5: 3
+            6: 768
             0: 2184
           -10,2:
-            6: 3
-            7: 768
+            7: 3
+            8: 768
             0: 34952
           -10,3:
             1: 16
             0: 49056
           -10,-1:
-            0: 64717
+            0: 64733
           -10,4:
             0: 3
             1: 64000
@@ -1498,7 +1526,8 @@ entities:
           -11,-4:
             0: 3822
           -10,-4:
-            0: 52733
+            0: 52477
+            9: 256
           -10,-3:
             0: 65501
           -10,-2:
@@ -1608,6 +1637,11 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
+            Oxygen: 21.6852
+            Nitrogen: 81.57766
+        - volume: 2500
+          temperature: 293.15
+          moles:
             Plasma: 6666.982
         - volume: 2500
           temperature: 293.15
@@ -1620,6 +1654,11 @@ entities:
           temperature: 293.15
           moles:
             Nitrogen: 6666.982
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
@@ -1629,7 +1668,7 @@ entities:
     - type: TileHistory
       chunkHistory: {}
     - type: ExplosionAirtightGrid
-  - uid: 3684
+  - uid: 3746
     components:
     - type: MetaData
       name: grid
@@ -1678,32 +1717,28 @@ entities:
     - type: ExplosionAirtightGrid
 - proto: AACTablet
   entities:
-  - uid: 3577
+  - uid: 5
     components:
     - type: Transform
-      parent: 3575
+      parent: 3
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: AirAlarm
+      storage: 3
+- proto: ActionToggleLight
   entities:
-  - uid: 3
+  - uid: 9
+    mapInit: true
+    paused: true
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -42.5,-9.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 1564
-      - 1565
-      - 1566
-      - 1569
-      - 2107
-      - 3708
-    - type: Fixtures
-      fixtures: {}
-  - uid: 4
+      parent: 8
+    - type: Action
+      originalIconColor: '#FFFFFFFF'
+      container: 8
+- proto: AirAlarm
+  entities:
+  - uid: 11
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1711,20 +1746,20 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1538
-      - 1537
-      - 1536
-      - 1535
-      - 1534
-      - 1533
-      - 1601
-      - 1602
-      - 1618
-      - 2152
-      - 2122
+      - 1516
+      - 1515
+      - 1514
+      - 1513
+      - 1512
+      - 1511
+      - 1578
+      - 1579
+      - 1594
+      - 2145
+      - 2115
     - type: Fixtures
       fixtures: {}
-  - uid: 5
+  - uid: 12
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1732,12 +1767,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2128
-      - 2157
-      - 1567
+      - 2121
+      - 2150
+      - 1545
     - type: Fixtures
       fixtures: {}
-  - uid: 6
+  - uid: 13
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1745,47 +1780,46 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2171
-      - 1616
+      - 2163
+      - 1592
     - type: Fixtures
       fixtures: {}
-  - uid: 7
+  - uid: 14
     components:
     - type: Transform
       pos: -16.5,0.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1538
-      - 1537
-      - 1536
-      - 1535
-      - 1534
-      - 1533
-      - 1599
-      - 1598
-      - 1597
-      - 1596
-      - 1595
-      - 1594
-      - 1605
-      - 1604
-      - 1606
-      - 1607
-      - 1531
-      - 1530
-      - 1541
-      - 1540
-      - 1539
-      - 1593
-      - 1592
-      - 2124
-      - 2154
-      - 2153
-      - 2123
+      - 1516
+      - 1515
+      - 1514
+      - 1513
+      - 1512
+      - 1511
+      - 1576
+      - 1575
+      - 1574
+      - 1573
+      - 1572
+      - 1571
+      - 1582
+      - 1581
+      - 1583
+      - 1509
+      - 1508
+      - 1519
+      - 1518
+      - 1517
+      - 1570
+      - 1569
+      - 2117
+      - 2147
+      - 2146
+      - 2116
     - type: Fixtures
       fixtures: {}
-  - uid: 8
+  - uid: 15
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1793,19 +1827,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2121
-      - 2151
-      - 1615
-      - 1620
-      - 1616
-      - 1545
-      - 1544
-      - 1543
-      - 1542
-      - 1621
+      - 2114
+      - 2144
+      - 1591
+      - 1596
+      - 1592
+      - 1523
+      - 1522
+      - 1521
+      - 1520
+      - 1597
     - type: Fixtures
       fixtures: {}
-  - uid: 9
+  - uid: 16
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1813,23 +1847,23 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2125
-      - 2155
-      - 1545
-      - 1544
-      - 1543
-      - 1542
-      - 1546
-      - 1547
+      - 2118
+      - 2148
+      - 1523
+      - 1522
+      - 1521
+      - 1520
+      - 1524
+      - 1525
+      - 1526
       - 1548
-      - 1570
-      - 1571
-      - 1572
-      - 1574
-      - 1575
+      - 1549
+      - 1550
+      - 1552
+      - 1553
     - type: Fixtures
       fixtures: {}
-  - uid: 10
+  - uid: 17
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1837,22 +1871,22 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2136
-      - 2169
-      - 1567
-      - 1568
-      - 1564
-      - 1565
-      - 1566
-      - 1548
-      - 1547
+      - 2129
+      - 2162
+      - 1545
       - 1546
-      - 1549
-      - 1550
-      - 1551
+      - 1542
+      - 1543
+      - 1544
+      - 1526
+      - 1525
+      - 1524
+      - 1527
+      - 1528
+      - 1529
     - type: Fixtures
       fixtures: {}
-  - uid: 11
+  - uid: 18
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1860,39 +1894,39 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2135
-      - 2168
-      - 1555
-      - 1554
-      - 1553
-      - 1552
-      - 1558
-      - 1559
-      - 1623
-      - 1622
-      - 1556
-      - 1549
-      - 1550
-      - 1551
+      - 2128
+      - 2161
+      - 1533
+      - 1532
+      - 1531
+      - 1530
+      - 1536
+      - 1537
+      - 1599
+      - 1598
+      - 1534
+      - 1527
+      - 1528
+      - 1529
     - type: Fixtures
       fixtures: {}
-  - uid: 12
+  - uid: 19
     components:
     - type: Transform
       pos: -46.5,-16.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2167
-      - 2134
-      - 1555
-      - 1554
-      - 1553
-      - 1552
-      - 1617
+      - 2160
+      - 2127
+      - 1533
+      - 1532
+      - 1531
+      - 1530
+      - 1593
     - type: Fixtures
       fixtures: {}
-  - uid: 13
+  - uid: 20
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1900,12 +1934,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2166
-      - 1617
-      - 2114
+      - 2159
+      - 1593
+      - 2107
     - type: Fixtures
       fixtures: {}
-  - uid: 14
+  - uid: 21
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1913,30 +1947,30 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2165
-      - 1563
+      - 2158
+      - 1541
     - type: Fixtures
       fixtures: {}
-  - uid: 15
+  - uid: 22
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2140
-      - 2178
-      - 1572
-      - 1571
-      - 1570
-      - 1526
-      - 1527
-      - 1528
-      - 1529
-      - 1586
+      - 2132
+      - 2170
+      - 1550
+      - 1549
+      - 1548
+      - 1504
+      - 1505
+      - 1506
+      - 1507
+      - 1563
     - type: Fixtures
       fixtures: {}
-  - uid: 16
+  - uid: 23
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1944,7 +1978,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17
+  - uid: 24
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1952,19 +1986,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2139
-      - 2174
-      - 1573
-      - 1577
-      - 1576
-      - 1582
-      - 1581
-      - 1580
-      - 1579
-      - 1578
+      - 2131
+      - 2166
+      - 1551
+      - 1555
+      - 1554
+      - 1560
+      - 1559
+      - 1558
+      - 1557
+      - 1556
     - type: Fixtures
       fixtures: {}
-  - uid: 18
+  - uid: 25
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1972,11 +2006,11 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2175
-      - 1578
+      - 2167
+      - 1556
     - type: Fixtures
       fixtures: {}
-  - uid: 19
+  - uid: 26
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1984,29 +2018,29 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2176
-      - 1573
+      - 2168
+      - 1551
     - type: Fixtures
       fixtures: {}
-  - uid: 20
+  - uid: 27
     components:
     - type: Transform
       pos: -25.5,8.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1584
-      - 1583
-      - 1582
-      - 1581
-      - 1580
-      - 1579
-      - 1525
-      - 2127
-      - 2156
+      - 1562
+      - 1561
+      - 1560
+      - 1559
+      - 1558
+      - 1557
+      - 1503
+      - 2120
+      - 2149
     - type: Fixtures
       fixtures: {}
-  - uid: 21
+  - uid: 28
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2014,19 +2048,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2145
-      - 2177
-      - 2126
-      - 1525
-      - 1584
-      - 1583
-      - 1589
-      - 1588
-      - 1590
-      - 1624
+      - 2138
+      - 2169
+      - 2119
+      - 1503
+      - 1562
+      - 1561
+      - 1566
+      - 1565
+      - 1567
+      - 1600
     - type: Fixtures
       fixtures: {}
-  - uid: 22
+  - uid: 29
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2034,19 +2068,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2119
-      - 2149
-      - 1589
-      - 1590
-      - 1588
-      - 1591
-      - 1592
-      - 1593
-      - 1619
-      - 1532
+      - 2112
+      - 2142
+      - 1566
+      - 1567
+      - 1565
+      - 1568
+      - 1569
+      - 1570
+      - 1595
+      - 2996
     - type: Fixtures
       fixtures: {}
-  - uid: 23
+  - uid: 30
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2054,34 +2088,20 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2147
-      - 2116
-      - 1599
-      - 1598
-      - 1597
-      - 1596
+      - 2140
+      - 2109
+      - 1576
+      - 1575
+      - 1574
+      - 1573
+      - 1572
+      - 1571
+      - 1577
+      - 1568
       - 1595
-      - 1594
-      - 1600
-      - 1591
-      - 1619
     - type: Fixtures
       fixtures: {}
-  - uid: 24
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 1601
-      - 1600
-      - 2115
-      - 2146
-    - type: Fixtures
-      fixtures: {}
-  - uid: 25
+  - uid: 31
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2089,18 +2109,18 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1608
-      - 1609
-      - 2120
-      - 2150
-      - 1614
-      - 1613
-      - 1612
-      - 1611
-      - 1610
+      - 1584
+      - 1585
+      - 2113
+      - 2143
+      - 1590
+      - 1589
+      - 1588
+      - 1587
+      - 1586
     - type: Fixtures
       fixtures: {}
-  - uid: 26
+  - uid: 32
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2108,18 +2128,17 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2144
-      - 2118
-      - 1604
-      - 1605
-      - 1606
-      - 1607
-      - 1608
-      - 1609
-      - 1603
+      - 2137
+      - 2111
+      - 1581
+      - 1582
+      - 1583
+      - 1584
+      - 1585
+      - 1580
     - type: Fixtures
       fixtures: {}
-  - uid: 27
+  - uid: 33
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2127,39 +2146,39 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1603
-      - 1618
-      - 1602
-      - 2148
-      - 2117
+      - 1580
+      - 1594
+      - 1579
+      - 2141
+      - 2110
     - type: Fixtures
       fixtures: {}
-  - uid: 28
+  - uid: 34
     components:
     - type: Transform
       pos: -30.5,-11.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2159
-      - 2130
-      - 1557
+      - 2152
+      - 2123
+      - 1535
     - type: Fixtures
       fixtures: {}
-  - uid: 29
+  - uid: 35
     components:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2160
-      - 2131
-      - 1556
-      - 1557
+      - 2153
+      - 2124
+      - 1534
+      - 1535
     - type: Fixtures
       fixtures: {}
-  - uid: 30
+  - uid: 36
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2167,52 +2186,52 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2132
-      - 2161
-      - 1623
-      - 1622
-      - 1561
+      - 2125
+      - 2154
+      - 1599
+      - 1598
+      - 1539
     - type: Fixtures
       fixtures: {}
-  - uid: 31
+  - uid: 37
     components:
     - type: Transform
       pos: -34.5,-25.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2164
-      - 2133
-      - 1562
-      - 1560
-      - 1559
-      - 1558
-      - 1561
+      - 2157
+      - 2126
+      - 1540
+      - 1538
+      - 1537
+      - 1536
+      - 1539
     - type: Fixtures
       fixtures: {}
-  - uid: 32
+  - uid: 38
     components:
     - type: Transform
       pos: -42.5,-21.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2162
-      - 1560
+      - 2155
+      - 1538
     - type: Fixtures
       fixtures: {}
-  - uid: 33
+  - uid: 39
     components:
     - type: Transform
       pos: -42.5,-26.5
       parent: 2
     - type: DeviceList
       devices:
-      - 2163
-      - 1562
+      - 2156
+      - 1540
     - type: Fixtures
       fixtures: {}
-  - uid: 34
+  - uid: 40
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2220,14 +2239,40 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1568
-      - 2129
-      - 2158
+      - 1546
+      - 2122
+      - 2151
     - type: Fixtures
       fixtures: {}
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1578
+      - 1577
+      - 2108
+      - 2139
+  - uid: 1237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-7.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1542
+      - 1543
+      - 1544
+      - 1547
+      - 2136
+      - 2133
 - proto: AirAlarmFreezer
   entities:
-  - uid: 36
+  - uid: 42
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2235,15 +2280,14 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1624
-      - 2180
-      - 2142
-      - 1532
+      - 1600
+      - 2171
+      - 2996
     - type: Fixtures
       fixtures: {}
 - proto: AirAlarmVox
   entities:
-  - uid: 37
+  - uid: 43
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2251,140 +2295,172 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 2181
-      - 2143
-      - 1531
-      - 2141
-      - 2179
-      - 1530
+      - 1509
+      - 1508
     - type: Fixtures
       fixtures: {}
+- proto: Airlock
+  entities:
+  - uid: 72
+    components:
+    - type: MetaData
+      name: Study
+    - type: Transform
+      pos: -34.5,-6.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockAtmosphericsLocked
   entities:
-  - uid: 38
+  - uid: 44
     components:
+    - type: MetaData
+      name: Nitrogen Closet
     - type: Transform
       pos: -20.5,-4.5
       parent: 2
-  - uid: 39
+  - uid: 45
     components:
     - type: Transform
       pos: -47.5,13.5
       parent: 2
-- proto: AirlockBarKitchenGlassLocked
-  entities:
-  - uid: 40
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,2.5
-      parent: 2
 - proto: AirlockBrigGlassLocked
   entities:
-  - uid: 41
+  - uid: 93
     components:
+    - type: MetaData
+      name: Security
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.5,-15.5
+      pos: -34.5,-17.5
       parent: 2
 - proto: AirlockCaptainLockedSyndie
   entities:
-  - uid: 42
+  - uid: 48
     components:
+    - type: MetaData
+      name: Captain's Office
     - type: Transform
       pos: -41.5,-28.5
       parent: 2
 - proto: AirlockCargoGlassLocked
   entities:
-  - uid: 43
+  - uid: 49
     components:
+    - type: MetaData
+      name: Logistics
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-6.5
       parent: 2
-  - uid: 44
+  - uid: 50
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 2
-  - uid: 45
+  - uid: 51
     components:
+    - type: MetaData
+      name: Mailroom
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 2
 - proto: AirlockChemistryGlassLocked
   entities:
-  - uid: 46
+  - uid: 52
     components:
+    - type: MetaData
+      name: Chemistry
     - type: Transform
       pos: -27.5,3.5
       parent: 2
 - proto: AirlockCommandGlassLockedSyndie
   entities:
-  - uid: 47
+  - uid: 53
     components:
+    - type: MetaData
+      name: Bridge
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
-  - uid: 48
+    - type: AccessReader
+      accessListsOriginal: []
+  - uid: 54
     components:
+    - type: MetaData
+      name: Bridge
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockCommandLockedSyndie
   entities:
-  - uid: 49
+  - uid: 55
     components:
+    - type: MetaData
+      name: Telecomms
     - type: Transform
       pos: -41.5,-23.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
 - proto: AirlockEngineeringGlassLocked
   entities:
-  - uid: 50
+  - uid: 56
     components:
+    - type: MetaData
+      name: Frank's Lair
     - type: Transform
       pos: -45.5,7.5
       parent: 2
-  - uid: 51
+    - type: AccessReader
+      accessListsOriginal: []
+  - uid: 57
     components:
+    - type: MetaData
+      name: Engineering
     - type: Transform
       pos: -38.5,-0.5
       parent: 2
-  - uid: 52
+  - uid: 58
     components:
+    - type: MetaData
+      name: Engineering
     - type: Transform
       pos: -36.5,0.5
       parent: 2
-  - uid: 53
+  - uid: 59
     components:
+    - type: MetaData
+      name: Engineering
     - type: Transform
       pos: -35.5,0.5
       parent: 2
 - proto: AirlockEngineeringLocked
   entities:
-  - uid: 54
+  - uid: 60
     components:
     - type: Transform
       pos: -37.5,14.5
       parent: 2
 - proto: AirlockExternalAtmosphericsLocked
   entities:
-  - uid: 56
+  - uid: 61
     components:
     - type: Transform
       pos: -41.5,12.5
       parent: 2
 - proto: AirlockExternalGlassCargoLocked
   entities:
-  - uid: 57
+  - uid: 62
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-11.5
       parent: 2
-  - uid: 58
+  - uid: 63
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2392,25 +2468,25 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassEngineeringLocked
   entities:
-  - uid: 59
+  - uid: 64
     components:
     - type: Transform
       pos: -50.5,10.5
       parent: 2
-  - uid: 60
+  - uid: 65
     components:
     - type: Transform
       pos: -49.5,7.5
       parent: 2
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
-  - uid: 61
+  - uid: 66
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 2
-  - uid: 62
+  - uid: 67
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2418,13 +2494,13 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
-  - uid: 63
+  - uid: 68
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,-18.5
       parent: 2
-  - uid: 64
+  - uid: 69
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2432,172 +2508,212 @@ entities:
       parent: 2
 - proto: AirlockExternalLocked
   entities:
-  - uid: 55
+  - uid: 70
     components:
+    - type: MetaData
+      name: EVA & Shipyard
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
 - proto: AirlockFreezerKitchenHydroLocked
   entities:
-  - uid: 65
+  - uid: 2556
     components:
+    - type: MetaData
+      name: Freezer
     - type: Transform
-      pos: -16.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -15.5,6.5
       parent: 2
 - proto: AirlockGlass
   entities:
-  - uid: 66
+  - uid: 73
     components:
-    - type: Transform
-      pos: -34.5,-6.5
-      parent: 2
-  - uid: 67
-    components:
+    - type: MetaData
+      name: Chapel
     - type: Transform
       pos: -34.5,-9.5
       parent: 2
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 68
+  - uid: 74
     components:
     - type: Transform
       pos: -11.5,-11.5
       parent: 2
-  - uid: 69
+  - uid: 75
     components:
     - type: Transform
       pos: -9.5,-11.5
       parent: 2
 - proto: AirlockHeadOfPersonnelGlassLockedSyndie
   entities:
-  - uid: 70
+  - uid: 76
     components:
+    - type: MetaData
+      name: HoP's Object
     - type: Transform
       pos: -32.5,-25.5
       parent: 2
 - proto: AirlockHydroGlassLocked
   entities:
-  - uid: 71
+  - uid: 77
     components:
+    - type: MetaData
+      name: Hydroponics
     - type: Transform
       pos: -21.5,0.5
       parent: 2
 - proto: AirlockJanitorLocked
   entities:
-  - uid: 72
+  - uid: 78
     components:
+    - type: MetaData
+      name: Janitorial
     - type: Transform
       pos: -38.5,-14.5
       parent: 2
-- proto: AirlockKitchenGlassLocked
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      pos: -19.5,2.5
-      parent: 2
 - proto: AirlockMaintLocked
   entities:
-  - uid: 74
+  - uid: 80
     components:
+    - type: MetaData
+      name: Disposals
     - type: Transform
       pos: -27.5,-4.5
       parent: 2
-  - uid: 75
+  - uid: 81
     components:
     - type: Transform
       pos: -44.5,-16.5
       parent: 2
 - proto: AirlockMedicalGlass
   entities:
-  - uid: 76
+  - uid: 82
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 2
-  - uid: 77
+  - uid: 83
     components:
     - type: Transform
       pos: -32.5,0.5
       parent: 2
 - proto: AirlockMedicalGlassLocked
   entities:
-  - uid: 78
+  - uid: 84
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 2
-  - uid: 79
+  - uid: 85
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 2
 - proto: AirlockMedicalLocked
   entities:
-  - uid: 81
+  - uid: 86
     components:
+    - type: MetaData
+      name: Breakroom & Surgery
     - type: Transform
       pos: -33.5,10.5
       parent: 2
 - proto: AirlockMedicalMorgueLocked
   entities:
-  - uid: 80
+  - uid: 87
     components:
+    - type: MetaData
+      name: Morgue
     - type: Transform
       pos: -33.5,5.5
       parent: 2
 - proto: AirlockSalvageGlassLocked
   entities:
-  - uid: 82
+  - uid: 88
     components:
+    - type: MetaData
+      name: Salvage
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-8.5
       parent: 2
 - proto: AirlockScienceGlassLocked
   entities:
-  - uid: 83
+  - uid: 89
     components:
+    - type: MetaData
+      name: Artifact Chamber
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-9.5
       parent: 2
-  - uid: 84
+  - uid: 90
     components:
+    - type: MetaData
+      name: Science
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,-8.5
       parent: 2
-  - uid: 85
+  - uid: 91
     components:
+    - type: MetaData
+      name: Science
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,-7.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
-  - uid: 86
+  - uid: 92
     components:
+    - type: MetaData
+      name: Brig
     - type: Transform
-      pos: -34.5,-17.5
+      pos: -31.5,-15.5
       parent: 2
 - proto: AirlockServiceGlassLocked
   entities:
-  - uid: 87
+  - uid: 46
     components:
+    - type: MetaData
+      name: Kitchen/Bar
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 47
+    components:
+    - type: MetaData
+      name: Bar/Supplies
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: MetaData
+      name: Hydroponics/Kitchen
+    - type: Transform
+      pos: -19.5,2.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: MetaData
+      name: Service Supply Room
     - type: Transform
       pos: -3.5,1.5
       parent: 2
 - proto: AltarSpawner
   entities:
-  - uid: 88
+  - uid: 95
     components:
     - type: Transform
       pos: -32.5,-8.5
       parent: 2
 - proto: AlwaysPoweredlightPink
   entities:
-  - uid: 89
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2605,199 +2721,231 @@ entities:
       parent: 2
 - proto: APCBasic
   entities:
-  - uid: 90
+  - uid: 97
     components:
+    - type: MetaData
+      name: Salvage APC
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 91
+  - uid: 98
     components:
+    - type: MetaData
+      name: Cargo Bay APC
     - type: Transform
       pos: -11.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 92
+  - uid: 99
     components:
+    - type: MetaData
+      name: Mailroom APC
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 93
+  - uid: 100
     components:
+    - type: MetaData
+      name: Bar APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 94
+  - uid: 101
     components:
+    - type: MetaData
+      name: Kitchen APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,0.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 95
+  - uid: 102
     components:
+    - type: MetaData
+      name: Hydroponics APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 96
+  - uid: 103
     components:
+    - type: MetaData
+      name: Chemistry APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 97
+  - uid: 104
     components:
+    - type: MetaData
+      name: Medical Bay APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 98
+  - uid: 105
     components:
+    - type: MetaData
+      name: Engineering APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 99
+  - uid: 106
     components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,12.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 100
-    components:
+    - type: MetaData
+      name: Gravity APC
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 101
+  - uid: 107
     components:
+    - type: MetaData
+      name: Science APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-12.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 102
+  - uid: 108
     components:
+    - type: MetaData
+      name: Evac APC
     - type: Transform
       pos: -42.5,-16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 103
+  - uid: 109
     components:
+    - type: MetaData
+      name: Bridge APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-25.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 104
+  - uid: 110
     components:
+    - type: MetaData
+      name: HoP's Office APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-25.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 105
+  - uid: 111
     components:
+    - type: MetaData
+      name: Security APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-20.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 106
+  - uid: 112
     components:
+    - type: MetaData
+      name: Brig APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-15.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
     - type: Fixtures
       fixtures: {}
-  - uid: 107
+  - uid: 113
     components:
-    - type: Transform
-      pos: -25.5,-7.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 108
-    components:
+    - type: MetaData
+      name: Arrivals APC
     - type: Transform
       pos: -1.5,1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 109
+  - uid: 114
     components:
+    - type: MetaData
+      name: Morgue APC
     - type: Transform
       pos: -35.5,7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 110
+  - uid: 115
     components:
+    - type: MetaData
+      name: Surgery APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 111
+  - uid: 116
     components:
+    - type: MetaData
+      name: Captain's Office APC
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-27.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 112
+  - uid: 117
     components:
+    - type: MetaData
+      name: Server Room APC
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 113
+  - uid: 118
     components:
+    - type: MetaData
+      name: Janitor APC
     - type: Transform
       pos: -42.5,-12.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 114
+  - uid: 119
     components:
+    - type: MetaData
+      name: Science Hall APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,-11.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 115
+  - uid: 120
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2805,45 +2953,60 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 116
+  - uid: 121
     components:
+    - type: MetaData
+      name: Disposals APC
     - type: Transform
       pos: -26.5,-4.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 117
+  - uid: 122
     components:
+    - type: MetaData
+      name: Library APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 118
+  - uid: 123
     components:
+    - type: MetaData
+      name: Chapel APC
     - type: Transform
       pos: -33.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: APECircuitboard
-  entities:
-  - uid: 119
+  - uid: 124
     components:
+    - type: MetaData
+      name: Shuttle Construction APC
     - type: Transform
-      pos: -40.42293,-11.49375
+      rot: 1.5707963267948966 rad
+      pos: -27.5,-8.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: MetaData
+      name: Anchor APC
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -44.5,12.5
       parent: 2
 - proto: AppraisalTool
   entities:
-  - uid: 3694
+  - uid: 126
     components:
     - type: Transform
       pos: -12.370373,-10.490229
       parent: 2
 - proto: ArrivalsShuttleTimer
   entities:
-  - uid: 120
+  - uid: 127
     components:
     - type: Transform
       pos: -0.5,1.5
@@ -2852,318 +3015,313 @@ entities:
       fixtures: {}
 - proto: Ashtray
   entities:
-  - uid: 121
+  - uid: 128
     components:
     - type: Transform
       pos: -8.381487,0.51868033
       parent: 2
 - proto: AstroNavCartridge
   entities:
-  - uid: 122
+  - uid: 129
     components:
     - type: Transform
       pos: -26.378168,-11.319313
       parent: 2
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 123
+  - uid: 130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
-  - uid: 124
+  - uid: 131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
-  - uid: 125
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -16.5,6.5
-      parent: 2
-  - uid: 126
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 2
-  - uid: 127
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 2
-  - uid: 128
+  - uid: 135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-4.5
       parent: 2
-  - uid: 129
+  - uid: 136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-4.5
       parent: 2
-  - uid: 130
+  - uid: 137
     components:
     - type: Transform
       pos: -9.5,-11.5
       parent: 2
-  - uid: 131
+  - uid: 138
     components:
     - type: Transform
       pos: -11.5,-11.5
       parent: 2
-  - uid: 132
+  - uid: 139
     components:
     - type: Transform
       pos: -16.5,-11.5
       parent: 2
-  - uid: 133
-    components:
-    - type: Transform
-      pos: -17.5,-11.5
-      parent: 2
-  - uid: 134
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-8.5
-      parent: 2
-  - uid: 135
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-9.5
-      parent: 2
-  - uid: 136
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-10.5
-      parent: 2
-  - uid: 137
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-8.5
-      parent: 2
-  - uid: 138
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-9.5
-      parent: 2
-  - uid: 139
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-10.5
-      parent: 2
   - uid: 140
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,12.5
+      pos: -17.5,-11.5
       parent: 2
   - uid: 141
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -51.5,-20.5
+      pos: -19.5,-8.5
       parent: 2
   - uid: 142
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -51.5,-18.5
+      pos: -19.5,-9.5
       parent: 2
   - uid: 143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-10.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-8.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-9.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,-10.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -41.5,12.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -51.5,-20.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -51.5,-18.5
+      parent: 2
+  - uid: 150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,10.5
       parent: 2
-  - uid: 144
+  - uid: 151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,7.5
       parent: 2
-  - uid: 146
+  - uid: 152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-5.5
       parent: 2
-  - uid: 147
+  - uid: 153
     components:
     - type: Transform
       pos: -23.5,-7.5
       parent: 2
+  - uid: 2752
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,6.5
+      parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 148
+  - uid: 154
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.5,13.5
       parent: 2
-  - uid: 3685
+  - uid: 3747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,0.5
-      parent: 3684
+      parent: 3746
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 149
+  - uid: 155
     components:
     - type: Transform
       pos: -38.5,6.5
       parent: 2
-  - uid: 150
+  - uid: 156
     components:
     - type: Transform
       pos: -39.5,6.5
       parent: 2
 - proto: AtmosFixFreezerMarker
   entities:
-  - uid: 152
+  - uid: 157
     components:
     - type: Transform
       pos: -15.5,7.5
       parent: 2
-  - uid: 153
+  - uid: 158
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
-  - uid: 154
+  - uid: 159
     components:
     - type: Transform
       pos: -15.5,8.5
       parent: 2
-  - uid: 155
+  - uid: 160
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
-  - uid: 156
+  - uid: 161
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 2
-  - uid: 157
+  - uid: 162
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 158
+  - uid: 163
     components:
     - type: Transform
       pos: -38.5,10.5
       parent: 2
-  - uid: 159
+  - uid: 164
     components:
     - type: Transform
       pos: -39.5,10.5
       parent: 2
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 161
+  - uid: 165
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 2
-  - uid: 162
+  - uid: 166
     components:
     - type: Transform
       pos: -39.5,8.5
       parent: 2
 - proto: AtmosFixPlasmaMarker
   entities:
-  - uid: 164
+  - uid: 167
     components:
     - type: Transform
       pos: -38.5,4.5
       parent: 2
-  - uid: 165
+  - uid: 168
     components:
     - type: Transform
       pos: -39.5,4.5
       parent: 2
 - proto: AtmosFixVoxMarker
   entities:
-  - uid: 167
+  - uid: 169
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 2
-  - uid: 168
+  - uid: 170
     components:
     - type: Transform
       pos: -14.5,-4.5
       parent: 2
-  - uid: 169
+  - uid: 171
     components:
     - type: Transform
       pos: -15.5,-4.5
       parent: 2
-  - uid: 170
+  - uid: 172
     components:
     - type: Transform
       pos: -15.5,-5.5
       parent: 2
-  - uid: 1483
+  - uid: 173
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-  - uid: 2780
+  - uid: 174
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 2
-  - uid: 2813
+  - uid: 175
     components:
     - type: Transform
       pos: -17.5,-4.5
       parent: 2
-  - uid: 3690
+  - uid: 176
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
-  - uid: 3691
+  - uid: 177
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
-  - uid: 3692
+  - uid: 178
     components:
     - type: Transform
       pos: -17.5,-5.5
       parent: 2
 - proto: Autolathe
   entities:
-  - uid: 171
+  - uid: 179
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 172
-    components:
-    - type: Transform
-      pos: -44.5,-4.5
-      parent: 2
-  - uid: 1132
+  - uid: 180
     components:
     - type: Transform
       pos: -44.5,3.5
@@ -3174,9 +3332,20 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -39.5,-11.5
+      parent: 2
+    - type: TechnologyDatabase
+      supportedDisciplines:
+      - Industrial
+      - Arsenal
+      - Experimental
+      - CivilianServices
 - proto: BarricadeDirectional
   entities:
-  - uid: 173
+  - uid: 182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3184,7 +3353,7 @@ entities:
       parent: 2
 - proto: BarSign
   entities:
-  - uid: 174
+  - uid: 183
     components:
     - type: Transform
       pos: -12.5,4.5
@@ -3193,97 +3362,111 @@ entities:
       fixtures: {}
 - proto: Bed
   entities:
-  - uid: 175
+  - uid: 184
     components:
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
-  - uid: 176
+  - uid: 185
     components:
     - type: Transform
       pos: -28.5,-13.5
       parent: 2
-  - uid: 2203
+  - uid: 186
     components:
     - type: Transform
       pos: -42.5,-27.5
       parent: 2
 - proto: BedsheetBlue
   entities:
-  - uid: 178
+  - uid: 187
     components:
     - type: Transform
       pos: -30.5,11.5
       parent: 2
 - proto: BedsheetCaptainSyndie
   entities:
-  - uid: 179
+  - uid: 188
     components:
     - type: Transform
       pos: -42.5,-27.5
       parent: 2
 - proto: BedsheetGrey
   entities:
-  - uid: 183
+  - uid: 189
     components:
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
-  - uid: 184
+  - uid: 190
     components:
     - type: Transform
       pos: -28.5,-13.5
       parent: 2
 - proto: BedsheetMedical
   entities:
-  - uid: 180
+  - uid: 191
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,4.5
       parent: 2
-  - uid: 182
+  - uid: 192
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,4.5
       parent: 2
-  - uid: 3589
+  - uid: 193
     components:
     - type: Transform
       pos: -30.5,6.5
       parent: 2
+- proto: Beehive
+  entities:
+  - uid: 2751
+    components:
+    - type: Transform
+      pos: -26.5,11.5
+      parent: 2
 - proto: BenchBlueComfy
   entities:
-  - uid: 186
+  - uid: 194
     components:
     - type: Transform
       pos: -30.5,11.5
       parent: 2
 - proto: Biogenerator
   entities:
-  - uid: 187
+  - uid: 195
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 2
 - proto: BlastDoorUnlinkedEpistemics
   entities:
-  - uid: 181
+  - uid: 196
     components:
     - type: Transform
       pos: -45.5,-10.5
       parent: 2
 - proto: BlockGameArcade
   entities:
-  - uid: 189
+  - uid: 197
     components:
     - type: Transform
-      pos: -31.5,-12.5
+      pos: -32.5,-12.5
+      parent: 2
+- proto: BlockGameArcadeComputerCircuitboard
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -4.5956,3.6287975
       parent: 2
 - proto: BookNames
   entities:
-  - uid: 190
+  - uid: 199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3291,74 +3474,101 @@ entities:
       parent: 2
 - proto: BookshelfFilled
   entities:
-  - uid: 191
+  - uid: 200
     components:
     - type: Transform
       pos: -33.5,-5.5
       parent: 2
 - proto: BoozeDispenser
   entities:
-  - uid: 192
+  - uid: 201
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
 - proto: BorgCharger
   entities:
-  - uid: 193
+  - uid: 202
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
 - proto: BoxBodyBag
   entities:
-  - uid: 194
+  - uid: 203
     components:
     - type: Transform
       pos: -36.575558,6.614525
       parent: 2
 - proto: BoxCandle
   entities:
-  - uid: 195
+  - uid: 204
     components:
     - type: Transform
       pos: -33.63739,-8.23268
       parent: 2
+- proto: BoxEnvelope
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -4.37603,3.7802439
+      parent: 2
+- proto: BoxFolderBlackThreePapers
+  entities:
+  - uid: 3745
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.31555,-25.237043
+      parent: 2
+- proto: BoxValentine
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -2.5597866,-10.252284
+      parent: 2
 - proto: BrigTimer
   entities:
-  - uid: 196
+  - uid: 207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-15.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        41:
-        - - Start
-          - DoorBolt
-        - - Timer
-          - Open
     - type: Fixtures
       fixtures: {}
 - proto: Bucket
   entities:
-  - uid: 197
+  - uid: 208
     components:
     - type: Transform
       pos: -40.077785,-15.636137
       parent: 2
 - proto: ButtonFrameCaution
   entities:
-  - uid: 198
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.5,-9.5
+      parent: 2
+  - uid: 209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,6.5
       parent: 2
+  - uid: 3733
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-11.5
+      parent: 2
 - proto: ButtonFrameExit
   entities:
-  - uid: 199
+  - uid: 210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3366,4411 +3576,4411 @@ entities:
       parent: 2
 - proto: ButtonFrameGrey
   entities:
-  - uid: 200
+  - uid: 211
     components:
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 201
+  - uid: 212
     components:
     - type: Transform
       pos: -34.5,-13.5
       parent: 2
-  - uid: 202
+  - uid: 213
     components:
     - type: Transform
       pos: -34.5,-14.5
       parent: 2
-  - uid: 203
+  - uid: 214
     components:
     - type: Transform
       pos: -33.5,-13.5
       parent: 2
-  - uid: 204
+  - uid: 215
     components:
     - type: Transform
       pos: -32.5,-15.5
       parent: 2
-  - uid: 205
+  - uid: 216
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 206
+  - uid: 217
     components:
     - type: Transform
       pos: -31.5,-15.5
       parent: 2
-  - uid: 207
+  - uid: 218
     components:
     - type: Transform
       pos: -31.5,-16.5
       parent: 2
-  - uid: 208
+  - uid: 219
     components:
     - type: Transform
       pos: -34.5,-19.5
       parent: 2
-  - uid: 209
+  - uid: 220
     components:
     - type: Transform
       pos: -34.5,-18.5
       parent: 2
-  - uid: 210
+  - uid: 221
     components:
     - type: Transform
       pos: -33.5,-18.5
       parent: 2
-  - uid: 211
-    components:
-    - type: Transform
-      pos: -5.5,2.5
-      parent: 2
-  - uid: 212
-    components:
-    - type: Transform
-      pos: -42.5,-9.5
-      parent: 2
-  - uid: 213
-    components:
-    - type: Transform
-      pos: -26.5,-11.5
-      parent: 2
-  - uid: 214
-    components:
-    - type: Transform
-      pos: -12.5,3.5
-      parent: 2
-  - uid: 215
-    components:
-    - type: Transform
-      pos: -42.5,-13.5
-      parent: 2
-  - uid: 216
-    components:
-    - type: Transform
-      pos: -32.5,-13.5
-      parent: 2
-  - uid: 217
-    components:
-    - type: Transform
-      pos: -31.5,-13.5
-      parent: 2
-  - uid: 218
-    components:
-    - type: Transform
-      pos: -30.5,-13.5
-      parent: 2
-  - uid: 219
-    components:
-    - type: Transform
-      pos: -29.5,-13.5
-      parent: 2
-  - uid: 220
-    components:
-    - type: Transform
-      pos: -28.5,-13.5
-      parent: 2
-  - uid: 221
-    components:
-    - type: Transform
-      pos: -28.5,-14.5
-      parent: 2
   - uid: 222
     components:
     - type: Transform
-      pos: -28.5,-15.5
+      pos: -5.5,2.5
       parent: 2
   - uid: 223
     components:
     - type: Transform
-      pos: -31.5,-17.5
+      pos: -42.5,-9.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      pos: -31.5,-18.5
+      pos: -26.5,-11.5
       parent: 2
   - uid: 225
     components:
     - type: Transform
-      pos: -31.5,-19.5
+      pos: -12.5,3.5
       parent: 2
   - uid: 226
     components:
     - type: Transform
-      pos: -31.5,-20.5
+      pos: -42.5,-13.5
       parent: 2
   - uid: 227
     components:
     - type: Transform
-      pos: -32.5,-17.5
+      pos: -32.5,-13.5
       parent: 2
   - uid: 228
     components:
     - type: Transform
-      pos: -30.5,-17.5
+      pos: -31.5,-13.5
       parent: 2
   - uid: 229
     components:
     - type: Transform
-      pos: -29.5,-17.5
+      pos: -30.5,-13.5
       parent: 2
   - uid: 230
     components:
     - type: Transform
-      pos: -29.5,-18.5
+      pos: -29.5,-13.5
       parent: 2
   - uid: 231
     components:
     - type: Transform
-      pos: -29.5,-19.5
+      pos: -28.5,-13.5
       parent: 2
   - uid: 232
     components:
     - type: Transform
-      pos: -29.5,-20.5
+      pos: -28.5,-14.5
       parent: 2
   - uid: 233
     components:
     - type: Transform
-      pos: -29.5,-21.5
+      pos: -28.5,-15.5
       parent: 2
   - uid: 234
     components:
     - type: Transform
-      pos: -33.5,-25.5
+      pos: -31.5,-17.5
       parent: 2
   - uid: 235
     components:
     - type: Transform
-      pos: -33.5,-24.5
+      pos: -31.5,-18.5
       parent: 2
   - uid: 236
     components:
     - type: Transform
-      pos: -33.5,-23.5
+      pos: -31.5,-19.5
       parent: 2
   - uid: 237
     components:
     - type: Transform
-      pos: -32.5,-23.5
+      pos: -31.5,-20.5
       parent: 2
   - uid: 238
     components:
     - type: Transform
-      pos: -31.5,-23.5
+      pos: -32.5,-17.5
       parent: 2
   - uid: 239
     components:
     - type: Transform
-      pos: -32.5,-22.5
+      pos: -30.5,-17.5
       parent: 2
   - uid: 240
     components:
     - type: Transform
-      pos: -41.5,-22.5
+      pos: -29.5,-17.5
       parent: 2
   - uid: 241
     components:
     - type: Transform
-      pos: -42.5,-22.5
+      pos: -29.5,-18.5
       parent: 2
   - uid: 242
     components:
     - type: Transform
-      pos: -43.5,-22.5
+      pos: -29.5,-19.5
       parent: 2
   - uid: 243
     components:
     - type: Transform
-      pos: -43.5,-23.5
+      pos: -29.5,-20.5
       parent: 2
   - uid: 244
     components:
     - type: Transform
-      pos: -43.5,-24.5
+      pos: -29.5,-21.5
       parent: 2
   - uid: 245
     components:
     - type: Transform
-      pos: -43.5,-25.5
+      pos: -33.5,-25.5
       parent: 2
   - uid: 246
     components:
     - type: Transform
-      pos: -41.5,-25.5
+      pos: -33.5,-24.5
       parent: 2
   - uid: 247
     components:
     - type: Transform
-      pos: -40.5,-25.5
+      pos: -33.5,-23.5
       parent: 2
   - uid: 248
     components:
     - type: Transform
-      pos: -39.5,-25.5
+      pos: -32.5,-23.5
       parent: 2
   - uid: 249
     components:
     - type: Transform
-      pos: -39.5,-26.5
+      pos: -31.5,-23.5
       parent: 2
   - uid: 250
     components:
     - type: Transform
-      pos: -39.5,-27.5
+      pos: -32.5,-22.5
       parent: 2
   - uid: 251
     components:
     - type: Transform
-      pos: -38.5,-27.5
+      pos: -41.5,-22.5
       parent: 2
   - uid: 252
     components:
     - type: Transform
-      pos: -37.5,-27.5
+      pos: -42.5,-22.5
       parent: 2
   - uid: 253
     components:
     - type: Transform
-      pos: -36.5,-27.5
+      pos: -43.5,-22.5
       parent: 2
   - uid: 254
     components:
     - type: Transform
-      pos: -35.5,-27.5
+      pos: -43.5,-23.5
       parent: 2
   - uid: 255
     components:
     - type: Transform
-      pos: -34.5,-27.5
+      pos: -43.5,-24.5
       parent: 2
   - uid: 256
     components:
     - type: Transform
-      pos: -33.5,-27.5
+      pos: -43.5,-25.5
       parent: 2
   - uid: 257
     components:
     - type: Transform
-      pos: -32.5,-27.5
+      pos: -41.5,-25.5
       parent: 2
   - uid: 258
     components:
     - type: Transform
-      pos: -31.5,-27.5
+      pos: -40.5,-25.5
       parent: 2
   - uid: 259
     components:
     - type: Transform
-      pos: -31.5,-28.5
+      pos: -39.5,-25.5
       parent: 2
   - uid: 260
     components:
     - type: Transform
-      pos: -33.5,-28.5
+      pos: -39.5,-26.5
       parent: 2
   - uid: 261
     components:
     - type: Transform
-      pos: -35.5,-28.5
+      pos: -39.5,-27.5
       parent: 2
   - uid: 262
     components:
     - type: Transform
-      pos: -37.5,-28.5
+      pos: -38.5,-27.5
       parent: 2
   - uid: 263
     components:
     - type: Transform
-      pos: -39.5,-28.5
+      pos: -37.5,-27.5
       parent: 2
   - uid: 264
     components:
     - type: Transform
-      pos: -41.5,-27.5
+      pos: -36.5,-27.5
       parent: 2
   - uid: 265
     components:
     - type: Transform
-      pos: -42.5,-27.5
+      pos: -35.5,-27.5
       parent: 2
   - uid: 266
     components:
     - type: Transform
-      pos: -43.5,-27.5
+      pos: -34.5,-27.5
       parent: 2
   - uid: 267
     components:
     - type: Transform
-      pos: -43.5,-28.5
+      pos: -33.5,-27.5
       parent: 2
   - uid: 268
     components:
     - type: Transform
-      pos: -43.5,-29.5
+      pos: -32.5,-27.5
       parent: 2
   - uid: 269
     components:
     - type: Transform
-      pos: -42.5,-29.5
+      pos: -31.5,-27.5
       parent: 2
   - uid: 270
     components:
     - type: Transform
-      pos: -42.5,-16.5
+      pos: -31.5,-28.5
       parent: 2
   - uid: 271
     components:
     - type: Transform
-      pos: -42.5,-17.5
+      pos: -33.5,-28.5
       parent: 2
   - uid: 272
     components:
     - type: Transform
-      pos: -42.5,-18.5
+      pos: -35.5,-28.5
       parent: 2
   - uid: 273
     components:
     - type: Transform
-      pos: -43.5,-18.5
+      pos: -37.5,-28.5
       parent: 2
   - uid: 274
     components:
     - type: Transform
-      pos: -44.5,-18.5
+      pos: -39.5,-28.5
       parent: 2
   - uid: 275
     components:
     - type: Transform
-      pos: -45.5,-18.5
+      pos: -41.5,-27.5
       parent: 2
   - uid: 276
     components:
     - type: Transform
-      pos: -46.5,-18.5
+      pos: -42.5,-27.5
       parent: 2
   - uid: 277
     components:
     - type: Transform
-      pos: -47.5,-18.5
+      pos: -43.5,-27.5
       parent: 2
   - uid: 278
     components:
     - type: Transform
-      pos: -48.5,-18.5
+      pos: -43.5,-28.5
       parent: 2
   - uid: 279
     components:
     - type: Transform
-      pos: -49.5,-18.5
+      pos: -43.5,-29.5
       parent: 2
   - uid: 280
     components:
     - type: Transform
-      pos: -50.5,-18.5
+      pos: -42.5,-29.5
       parent: 2
   - uid: 281
     components:
     - type: Transform
-      pos: -41.5,-18.5
+      pos: -42.5,-16.5
       parent: 2
   - uid: 282
     components:
     - type: Transform
-      pos: -40.5,-18.5
+      pos: -42.5,-17.5
       parent: 2
   - uid: 283
     components:
     - type: Transform
-      pos: -39.5,-18.5
+      pos: -42.5,-18.5
       parent: 2
   - uid: 284
     components:
     - type: Transform
-      pos: -38.5,-18.5
+      pos: -43.5,-18.5
       parent: 2
   - uid: 285
     components:
     - type: Transform
-      pos: -38.5,-19.5
+      pos: -44.5,-18.5
       parent: 2
   - uid: 286
     components:
     - type: Transform
-      pos: -40.5,-19.5
+      pos: -45.5,-18.5
       parent: 2
   - uid: 287
     components:
     - type: Transform
-      pos: -42.5,-19.5
+      pos: -46.5,-18.5
       parent: 2
   - uid: 288
     components:
     - type: Transform
-      pos: -44.5,-19.5
+      pos: -47.5,-18.5
       parent: 2
   - uid: 289
     components:
     - type: Transform
-      pos: -46.5,-19.5
+      pos: -48.5,-18.5
       parent: 2
   - uid: 290
     components:
     - type: Transform
-      pos: -48.5,-19.5
+      pos: -49.5,-18.5
       parent: 2
   - uid: 291
     components:
     - type: Transform
-      pos: -50.5,-19.5
+      pos: -50.5,-18.5
       parent: 2
   - uid: 292
     components:
     - type: Transform
-      pos: -44.5,-17.5
+      pos: -41.5,-18.5
       parent: 2
   - uid: 293
     components:
     - type: Transform
-      pos: -44.5,-16.5
+      pos: -40.5,-18.5
       parent: 2
   - uid: 294
     components:
     - type: Transform
-      pos: -44.5,-15.5
+      pos: -39.5,-18.5
       parent: 2
   - uid: 295
     components:
     - type: Transform
-      pos: -44.5,-14.5
+      pos: -38.5,-18.5
       parent: 2
   - uid: 296
     components:
     - type: Transform
-      pos: -42.5,-12.5
+      pos: -38.5,-19.5
       parent: 2
   - uid: 297
     components:
     - type: Transform
-      pos: -42.5,-14.5
+      pos: -40.5,-19.5
       parent: 2
   - uid: 298
     components:
     - type: Transform
-      pos: -41.5,-14.5
+      pos: -42.5,-19.5
       parent: 2
   - uid: 299
     components:
     - type: Transform
-      pos: -40.5,-14.5
+      pos: -44.5,-19.5
       parent: 2
   - uid: 300
     components:
     - type: Transform
-      pos: -39.5,-14.5
+      pos: -46.5,-19.5
       parent: 2
   - uid: 301
     components:
     - type: Transform
-      pos: -40.5,-12.5
+      pos: -48.5,-19.5
       parent: 2
   - uid: 302
     components:
     - type: Transform
-      pos: -40.5,-11.5
+      pos: -50.5,-19.5
       parent: 2
   - uid: 303
     components:
     - type: Transform
-      pos: -40.5,-10.5
+      pos: -44.5,-17.5
       parent: 2
   - uid: 304
     components:
     - type: Transform
-      pos: -40.5,-9.5
+      pos: -44.5,-16.5
       parent: 2
   - uid: 305
     components:
     - type: Transform
-      pos: -40.5,-8.5
+      pos: -44.5,-15.5
       parent: 2
   - uid: 306
     components:
     - type: Transform
-      pos: -40.5,-7.5
+      pos: -44.5,-14.5
       parent: 2
   - uid: 307
     components:
     - type: Transform
-      pos: -41.5,-7.5
+      pos: -42.5,-12.5
       parent: 2
   - uid: 308
     components:
     - type: Transform
-      pos: -42.5,-7.5
+      pos: -42.5,-14.5
       parent: 2
   - uid: 309
     components:
     - type: Transform
-      pos: -43.5,-7.5
+      pos: -41.5,-14.5
       parent: 2
   - uid: 310
     components:
     - type: Transform
-      pos: -43.5,-6.5
+      pos: -40.5,-14.5
       parent: 2
   - uid: 311
     components:
     - type: Transform
-      pos: -43.5,-5.5
+      pos: -39.5,-14.5
       parent: 2
   - uid: 312
     components:
     - type: Transform
-      pos: -43.5,-4.5
+      pos: -40.5,-12.5
       parent: 2
   - uid: 313
     components:
     - type: Transform
-      pos: -40.5,-6.5
+      pos: -40.5,-11.5
       parent: 2
   - uid: 314
     components:
     - type: Transform
-      pos: -40.5,-5.5
+      pos: -40.5,-10.5
       parent: 2
   - uid: 315
     components:
     - type: Transform
-      pos: -40.5,-4.5
+      pos: -40.5,-9.5
       parent: 2
   - uid: 316
     components:
     - type: Transform
-      pos: -43.5,-8.5
+      pos: -40.5,-8.5
       parent: 2
   - uid: 317
     components:
     - type: Transform
-      pos: -43.5,-9.5
+      pos: -40.5,-7.5
       parent: 2
   - uid: 318
     components:
     - type: Transform
-      pos: -38.5,-11.5
+      pos: -41.5,-7.5
       parent: 2
   - uid: 319
     components:
     - type: Transform
-      pos: -37.5,-11.5
+      pos: -42.5,-7.5
       parent: 2
   - uid: 320
     components:
     - type: Transform
-      pos: -36.5,-11.5
+      pos: -43.5,-7.5
       parent: 2
   - uid: 321
     components:
     - type: Transform
-      pos: -36.5,-12.5
+      pos: -43.5,-6.5
       parent: 2
   - uid: 322
     components:
     - type: Transform
-      pos: -36.5,-13.5
+      pos: -43.5,-5.5
       parent: 2
   - uid: 323
     components:
     - type: Transform
-      pos: -36.5,-14.5
+      pos: -43.5,-4.5
       parent: 2
   - uid: 324
     components:
     - type: Transform
-      pos: -36.5,-15.5
+      pos: -40.5,-6.5
       parent: 2
   - uid: 325
     components:
     - type: Transform
-      pos: -36.5,-16.5
+      pos: -40.5,-5.5
       parent: 2
   - uid: 326
     components:
     - type: Transform
-      pos: -36.5,-17.5
+      pos: -40.5,-4.5
       parent: 2
   - uid: 327
     components:
     - type: Transform
-      pos: -36.5,-18.5
+      pos: -43.5,-8.5
       parent: 2
   - uid: 328
     components:
     - type: Transform
-      pos: -36.5,-19.5
+      pos: -43.5,-9.5
       parent: 2
   - uid: 329
     components:
     - type: Transform
-      pos: -36.5,-20.5
+      pos: -38.5,-11.5
       parent: 2
   - uid: 330
     components:
     - type: Transform
-      pos: -36.5,-21.5
+      pos: -37.5,-11.5
       parent: 2
   - uid: 331
     components:
     - type: Transform
-      pos: -36.5,-22.5
+      pos: -36.5,-11.5
       parent: 2
   - uid: 332
     components:
     - type: Transform
-      pos: -36.5,-10.5
+      pos: -36.5,-12.5
       parent: 2
   - uid: 333
     components:
     - type: Transform
-      pos: -36.5,-9.5
+      pos: -36.5,-13.5
       parent: 2
   - uid: 334
     components:
     - type: Transform
-      pos: -36.5,-8.5
+      pos: -36.5,-14.5
       parent: 2
   - uid: 335
     components:
     - type: Transform
-      pos: -36.5,-7.5
+      pos: -36.5,-15.5
       parent: 2
   - uid: 336
     components:
     - type: Transform
-      pos: -36.5,-6.5
+      pos: -36.5,-16.5
       parent: 2
   - uid: 337
     components:
     - type: Transform
-      pos: -36.5,-5.5
+      pos: -36.5,-17.5
       parent: 2
   - uid: 338
     components:
     - type: Transform
-      pos: -36.5,-4.5
+      pos: -36.5,-18.5
       parent: 2
   - uid: 339
     components:
     - type: Transform
-      pos: -36.5,-3.5
+      pos: -36.5,-19.5
       parent: 2
   - uid: 340
     components:
     - type: Transform
-      pos: -36.5,-2.5
+      pos: -36.5,-20.5
       parent: 2
   - uid: 341
     components:
     - type: Transform
-      pos: -36.5,-1.5
+      pos: -36.5,-21.5
       parent: 2
   - uid: 342
     components:
     - type: Transform
-      pos: -35.5,-1.5
+      pos: -36.5,-22.5
       parent: 2
   - uid: 343
     components:
     - type: Transform
-      pos: -30.5,-4.5
+      pos: -36.5,-10.5
       parent: 2
   - uid: 344
     components:
     - type: Transform
-      pos: -30.5,-3.5
+      pos: -36.5,-9.5
       parent: 2
   - uid: 345
     components:
     - type: Transform
-      pos: -30.5,-2.5
+      pos: -36.5,-8.5
       parent: 2
   - uid: 346
     components:
     - type: Transform
-      pos: -31.5,-2.5
+      pos: -36.5,-7.5
       parent: 2
   - uid: 347
     components:
     - type: Transform
-      pos: -32.5,-2.5
+      pos: -36.5,-6.5
       parent: 2
   - uid: 348
     components:
     - type: Transform
-      pos: -33.5,-2.5
+      pos: -36.5,-5.5
       parent: 2
   - uid: 349
     components:
     - type: Transform
-      pos: -34.5,-2.5
+      pos: -36.5,-4.5
       parent: 2
   - uid: 350
     components:
     - type: Transform
-      pos: -29.5,-2.5
+      pos: -36.5,-3.5
       parent: 2
   - uid: 351
     components:
     - type: Transform
-      pos: -28.5,-2.5
+      pos: -36.5,-2.5
       parent: 2
   - uid: 352
     components:
     - type: Transform
-      pos: -27.5,-2.5
+      pos: -36.5,-1.5
       parent: 2
   - uid: 353
     components:
     - type: Transform
-      pos: -26.5,-2.5
+      pos: -35.5,-1.5
       parent: 2
   - uid: 354
     components:
     - type: Transform
-      pos: -26.5,-2.5
+      pos: -30.5,-4.5
       parent: 2
   - uid: 355
     components:
     - type: Transform
-      pos: -25.5,-2.5
+      pos: -30.5,-3.5
       parent: 2
   - uid: 356
     components:
     - type: Transform
-      pos: -24.5,-2.5
+      pos: -30.5,-2.5
       parent: 2
   - uid: 357
     components:
     - type: Transform
-      pos: -23.5,-2.5
+      pos: -31.5,-2.5
       parent: 2
   - uid: 358
     components:
     - type: Transform
-      pos: -22.5,-2.5
+      pos: -32.5,-2.5
       parent: 2
   - uid: 359
     components:
     - type: Transform
-      pos: -21.5,-2.5
+      pos: -33.5,-2.5
       parent: 2
   - uid: 360
     components:
     - type: Transform
-      pos: -20.5,-2.5
+      pos: -34.5,-2.5
       parent: 2
   - uid: 361
     components:
     - type: Transform
-      pos: -19.5,-2.5
+      pos: -29.5,-2.5
       parent: 2
   - uid: 362
     components:
     - type: Transform
-      pos: -18.5,-2.5
+      pos: -28.5,-2.5
       parent: 2
   - uid: 363
     components:
     - type: Transform
-      pos: -17.5,-2.5
+      pos: -27.5,-2.5
       parent: 2
   - uid: 364
     components:
     - type: Transform
-      pos: -17.5,-2.5
+      pos: -26.5,-2.5
       parent: 2
   - uid: 365
     components:
     - type: Transform
-      pos: -16.5,-2.5
+      pos: -26.5,-2.5
       parent: 2
   - uid: 366
     components:
     - type: Transform
-      pos: -1.5,1.5
+      pos: -25.5,-2.5
       parent: 2
   - uid: 367
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -24.5,-2.5
       parent: 2
   - uid: 368
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: -23.5,-2.5
       parent: 2
   - uid: 369
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -22.5,-2.5
       parent: 2
   - uid: 370
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -21.5,-2.5
       parent: 2
   - uid: 371
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -20.5,-2.5
       parent: 2
   - uid: 372
     components:
     - type: Transform
-      pos: -1.5,-4.5
+      pos: -19.5,-2.5
       parent: 2
   - uid: 373
     components:
     - type: Transform
-      pos: -1.5,-5.5
+      pos: -18.5,-2.5
       parent: 2
   - uid: 374
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: -17.5,-2.5
       parent: 2
   - uid: 375
     components:
     - type: Transform
-      pos: -3.5,-2.5
+      pos: -17.5,-2.5
       parent: 2
   - uid: 376
     components:
     - type: Transform
-      pos: -4.5,-2.5
+      pos: -16.5,-2.5
       parent: 2
   - uid: 377
     components:
     - type: Transform
-      pos: -6.5,-2.5
+      pos: -1.5,1.5
       parent: 2
   - uid: 378
     components:
     - type: Transform
-      pos: -7.5,-2.5
+      pos: -1.5,0.5
       parent: 2
   - uid: 379
     components:
     - type: Transform
-      pos: -5.5,-2.5
+      pos: -1.5,-0.5
       parent: 2
   - uid: 380
     components:
     - type: Transform
-      pos: -8.5,-2.5
+      pos: -1.5,-1.5
       parent: 2
   - uid: 381
     components:
     - type: Transform
-      pos: -9.5,-2.5
+      pos: -1.5,-2.5
       parent: 2
   - uid: 382
     components:
     - type: Transform
-      pos: -10.5,-2.5
+      pos: -1.5,-3.5
       parent: 2
   - uid: 383
     components:
     - type: Transform
-      pos: -11.5,-2.5
+      pos: -1.5,-4.5
       parent: 2
   - uid: 384
     components:
     - type: Transform
-      pos: -12.5,-2.5
+      pos: -1.5,-5.5
       parent: 2
   - uid: 385
     components:
     - type: Transform
-      pos: -13.5,-2.5
+      pos: -2.5,-2.5
       parent: 2
   - uid: 386
     components:
     - type: Transform
-      pos: -14.5,-2.5
+      pos: -3.5,-2.5
       parent: 2
   - uid: 387
     components:
     - type: Transform
-      pos: -12.5,-3.5
+      pos: -4.5,-2.5
       parent: 2
   - uid: 388
     components:
     - type: Transform
-      pos: -12.5,-4.5
+      pos: -6.5,-2.5
       parent: 2
   - uid: 389
     components:
     - type: Transform
-      pos: -9.5,-3.5
+      pos: -7.5,-2.5
       parent: 2
   - uid: 390
     components:
     - type: Transform
-      pos: -9.5,-4.5
+      pos: -5.5,-2.5
       parent: 2
   - uid: 391
     components:
     - type: Transform
-      pos: -6.5,-3.5
+      pos: -8.5,-2.5
       parent: 2
   - uid: 392
     components:
     - type: Transform
-      pos: -6.5,-4.5
+      pos: -9.5,-2.5
       parent: 2
   - uid: 393
     components:
     - type: Transform
-      pos: -4.5,-3.5
+      pos: -10.5,-2.5
       parent: 2
   - uid: 394
     components:
     - type: Transform
-      pos: -4.5,-4.5
+      pos: -11.5,-2.5
       parent: 2
   - uid: 395
     components:
     - type: Transform
-      pos: -4.5,-1.5
+      pos: -12.5,-2.5
       parent: 2
   - uid: 396
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      pos: -13.5,-2.5
       parent: 2
   - uid: 397
     components:
     - type: Transform
-      pos: -9.5,-1.5
+      pos: -14.5,-2.5
       parent: 2
   - uid: 398
     components:
     - type: Transform
-      pos: -12.5,-1.5
+      pos: -12.5,-3.5
       parent: 2
   - uid: 399
     components:
     - type: Transform
-      pos: -4.5,1.5
+      pos: -12.5,-4.5
       parent: 2
   - uid: 400
     components:
     - type: Transform
-      pos: -4.5,2.5
+      pos: -9.5,-3.5
       parent: 2
   - uid: 401
     components:
     - type: Transform
-      pos: -4.5,3.5
+      pos: -9.5,-4.5
       parent: 2
   - uid: 402
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: -6.5,-3.5
       parent: 2
   - uid: 403
     components:
     - type: Transform
-      pos: -3.5,3.5
+      pos: -6.5,-4.5
       parent: 2
   - uid: 404
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: -4.5,-3.5
       parent: 2
   - uid: 405
     components:
     - type: Transform
-      pos: -6.5,1.5
+      pos: -4.5,-4.5
       parent: 2
   - uid: 406
     components:
     - type: Transform
-      pos: -7.5,1.5
+      pos: -4.5,-1.5
       parent: 2
   - uid: 407
     components:
     - type: Transform
-      pos: -8.5,1.5
+      pos: -6.5,-1.5
       parent: 2
   - uid: 408
     components:
     - type: Transform
-      pos: -9.5,1.5
+      pos: -9.5,-1.5
       parent: 2
   - uid: 409
     components:
     - type: Transform
-      pos: -10.5,1.5
+      pos: -12.5,-1.5
       parent: 2
   - uid: 410
     components:
     - type: Transform
-      pos: -11.5,1.5
+      pos: -4.5,1.5
       parent: 2
   - uid: 411
     components:
     - type: Transform
-      pos: -12.5,1.5
+      pos: -4.5,2.5
       parent: 2
   - uid: 412
     components:
     - type: Transform
-      pos: -12.5,2.5
+      pos: -4.5,3.5
       parent: 2
   - uid: 413
     components:
     - type: Transform
-      pos: -9.5,2.5
+      pos: -5.5,3.5
       parent: 2
   - uid: 414
     components:
     - type: Transform
-      pos: -6.5,2.5
+      pos: -3.5,3.5
       parent: 2
   - uid: 415
     components:
     - type: Transform
-      pos: -17.5,0.5
+      pos: -2.5,3.5
       parent: 2
   - uid: 416
     components:
     - type: Transform
-      pos: -17.5,1.5
+      pos: -6.5,1.5
       parent: 2
   - uid: 417
     components:
     - type: Transform
-      pos: -17.5,2.5
+      pos: -7.5,1.5
       parent: 2
   - uid: 418
     components:
     - type: Transform
-      pos: -16.5,2.5
+      pos: -8.5,1.5
       parent: 2
   - uid: 419
     components:
     - type: Transform
-      pos: -15.5,2.5
+      pos: -9.5,1.5
       parent: 2
   - uid: 420
     components:
     - type: Transform
-      pos: -14.5,2.5
+      pos: -10.5,1.5
       parent: 2
   - uid: 421
     components:
     - type: Transform
-      pos: -18.5,2.5
+      pos: -11.5,1.5
       parent: 2
   - uid: 422
     components:
     - type: Transform
-      pos: -16.5,3.5
+      pos: -12.5,1.5
       parent: 2
   - uid: 423
     components:
     - type: Transform
-      pos: -16.5,4.5
+      pos: -12.5,2.5
       parent: 2
   - uid: 424
     components:
     - type: Transform
-      pos: -16.5,5.5
+      pos: -9.5,2.5
       parent: 2
   - uid: 425
     components:
     - type: Transform
-      pos: -16.5,6.5
+      pos: -6.5,2.5
       parent: 2
   - uid: 426
     components:
     - type: Transform
-      pos: -23.5,3.5
+      pos: -17.5,0.5
       parent: 2
   - uid: 427
     components:
     - type: Transform
-      pos: -22.5,3.5
+      pos: -17.5,1.5
       parent: 2
   - uid: 428
     components:
     - type: Transform
-      pos: -21.5,3.5
+      pos: -17.5,2.5
       parent: 2
   - uid: 429
     components:
     - type: Transform
-      pos: -21.5,4.5
+      pos: -16.5,2.5
       parent: 2
   - uid: 430
     components:
     - type: Transform
-      pos: -21.5,5.5
+      pos: -15.5,2.5
       parent: 2
   - uid: 431
     components:
     - type: Transform
-      pos: -21.5,6.5
+      pos: -14.5,2.5
       parent: 2
   - uid: 432
     components:
     - type: Transform
-      pos: -20.5,6.5
+      pos: -18.5,2.5
       parent: 2
   - uid: 433
     components:
     - type: Transform
-      pos: -19.5,6.5
+      pos: -16.5,3.5
       parent: 2
   - uid: 434
     components:
     - type: Transform
-      pos: -19.5,7.5
+      pos: -16.5,4.5
       parent: 2
   - uid: 435
     components:
     - type: Transform
-      pos: -21.5,7.5
+      pos: -16.5,5.5
       parent: 2
   - uid: 436
     components:
     - type: Transform
-      pos: -21.5,3.5
+      pos: -16.5,6.5
       parent: 2
   - uid: 437
     components:
     - type: Transform
-      pos: -21.5,2.5
+      pos: -23.5,3.5
       parent: 2
   - uid: 438
     components:
     - type: Transform
-      pos: -21.5,1.5
+      pos: -22.5,3.5
       parent: 2
   - uid: 439
     components:
     - type: Transform
-      pos: -21.5,0.5
+      pos: -21.5,3.5
       parent: 2
   - uid: 440
     components:
     - type: Transform
-      pos: -18.5,6.5
+      pos: -21.5,4.5
       parent: 2
   - uid: 441
     components:
     - type: Transform
-      pos: -27.5,6.5
+      pos: -21.5,5.5
       parent: 2
   - uid: 442
     components:
     - type: Transform
-      pos: -26.5,6.5
+      pos: -21.5,6.5
       parent: 2
   - uid: 443
     components:
     - type: Transform
-      pos: -25.5,6.5
+      pos: -20.5,6.5
       parent: 2
   - uid: 444
     components:
     - type: Transform
-      pos: -25.5,5.5
+      pos: -19.5,6.5
       parent: 2
   - uid: 445
     components:
     - type: Transform
-      pos: -25.5,4.5
+      pos: -19.5,7.5
       parent: 2
   - uid: 446
     components:
     - type: Transform
-      pos: -25.5,3.5
+      pos: -21.5,7.5
       parent: 2
   - uid: 447
     components:
     - type: Transform
-      pos: -25.5,2.5
+      pos: -21.5,3.5
       parent: 2
   - uid: 448
     components:
     - type: Transform
-      pos: -25.5,1.5
+      pos: -21.5,2.5
       parent: 2
   - uid: 449
     components:
     - type: Transform
-      pos: -25.5,7.5
+      pos: -21.5,1.5
       parent: 2
   - uid: 450
     components:
     - type: Transform
-      pos: -24.5,4.5
+      pos: -21.5,0.5
       parent: 2
   - uid: 451
     components:
     - type: Transform
-      pos: -26.5,4.5
+      pos: -18.5,6.5
       parent: 2
   - uid: 452
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: -27.5,6.5
       parent: 2
   - uid: 453
     components:
     - type: Transform
-      pos: -32.5,2.5
+      pos: -26.5,6.5
       parent: 2
   - uid: 454
     components:
     - type: Transform
-      pos: -32.5,1.5
+      pos: -25.5,6.5
       parent: 2
   - uid: 455
     components:
     - type: Transform
-      pos: -32.5,4.5
+      pos: -25.5,5.5
       parent: 2
   - uid: 456
     components:
     - type: Transform
-      pos: -32.5,5.5
+      pos: -25.5,4.5
       parent: 2
   - uid: 457
     components:
     - type: Transform
-      pos: -31.5,5.5
+      pos: -25.5,3.5
       parent: 2
   - uid: 458
     components:
     - type: Transform
-      pos: -30.5,5.5
+      pos: -25.5,2.5
       parent: 2
   - uid: 459
     components:
     - type: Transform
-      pos: -30.5,6.5
+      pos: -25.5,1.5
       parent: 2
   - uid: 460
     components:
     - type: Transform
-      pos: -30.5,7.5
+      pos: -25.5,7.5
       parent: 2
   - uid: 461
     components:
     - type: Transform
-      pos: -30.5,8.5
+      pos: -24.5,4.5
       parent: 2
   - uid: 462
     components:
     - type: Transform
-      pos: -30.5,9.5
+      pos: -26.5,4.5
       parent: 2
   - uid: 463
     components:
     - type: Transform
-      pos: -30.5,10.5
+      pos: -32.5,3.5
       parent: 2
   - uid: 464
     components:
     - type: Transform
-      pos: -31.5,10.5
+      pos: -32.5,2.5
       parent: 2
   - uid: 465
     components:
     - type: Transform
-      pos: -29.5,10.5
+      pos: -32.5,1.5
       parent: 2
   - uid: 466
     components:
     - type: Transform
-      pos: -29.5,7.5
+      pos: -32.5,4.5
       parent: 2
   - uid: 467
     components:
     - type: Transform
-      pos: -31.5,7.5
+      pos: -32.5,5.5
       parent: 2
   - uid: 468
     components:
     - type: Transform
-      pos: -29.5,5.5
+      pos: -31.5,5.5
       parent: 2
   - uid: 469
     components:
     - type: Transform
-      pos: -29.5,4.5
+      pos: -30.5,5.5
       parent: 2
   - uid: 470
     components:
     - type: Transform
-      pos: -29.5,3.5
+      pos: -30.5,6.5
       parent: 2
   - uid: 471
     components:
     - type: Transform
-      pos: -29.5,2.5
+      pos: -30.5,7.5
       parent: 2
   - uid: 472
     components:
     - type: Transform
-      pos: -28.5,2.5
+      pos: -30.5,8.5
       parent: 2
   - uid: 473
     components:
     - type: Transform
-      pos: -28.5,5.5
+      pos: -30.5,9.5
       parent: 2
   - uid: 474
     components:
     - type: Transform
-      pos: -37.5,9.5
+      pos: -30.5,10.5
       parent: 2
   - uid: 475
     components:
     - type: Transform
-      pos: -36.5,9.5
+      pos: -31.5,10.5
       parent: 2
   - uid: 476
     components:
     - type: Transform
-      pos: -35.5,9.5
+      pos: -29.5,10.5
       parent: 2
   - uid: 477
     components:
     - type: Transform
-      pos: -35.5,10.5
+      pos: -29.5,7.5
       parent: 2
   - uid: 478
     components:
     - type: Transform
-      pos: -34.5,9.5
+      pos: -31.5,7.5
       parent: 2
   - uid: 479
     components:
     - type: Transform
-      pos: -46.5,8.5
+      pos: -29.5,5.5
       parent: 2
   - uid: 480
     components:
     - type: Transform
-      pos: -35.5,11.5
+      pos: -29.5,4.5
       parent: 2
   - uid: 481
     components:
     - type: Transform
-      pos: -35.5,7.5
+      pos: -29.5,3.5
       parent: 2
   - uid: 482
     components:
     - type: Transform
-      pos: -35.5,6.5
+      pos: -29.5,2.5
       parent: 2
   - uid: 483
     components:
     - type: Transform
-      pos: -35.5,5.5
+      pos: -28.5,2.5
       parent: 2
   - uid: 484
     components:
     - type: Transform
-      pos: -36.5,5.5
+      pos: -28.5,5.5
       parent: 2
   - uid: 485
     components:
     - type: Transform
-      pos: -34.5,5.5
+      pos: -37.5,9.5
       parent: 2
   - uid: 486
     components:
     - type: Transform
-      pos: -45.5,8.5
+      pos: -36.5,9.5
       parent: 2
   - uid: 487
     components:
     - type: Transform
-      pos: -47.5,8.5
+      pos: -35.5,9.5
       parent: 2
   - uid: 488
     components:
     - type: Transform
-      pos: -47.5,9.5
+      pos: -35.5,10.5
       parent: 2
   - uid: 489
     components:
     - type: Transform
-      pos: -47.5,7.5
+      pos: -34.5,9.5
       parent: 2
   - uid: 490
     components:
     - type: Transform
-      pos: -47.5,7.5
+      pos: -46.5,8.5
       parent: 2
   - uid: 491
     components:
     - type: Transform
-      pos: -47.5,6.5
+      pos: -35.5,11.5
       parent: 2
   - uid: 492
     components:
     - type: Transform
-      pos: -48.5,7.5
+      pos: -35.5,7.5
       parent: 2
   - uid: 493
     components:
     - type: Transform
-      pos: -49.5,7.5
+      pos: -35.5,6.5
       parent: 2
   - uid: 494
     components:
     - type: Transform
-      pos: -50.5,7.5
+      pos: -35.5,5.5
       parent: 2
   - uid: 495
     components:
     - type: Transform
-      pos: -50.5,8.5
+      pos: -36.5,5.5
       parent: 2
   - uid: 496
     components:
     - type: Transform
-      pos: -50.5,9.5
+      pos: -34.5,5.5
       parent: 2
   - uid: 497
     components:
     - type: Transform
-      pos: -42.5,12.5
+      pos: -45.5,8.5
       parent: 2
   - uid: 498
     components:
     - type: Transform
-      pos: -42.5,13.5
+      pos: -47.5,8.5
       parent: 2
   - uid: 499
     components:
     - type: Transform
-      pos: -42.5,14.5
+      pos: -47.5,9.5
       parent: 2
   - uid: 500
     components:
     - type: Transform
-      pos: -42.5,15.5
+      pos: -47.5,7.5
       parent: 2
   - uid: 501
     components:
     - type: Transform
-      pos: -43.5,15.5
+      pos: -47.5,7.5
       parent: 2
   - uid: 502
     components:
     - type: Transform
-      pos: -45.5,15.5
+      pos: -47.5,6.5
       parent: 2
   - uid: 503
     components:
     - type: Transform
-      pos: -45.5,14.5
+      pos: -48.5,7.5
       parent: 2
   - uid: 504
     components:
     - type: Transform
-      pos: -45.5,13.5
+      pos: -49.5,7.5
       parent: 2
   - uid: 505
     components:
     - type: Transform
-      pos: -46.5,13.5
+      pos: -50.5,7.5
       parent: 2
   - uid: 506
     components:
     - type: Transform
-      pos: -41.5,15.5
+      pos: -50.5,8.5
       parent: 2
   - uid: 507
     components:
     - type: Transform
-      pos: -40.5,15.5
+      pos: -50.5,9.5
       parent: 2
   - uid: 508
     components:
     - type: Transform
-      pos: -39.5,15.5
+      pos: -42.5,15.5
       parent: 2
   - uid: 509
     components:
     - type: Transform
-      pos: -39.5,14.5
+      pos: -43.5,15.5
       parent: 2
   - uid: 510
     components:
     - type: Transform
-      pos: -39.5,13.5
+      pos: -45.5,15.5
       parent: 2
   - uid: 511
     components:
     - type: Transform
-      pos: -42.5,-1.5
+      pos: -45.5,14.5
       parent: 2
   - uid: 512
     components:
     - type: Transform
-      pos: -42.5,-0.5
+      pos: -45.5,13.5
       parent: 2
   - uid: 513
     components:
     - type: Transform
-      pos: -42.5,0.5
+      pos: -46.5,13.5
       parent: 2
   - uid: 514
     components:
     - type: Transform
-      pos: -42.5,1.5
+      pos: -41.5,15.5
       parent: 2
   - uid: 515
     components:
     - type: Transform
-      pos: -42.5,2.5
+      pos: -40.5,15.5
       parent: 2
   - uid: 516
     components:
     - type: Transform
-      pos: -42.5,3.5
+      pos: -39.5,15.5
       parent: 2
   - uid: 517
     components:
     - type: Transform
-      pos: -42.5,4.5
+      pos: -39.5,14.5
       parent: 2
   - uid: 518
     components:
     - type: Transform
-      pos: -42.5,5.5
+      pos: -39.5,13.5
       parent: 2
   - uid: 519
     components:
     - type: Transform
-      pos: -42.5,6.5
+      pos: -42.5,-1.5
       parent: 2
   - uid: 520
     components:
     - type: Transform
-      pos: -42.5,7.5
+      pos: -42.5,-0.5
       parent: 2
   - uid: 521
     components:
     - type: Transform
-      pos: -42.5,8.5
+      pos: -42.5,0.5
       parent: 2
   - uid: 522
     components:
     - type: Transform
-      pos: -42.5,9.5
+      pos: -42.5,1.5
       parent: 2
   - uid: 523
     components:
     - type: Transform
-      pos: -42.5,10.5
+      pos: -42.5,2.5
       parent: 2
   - uid: 524
     components:
     - type: Transform
-      pos: -41.5,10.5
+      pos: -42.5,3.5
       parent: 2
   - uid: 525
     components:
     - type: Transform
-      pos: -40.5,10.5
+      pos: -42.5,4.5
       parent: 2
   - uid: 526
     components:
     - type: Transform
-      pos: -39.5,10.5
+      pos: -42.5,5.5
       parent: 2
   - uid: 527
     components:
     - type: Transform
-      pos: -39.5,8.5
+      pos: -42.5,6.5
       parent: 2
   - uid: 528
     components:
     - type: Transform
-      pos: -40.5,8.5
+      pos: -42.5,7.5
       parent: 2
   - uid: 529
     components:
     - type: Transform
-      pos: -41.5,8.5
+      pos: -42.5,8.5
       parent: 2
   - uid: 530
     components:
     - type: Transform
-      pos: -41.5,6.5
+      pos: -42.5,9.5
       parent: 2
   - uid: 531
     components:
     - type: Transform
-      pos: -40.5,6.5
+      pos: -42.5,10.5
       parent: 2
   - uid: 532
     components:
     - type: Transform
-      pos: -39.5,6.5
+      pos: -41.5,10.5
       parent: 2
   - uid: 533
     components:
     - type: Transform
-      pos: -39.5,4.5
+      pos: -40.5,10.5
       parent: 2
   - uid: 534
     components:
     - type: Transform
-      pos: -40.5,4.5
+      pos: -39.5,10.5
       parent: 2
   - uid: 535
     components:
     - type: Transform
-      pos: -41.5,4.5
+      pos: -39.5,8.5
       parent: 2
   - uid: 536
     components:
     - type: Transform
-      pos: -41.5,1.5
+      pos: -40.5,8.5
       parent: 2
   - uid: 537
     components:
     - type: Transform
-      pos: -40.5,1.5
+      pos: -41.5,8.5
       parent: 2
   - uid: 538
     components:
     - type: Transform
-      pos: -39.5,1.5
+      pos: -41.5,6.5
       parent: 2
   - uid: 539
     components:
     - type: Transform
-      pos: -38.5,1.5
+      pos: -40.5,6.5
       parent: 2
   - uid: 540
     components:
     - type: Transform
-      pos: -37.5,1.5
+      pos: -39.5,6.5
       parent: 2
   - uid: 541
     components:
     - type: Transform
-      pos: -36.5,1.5
+      pos: -39.5,4.5
       parent: 2
   - uid: 542
     components:
     - type: Transform
-      pos: -35.5,1.5
+      pos: -40.5,4.5
       parent: 2
   - uid: 543
     components:
     - type: Transform
-      pos: -41.5,-0.5
+      pos: -41.5,4.5
       parent: 2
   - uid: 544
     components:
     - type: Transform
-      pos: -40.5,-0.5
+      pos: -41.5,1.5
       parent: 2
   - uid: 545
     components:
     - type: Transform
-      pos: -43.5,-0.5
+      pos: -40.5,1.5
       parent: 2
   - uid: 546
     components:
     - type: Transform
-      pos: -43.5,1.5
+      pos: -39.5,1.5
       parent: 2
   - uid: 547
     components:
     - type: Transform
-      pos: -43.5,4.5
+      pos: -38.5,1.5
       parent: 2
   - uid: 548
     components:
     - type: Transform
-      pos: -43.5,6.5
+      pos: -37.5,1.5
       parent: 2
   - uid: 549
     components:
     - type: Transform
-      pos: -43.5,8.5
+      pos: -36.5,1.5
       parent: 2
   - uid: 550
     components:
     - type: Transform
-      pos: -43.5,10.5
+      pos: -35.5,1.5
       parent: 2
   - uid: 551
     components:
     - type: Transform
-      pos: -35.5,-3.5
+      pos: -41.5,-0.5
       parent: 2
   - uid: 552
     components:
     - type: Transform
-      pos: -35.5,-6.5
+      pos: -40.5,-0.5
       parent: 2
   - uid: 553
     components:
     - type: Transform
-      pos: -35.5,-9.5
+      pos: -43.5,-0.5
       parent: 2
   - uid: 554
     components:
     - type: Transform
-      pos: -35.5,-12.5
+      pos: -43.5,1.5
       parent: 2
   - uid: 555
     components:
     - type: Transform
-      pos: -35.5,-15.5
+      pos: -43.5,4.5
       parent: 2
   - uid: 556
     components:
     - type: Transform
-      pos: -32.5,-18.5
+      pos: -43.5,6.5
       parent: 2
   - uid: 557
     components:
     - type: Transform
-      pos: -35.5,-22.5
+      pos: -43.5,8.5
       parent: 2
   - uid: 558
     components:
     - type: Transform
-      pos: -35.5,-20.5
+      pos: -43.5,10.5
       parent: 2
   - uid: 559
     components:
     - type: Transform
-      pos: -35.5,-17.5
+      pos: -35.5,-3.5
       parent: 2
   - uid: 560
     components:
     - type: Transform
-      pos: -26.5,-4.5
+      pos: -35.5,-6.5
       parent: 2
   - uid: 561
     components:
     - type: Transform
-      pos: -26.5,-5.5
+      pos: -35.5,-9.5
       parent: 2
   - uid: 562
     components:
     - type: Transform
-      pos: -27.5,-5.5
+      pos: -35.5,-12.5
       parent: 2
   - uid: 563
     components:
     - type: Transform
-      pos: -28.5,-5.5
+      pos: -35.5,-15.5
       parent: 2
   - uid: 564
     components:
     - type: Transform
-      pos: -28.5,-6.5
+      pos: -32.5,-18.5
       parent: 2
   - uid: 565
     components:
     - type: Transform
-      pos: -28.5,-7.5
+      pos: -35.5,-22.5
       parent: 2
   - uid: 566
     components:
     - type: Transform
-      pos: -29.5,-7.5
+      pos: -35.5,-20.5
       parent: 2
   - uid: 567
     components:
     - type: Transform
-      pos: -29.5,-8.5
+      pos: -35.5,-17.5
       parent: 2
   - uid: 568
     components:
     - type: Transform
-      pos: -29.5,-9.5
+      pos: -26.5,-4.5
       parent: 2
   - uid: 569
     components:
     - type: Transform
-      pos: -29.5,-10.5
+      pos: -26.5,-5.5
       parent: 2
   - uid: 570
     components:
     - type: Transform
-      pos: -25.5,-7.5
+      pos: -27.5,-5.5
       parent: 2
   - uid: 571
     components:
     - type: Transform
-      pos: -25.5,-8.5
+      pos: -28.5,-5.5
       parent: 2
   - uid: 572
     components:
     - type: Transform
-      pos: -26.5,-8.5
+      pos: -28.5,-6.5
       parent: 2
   - uid: 573
     components:
     - type: Transform
-      pos: -26.5,-9.5
+      pos: -28.5,-7.5
       parent: 2
   - uid: 574
     components:
     - type: Transform
-      pos: -26.5,-10.5
+      pos: -29.5,-7.5
       parent: 2
   - uid: 575
     components:
     - type: Transform
-      pos: -26.5,-12.5
+      pos: -29.5,-8.5
       parent: 2
   - uid: 576
     components:
     - type: Transform
-      pos: -26.5,-13.5
+      pos: -29.5,-9.5
       parent: 2
   - uid: 577
     components:
     - type: Transform
-      pos: -24.5,-8.5
+      pos: -29.5,-10.5
       parent: 2
   - uid: 578
     components:
     - type: Transform
-      pos: -23.5,-8.5
+      pos: -27.5,-8.5
       parent: 2
   - uid: 579
     components:
     - type: Transform
-      pos: -22.5,-8.5
+      pos: -25.5,-8.5
       parent: 2
   - uid: 580
     components:
     - type: Transform
-      pos: -21.5,-8.5
+      pos: -26.5,-8.5
       parent: 2
   - uid: 581
     components:
     - type: Transform
-      pos: -20.5,-8.5
+      pos: -26.5,-9.5
       parent: 2
   - uid: 582
     components:
     - type: Transform
-      pos: -20.5,-9.5
+      pos: -26.5,-10.5
       parent: 2
   - uid: 583
     components:
     - type: Transform
-      pos: -20.5,-10.5
+      pos: -26.5,-12.5
       parent: 2
   - uid: 584
     components:
     - type: Transform
-      pos: -20.5,-11.5
+      pos: -26.5,-13.5
       parent: 2
   - uid: 585
     components:
     - type: Transform
-      pos: -20.5,-12.5
+      pos: -24.5,-8.5
       parent: 2
   - uid: 586
     components:
     - type: Transform
-      pos: -20.5,-13.5
+      pos: -23.5,-8.5
       parent: 2
   - uid: 587
     components:
     - type: Transform
-      pos: -23.5,-7.5
+      pos: -22.5,-8.5
       parent: 2
   - uid: 588
     components:
     - type: Transform
-      pos: -23.5,-6.5
+      pos: -21.5,-8.5
       parent: 2
   - uid: 589
     components:
     - type: Transform
-      pos: -23.5,-5.5
+      pos: -20.5,-8.5
       parent: 2
   - uid: 590
     components:
     - type: Transform
-      pos: -20.5,-3.5
+      pos: -20.5,-9.5
       parent: 2
   - uid: 591
     components:
     - type: Transform
-      pos: -20.5,-4.5
+      pos: -20.5,-10.5
       parent: 2
   - uid: 592
     components:
     - type: Transform
-      pos: -31.5,-7.5
+      pos: -20.5,-11.5
       parent: 2
   - uid: 593
     components:
     - type: Transform
-      pos: -31.5,-6.5
+      pos: -20.5,-12.5
       parent: 2
   - uid: 594
     components:
     - type: Transform
-      pos: -31.5,-5.5
+      pos: -20.5,-13.5
       parent: 2
   - uid: 595
     components:
     - type: Transform
-      pos: -32.5,-5.5
+      pos: -23.5,-7.5
       parent: 2
   - uid: 596
     components:
     - type: Transform
-      pos: -33.5,-5.5
+      pos: -23.5,-6.5
       parent: 2
   - uid: 597
     components:
     - type: Transform
-      pos: -33.5,-7.5
+      pos: -23.5,-5.5
       parent: 2
   - uid: 598
     components:
     - type: Transform
-      pos: -33.5,-8.5
+      pos: -20.5,-3.5
       parent: 2
   - uid: 599
     components:
     - type: Transform
-      pos: -33.5,-9.5
+      pos: -20.5,-4.5
       parent: 2
   - uid: 600
     components:
     - type: Transform
-      pos: -32.5,-9.5
+      pos: -31.5,-7.5
       parent: 2
   - uid: 601
     components:
     - type: Transform
-      pos: -31.5,-9.5
+      pos: -31.5,-6.5
       parent: 2
   - uid: 602
     components:
     - type: Transform
-      pos: -17.5,-3.5
+      pos: -31.5,-5.5
       parent: 2
   - uid: 603
     components:
     - type: Transform
-      pos: -14.5,-3.5
+      pos: -32.5,-5.5
       parent: 2
   - uid: 604
     components:
     - type: Transform
-      pos: -15.5,-3.5
+      pos: -33.5,-5.5
       parent: 2
   - uid: 605
     components:
     - type: Transform
-      pos: -15.5,-4.5
+      pos: -33.5,-7.5
       parent: 2
   - uid: 606
     components:
     - type: Transform
-      pos: -17.5,-4.5
+      pos: -33.5,-8.5
       parent: 2
   - uid: 607
     components:
     - type: Transform
-      pos: -11.5,-6.5
+      pos: -33.5,-9.5
       parent: 2
   - uid: 608
     components:
     - type: Transform
-      pos: -11.5,-7.5
+      pos: -32.5,-9.5
       parent: 2
   - uid: 609
     components:
     - type: Transform
-      pos: -11.5,-8.5
+      pos: -31.5,-9.5
       parent: 2
   - uid: 610
     components:
     - type: Transform
-      pos: -11.5,-9.5
+      pos: -17.5,-3.5
       parent: 2
   - uid: 611
     components:
     - type: Transform
-      pos: -12.5,-9.5
+      pos: -14.5,-3.5
       parent: 2
   - uid: 612
     components:
     - type: Transform
-      pos: -13.5,-9.5
+      pos: -15.5,-3.5
       parent: 2
   - uid: 613
     components:
     - type: Transform
-      pos: -10.5,-9.5
+      pos: -15.5,-4.5
       parent: 2
   - uid: 614
     components:
     - type: Transform
-      pos: -9.5,-9.5
+      pos: -17.5,-4.5
       parent: 2
   - uid: 615
     components:
     - type: Transform
-      pos: -8.5,-9.5
+      pos: -11.5,-6.5
       parent: 2
   - uid: 616
     components:
     - type: Transform
-      pos: -7.5,-9.5
+      pos: -11.5,-7.5
       parent: 2
   - uid: 617
     components:
     - type: Transform
-      pos: -6.5,-9.5
+      pos: -11.5,-8.5
       parent: 2
   - uid: 618
     components:
     - type: Transform
-      pos: -7.5,-8.5
+      pos: -11.5,-9.5
       parent: 2
   - uid: 619
     components:
     - type: Transform
-      pos: -9.5,-8.5
+      pos: -12.5,-9.5
       parent: 2
   - uid: 620
     components:
     - type: Transform
-      pos: -2.5,-6.5
+      pos: -13.5,-9.5
       parent: 2
   - uid: 621
     components:
     - type: Transform
-      pos: -2.5,-7.5
+      pos: -10.5,-9.5
       parent: 2
   - uid: 622
     components:
     - type: Transform
-      pos: -3.5,-7.5
+      pos: -9.5,-9.5
       parent: 2
   - uid: 623
     components:
     - type: Transform
-      pos: -3.5,-8.5
+      pos: -8.5,-9.5
       parent: 2
   - uid: 624
     components:
     - type: Transform
-      pos: -3.5,-9.5
+      pos: -7.5,-9.5
       parent: 2
   - uid: 625
     components:
     - type: Transform
-      pos: -3.5,-10.5
+      pos: -6.5,-9.5
       parent: 2
   - uid: 626
     components:
     - type: Transform
-      pos: -2.5,-9.5
+      pos: -7.5,-8.5
       parent: 2
   - uid: 627
     components:
     - type: Transform
-      pos: -4.5,-9.5
+      pos: -9.5,-8.5
       parent: 2
   - uid: 628
     components:
     - type: Transform
-      pos: -16.5,-6.5
+      pos: -2.5,-6.5
       parent: 2
   - uid: 629
     components:
     - type: Transform
-      pos: -16.5,-7.5
+      pos: -2.5,-7.5
       parent: 2
   - uid: 630
     components:
     - type: Transform
-      pos: -16.5,-8.5
+      pos: -3.5,-7.5
       parent: 2
   - uid: 631
     components:
     - type: Transform
-      pos: -16.5,-9.5
+      pos: -3.5,-8.5
       parent: 2
   - uid: 632
     components:
     - type: Transform
-      pos: -15.5,-8.5
+      pos: -3.5,-9.5
       parent: 2
   - uid: 633
     components:
     - type: Transform
-      pos: -17.5,-8.5
+      pos: -3.5,-10.5
       parent: 2
   - uid: 634
     components:
     - type: Transform
-      pos: -18.5,-8.5
+      pos: -2.5,-9.5
       parent: 2
   - uid: 635
     components:
     - type: Transform
-      pos: -16.5,-10.5
+      pos: -4.5,-9.5
       parent: 2
   - uid: 636
     components:
     - type: Transform
-      pos: -17.5,-10.5
+      pos: -16.5,-6.5
       parent: 2
   - uid: 637
     components:
     - type: Transform
-      pos: -15.5,-10.5
+      pos: -16.5,-7.5
       parent: 2
   - uid: 638
     components:
     - type: Transform
-      pos: -18.5,-10.5
+      pos: -16.5,-8.5
       parent: 2
   - uid: 639
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -16.5,-9.5
       parent: 2
   - uid: 640
     components:
     - type: Transform
-      pos: -0.5,-5.5
+      pos: -15.5,-8.5
       parent: 2
   - uid: 641
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: -17.5,-8.5
       parent: 2
   - uid: 642
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      pos: -18.5,-8.5
       parent: 2
   - uid: 643
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: -16.5,-10.5
       parent: 2
   - uid: 644
     components:
     - type: Transform
-      pos: -9.5,-5.5
+      pos: -17.5,-10.5
       parent: 2
   - uid: 645
     components:
     - type: Transform
-      pos: -12.5,-5.5
+      pos: -15.5,-10.5
       parent: 2
   - uid: 646
     components:
     - type: Transform
-      pos: -6.5,-5.5
+      pos: -18.5,-10.5
       parent: 2
   - uid: 647
     components:
     - type: Transform
-      pos: -4.5,-4.5
+      pos: -0.5,0.5
       parent: 2
   - uid: 648
     components:
     - type: Transform
-      pos: -4.5,-5.5
+      pos: -0.5,-5.5
       parent: 2
   - uid: 649
     components:
     - type: Transform
-      pos: -12.5,-0.5
+      pos: -0.5,-6.5
       parent: 2
   - uid: 650
     components:
     - type: Transform
-      pos: -9.5,-0.5
+      pos: 0.5,-6.5
       parent: 2
   - uid: 651
     components:
     - type: Transform
-      pos: -6.5,-0.5
+      pos: 0.5,0.5
       parent: 2
   - uid: 652
     components:
     - type: Transform
-      pos: -4.5,-0.5
+      pos: -9.5,-5.5
       parent: 2
   - uid: 653
     components:
     - type: Transform
-      pos: -17.5,-1.5
+      pos: -12.5,-5.5
       parent: 2
   - uid: 654
     components:
     - type: Transform
-      pos: -23.5,-1.5
+      pos: -6.5,-5.5
       parent: 2
   - uid: 655
     components:
     - type: Transform
-      pos: -30.5,-1.5
+      pos: -4.5,-4.5
       parent: 2
   - uid: 656
     components:
     - type: Transform
-      pos: -23.5,-3.5
+      pos: -4.5,-5.5
       parent: 2
   - uid: 657
     components:
     - type: Transform
-      pos: -44.5,15.5
+      pos: -12.5,-0.5
       parent: 2
   - uid: 658
     components:
     - type: Transform
-      pos: -9.5,3.5
+      pos: -9.5,-0.5
       parent: 2
   - uid: 659
     components:
     - type: Transform
-      pos: -28.5,-18.5
+      pos: -6.5,-0.5
       parent: 2
   - uid: 660
     components:
     - type: Transform
-      pos: -27.5,-18.5
+      pos: -4.5,-0.5
       parent: 2
   - uid: 661
     components:
     - type: Transform
-      pos: -27.5,-19.5
+      pos: -17.5,-1.5
       parent: 2
   - uid: 662
     components:
     - type: Transform
-      pos: -27.5,-17.5
+      pos: -23.5,-1.5
       parent: 2
   - uid: 663
     components:
     - type: Transform
-      pos: -30.5,-27.5
+      pos: -30.5,-1.5
       parent: 2
   - uid: 664
     components:
     - type: Transform
-      pos: -29.5,-27.5
+      pos: -23.5,-3.5
       parent: 2
   - uid: 665
     components:
     - type: Transform
-      pos: -29.5,-28.5
+      pos: -44.5,15.5
       parent: 2
   - uid: 666
     components:
     - type: Transform
-      pos: -33.5,-28.5
+      pos: -9.5,3.5
       parent: 2
   - uid: 667
     components:
     - type: Transform
-      pos: -33.5,-29.5
+      pos: -28.5,-18.5
       parent: 2
   - uid: 668
     components:
     - type: Transform
-      pos: -33.5,-30.5
+      pos: -27.5,-18.5
       parent: 2
   - uid: 669
     components:
     - type: Transform
-      pos: -35.5,-30.5
+      pos: -27.5,-19.5
       parent: 2
   - uid: 670
     components:
     - type: Transform
-      pos: -34.5,-30.5
+      pos: -27.5,-17.5
       parent: 2
   - uid: 671
     components:
     - type: Transform
-      pos: -36.5,-30.5
+      pos: -30.5,-27.5
       parent: 2
   - uid: 672
     components:
     - type: Transform
-      pos: -37.5,-30.5
+      pos: -29.5,-27.5
       parent: 2
   - uid: 673
     components:
     - type: Transform
-      pos: -32.5,-30.5
+      pos: -29.5,-28.5
       parent: 2
   - uid: 674
     components:
     - type: Transform
-      pos: -31.5,-30.5
+      pos: -33.5,-28.5
       parent: 2
   - uid: 675
     components:
     - type: Transform
-      pos: -44.5,-28.5
+      pos: -33.5,-29.5
       parent: 2
   - uid: 676
     components:
     - type: Transform
-      pos: -38.5,14.5
+      pos: -33.5,-30.5
       parent: 2
   - uid: 677
     components:
     - type: Transform
-      pos: -37.5,14.5
+      pos: -35.5,-30.5
       parent: 2
   - uid: 678
     components:
     - type: Transform
-      pos: -36.5,14.5
+      pos: -34.5,-30.5
       parent: 2
   - uid: 679
     components:
     - type: Transform
-      pos: -35.5,14.5
+      pos: -36.5,-30.5
       parent: 2
-  - uid: 3720
-    components:
-    - type: Transform
-      pos: -52.5,4.5
-      parent: 2
-  - uid: 3721
-    components:
-    - type: Transform
-      pos: -51.5,4.5
-      parent: 2
-  - uid: 3722
-    components:
-    - type: Transform
-      pos: -50.5,4.5
-      parent: 2
-  - uid: 3723
-    components:
-    - type: Transform
-      pos: -50.5,3.5
-      parent: 2
-  - uid: 3724
-    components:
-    - type: Transform
-      pos: -50.5,2.5
-      parent: 2
-  - uid: 3725
-    components:
-    - type: Transform
-      pos: -50.5,1.5
-      parent: 2
-  - uid: 3726
-    components:
-    - type: Transform
-      pos: -49.5,1.5
-      parent: 2
-  - uid: 3727
-    components:
-    - type: Transform
-      pos: -48.5,1.5
-      parent: 2
-  - uid: 3728
-    components:
-    - type: Transform
-      pos: -47.5,1.5
-      parent: 2
-  - uid: 3729
-    components:
-    - type: Transform
-      pos: -46.5,1.5
-      parent: 2
-  - uid: 3730
-    components:
-    - type: Transform
-      pos: -46.5,0.5
-      parent: 2
-  - uid: 3731
-    components:
-    - type: Transform
-      pos: -46.5,-0.5
-      parent: 2
-- proto: CableHV
-  entities:
   - uid: 680
     components:
     - type: Transform
-      pos: -12.5,9.5
+      pos: -37.5,-30.5
       parent: 2
   - uid: 681
     components:
     - type: Transform
-      pos: -12.5,8.5
+      pos: -32.5,-30.5
       parent: 2
   - uid: 682
     components:
     - type: Transform
-      pos: -12.5,7.5
+      pos: -31.5,-30.5
       parent: 2
   - uid: 683
     components:
     - type: Transform
-      pos: -12.5,6.5
+      pos: -44.5,-28.5
       parent: 2
   - uid: 684
     components:
     - type: Transform
-      pos: -10.5,6.5
+      pos: -38.5,14.5
       parent: 2
   - uid: 685
     components:
     - type: Transform
-      pos: -10.5,7.5
+      pos: -37.5,14.5
       parent: 2
   - uid: 686
     components:
     - type: Transform
-      pos: -10.5,8.5
+      pos: -36.5,14.5
       parent: 2
   - uid: 687
     components:
     - type: Transform
-      pos: -10.5,9.5
+      pos: -35.5,14.5
       parent: 2
   - uid: 688
     components:
     - type: Transform
-      pos: -8.5,9.5
+      pos: -52.5,4.5
       parent: 2
   - uid: 689
     components:
     - type: Transform
-      pos: -8.5,8.5
+      pos: -51.5,4.5
       parent: 2
   - uid: 690
     components:
     - type: Transform
-      pos: -8.5,7.5
+      pos: -50.5,4.5
       parent: 2
   - uid: 691
     components:
     - type: Transform
-      pos: -8.5,6.5
+      pos: -50.5,3.5
       parent: 2
   - uid: 692
     components:
     - type: Transform
-      pos: -6.5,6.5
+      pos: -50.5,2.5
       parent: 2
   - uid: 693
     components:
     - type: Transform
-      pos: -6.5,7.5
+      pos: -50.5,1.5
       parent: 2
   - uid: 694
     components:
     - type: Transform
-      pos: -6.5,8.5
+      pos: -49.5,1.5
       parent: 2
   - uid: 695
     components:
     - type: Transform
-      pos: -6.5,9.5
+      pos: -48.5,1.5
       parent: 2
   - uid: 696
     components:
     - type: Transform
-      pos: -4.5,9.5
+      pos: -47.5,1.5
       parent: 2
   - uid: 697
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: -46.5,1.5
       parent: 2
   - uid: 698
     components:
     - type: Transform
-      pos: -4.5,7.5
+      pos: -46.5,0.5
       parent: 2
   - uid: 699
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: -46.5,-0.5
       parent: 2
   - uid: 700
     components:
     - type: Transform
-      pos: -2.5,6.5
+      pos: -44.5,13.5
       parent: 2
   - uid: 701
     components:
     - type: Transform
-      pos: -2.5,7.5
+      pos: -44.5,12.5
       parent: 2
+- proto: CableHV
+  entities:
   - uid: 702
     components:
     - type: Transform
-      pos: -2.5,8.5
+      pos: -12.5,9.5
       parent: 2
   - uid: 703
     components:
     - type: Transform
-      pos: -2.5,9.5
+      pos: -12.5,8.5
       parent: 2
   - uid: 704
     components:
     - type: Transform
-      pos: -2.5,5.5
+      pos: -12.5,7.5
       parent: 2
   - uid: 705
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -12.5,6.5
       parent: 2
   - uid: 706
     components:
     - type: Transform
-      pos: -4.5,5.5
+      pos: -10.5,6.5
       parent: 2
   - uid: 707
     components:
     - type: Transform
-      pos: -5.5,5.5
+      pos: -10.5,7.5
       parent: 2
   - uid: 708
     components:
     - type: Transform
-      pos: -6.5,5.5
+      pos: -10.5,8.5
       parent: 2
   - uid: 709
     components:
     - type: Transform
-      pos: -8.5,5.5
+      pos: -10.5,9.5
       parent: 2
   - uid: 710
     components:
     - type: Transform
-      pos: -8.5,5.5
+      pos: -8.5,9.5
       parent: 2
   - uid: 711
     components:
     - type: Transform
-      pos: -8.5,5.5
+      pos: -8.5,8.5
       parent: 2
   - uid: 712
     components:
     - type: Transform
-      pos: -9.5,5.5
+      pos: -8.5,7.5
       parent: 2
   - uid: 713
     components:
     - type: Transform
-      pos: -7.5,5.5
+      pos: -8.5,6.5
       parent: 2
   - uid: 714
     components:
     - type: Transform
-      pos: -10.5,5.5
+      pos: -6.5,6.5
       parent: 2
   - uid: 715
     components:
     - type: Transform
-      pos: -11.5,5.5
+      pos: -6.5,7.5
       parent: 2
   - uid: 716
     components:
     - type: Transform
-      pos: -12.5,5.5
+      pos: -6.5,8.5
       parent: 2
   - uid: 717
     components:
     - type: Transform
-      pos: -2.5,10.5
+      pos: -6.5,9.5
       parent: 2
   - uid: 718
     components:
     - type: Transform
-      pos: -4.5,10.5
+      pos: -4.5,9.5
       parent: 2
   - uid: 719
     components:
     - type: Transform
-      pos: -6.5,10.5
+      pos: -4.5,8.5
       parent: 2
   - uid: 720
     components:
     - type: Transform
-      pos: -8.5,10.5
+      pos: -4.5,7.5
       parent: 2
   - uid: 721
     components:
     - type: Transform
-      pos: -10.5,10.5
+      pos: -4.5,6.5
       parent: 2
   - uid: 722
     components:
     - type: Transform
-      pos: -12.5,10.5
+      pos: -2.5,6.5
       parent: 2
   - uid: 723
     components:
     - type: Transform
-      pos: -7.5,7.5
+      pos: -2.5,7.5
       parent: 2
   - uid: 724
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: -2.5,8.5
       parent: 2
   - uid: 725
     components:
     - type: Transform
-      pos: -40.5,-0.5
+      pos: -2.5,9.5
       parent: 2
   - uid: 726
     components:
     - type: Transform
-      pos: -39.5,-0.5
+      pos: -2.5,5.5
       parent: 2
   - uid: 727
     components:
     - type: Transform
-      pos: -44.5,2.5
+      pos: -3.5,5.5
       parent: 2
   - uid: 728
     components:
     - type: Transform
-      pos: -43.5,1.5
+      pos: -4.5,5.5
       parent: 2
   - uid: 729
     components:
     - type: Transform
-      pos: -43.5,2.5
+      pos: -5.5,5.5
       parent: 2
   - uid: 730
     components:
     - type: Transform
-      pos: -43.5,3.5
+      pos: -6.5,5.5
       parent: 2
   - uid: 731
     components:
     - type: Transform
-      pos: -43.5,4.5
+      pos: -8.5,5.5
       parent: 2
   - uid: 732
     components:
     - type: Transform
-      pos: -43.5,5.5
+      pos: -8.5,5.5
       parent: 2
   - uid: 733
     components:
     - type: Transform
-      pos: -43.5,6.5
+      pos: -8.5,5.5
       parent: 2
   - uid: 734
     components:
     - type: Transform
-      pos: -43.5,7.5
+      pos: -9.5,5.5
       parent: 2
   - uid: 735
     components:
     - type: Transform
-      pos: -44.5,0.5
+      pos: -7.5,5.5
       parent: 2
   - uid: 736
     components:
     - type: Transform
-      pos: -44.5,8.5
+      pos: -10.5,5.5
       parent: 2
   - uid: 737
     components:
     - type: Transform
-      pos: -44.5,9.5
+      pos: -11.5,5.5
       parent: 2
   - uid: 738
     components:
     - type: Transform
-      pos: -44.5,1.5
+      pos: -12.5,5.5
       parent: 2
   - uid: 739
     components:
     - type: Transform
-      pos: -44.5,7.5
+      pos: -2.5,10.5
       parent: 2
   - uid: 740
     components:
     - type: Transform
-      pos: -45.5,7.5
+      pos: -4.5,10.5
       parent: 2
   - uid: 741
     components:
     - type: Transform
-      pos: -46.5,7.5
+      pos: -6.5,10.5
       parent: 2
   - uid: 742
     components:
     - type: Transform
-      pos: -47.5,7.5
+      pos: -8.5,10.5
       parent: 2
   - uid: 743
     components:
     - type: Transform
-      pos: -47.5,6.5
+      pos: -10.5,10.5
       parent: 2
   - uid: 744
     components:
     - type: Transform
-      pos: -47.5,5.5
+      pos: -12.5,10.5
       parent: 2
   - uid: 745
     components:
     - type: Transform
-      pos: -46.5,5.5
+      pos: -7.5,7.5
       parent: 2
   - uid: 746
     components:
     - type: Transform
-      pos: -48.5,5.5
+      pos: -5.5,3.5
       parent: 2
   - uid: 747
     components:
     - type: Transform
-      pos: -44.5,-0.5
+      pos: -40.5,-0.5
       parent: 2
   - uid: 748
     components:
     - type: Transform
-      pos: -43.5,-0.5
+      pos: -39.5,-0.5
       parent: 2
   - uid: 749
     components:
     - type: Transform
-      pos: -42.5,-0.5
+      pos: -44.5,2.5
       parent: 2
   - uid: 750
     components:
     - type: Transform
-      pos: -41.5,-0.5
+      pos: -43.5,1.5
       parent: 2
   - uid: 751
     components:
     - type: Transform
-      pos: -38.5,-0.5
+      pos: -43.5,2.5
       parent: 2
   - uid: 752
     components:
     - type: Transform
-      pos: -5.5,4.5
+      pos: -43.5,3.5
       parent: 2
   - uid: 753
     components:
     - type: Transform
-      pos: -5.5,2.5
+      pos: -43.5,4.5
       parent: 2
   - uid: 754
     components:
     - type: Transform
-      pos: -45.5,-19.5
+      pos: -43.5,5.5
       parent: 2
   - uid: 755
     components:
     - type: Transform
-      pos: -45.5,-20.5
+      pos: -43.5,6.5
       parent: 2
   - uid: 756
     components:
     - type: Transform
-      pos: -50.5,-32.5
+      pos: -43.5,7.5
       parent: 2
   - uid: 757
     components:
     - type: Transform
-      pos: -50.5,-31.5
+      pos: -44.5,0.5
       parent: 2
   - uid: 758
     components:
     - type: Transform
-      pos: -50.5,-30.5
+      pos: -44.5,8.5
       parent: 2
   - uid: 759
     components:
     - type: Transform
-      pos: -50.5,-29.5
+      pos: -44.5,9.5
       parent: 2
   - uid: 760
     components:
     - type: Transform
-      pos: -50.5,-28.5
+      pos: -44.5,1.5
       parent: 2
   - uid: 761
     components:
     - type: Transform
-      pos: -50.5,-27.5
+      pos: -44.5,7.5
       parent: 2
   - uid: 762
     components:
     - type: Transform
-      pos: -50.5,-26.5
+      pos: -45.5,7.5
       parent: 2
   - uid: 763
     components:
     - type: Transform
-      pos: -50.5,-25.5
+      pos: -46.5,7.5
       parent: 2
   - uid: 764
     components:
     - type: Transform
-      pos: -50.5,-24.5
+      pos: -47.5,7.5
       parent: 2
   - uid: 765
     components:
     - type: Transform
-      pos: -50.5,-23.5
+      pos: -47.5,6.5
       parent: 2
   - uid: 766
     components:
     - type: Transform
-      pos: -48.5,-23.5
+      pos: -47.5,5.5
       parent: 2
   - uid: 767
     components:
     - type: Transform
-      pos: -48.5,-24.5
+      pos: -46.5,5.5
       parent: 2
   - uid: 768
     components:
     - type: Transform
-      pos: -48.5,-25.5
+      pos: -48.5,5.5
       parent: 2
   - uid: 769
     components:
     - type: Transform
-      pos: -48.5,-26.5
+      pos: -44.5,-0.5
       parent: 2
   - uid: 770
     components:
     - type: Transform
-      pos: -48.5,-27.5
+      pos: -43.5,-0.5
       parent: 2
   - uid: 771
     components:
     - type: Transform
-      pos: -48.5,-28.5
+      pos: -42.5,-0.5
       parent: 2
   - uid: 772
     components:
     - type: Transform
-      pos: -48.5,-29.5
+      pos: -41.5,-0.5
       parent: 2
   - uid: 773
     components:
     - type: Transform
-      pos: -48.5,-30.5
+      pos: -38.5,-0.5
       parent: 2
   - uid: 774
     components:
     - type: Transform
-      pos: -48.5,-31.5
+      pos: -5.5,4.5
       parent: 2
   - uid: 775
     components:
     - type: Transform
-      pos: -48.5,-32.5
+      pos: -5.5,2.5
       parent: 2
   - uid: 776
     components:
     - type: Transform
-      pos: -46.5,-32.5
+      pos: -45.5,-19.5
       parent: 2
   - uid: 777
     components:
     - type: Transform
-      pos: -46.5,-31.5
+      pos: -45.5,-20.5
       parent: 2
   - uid: 778
     components:
     - type: Transform
-      pos: -46.5,-30.5
+      pos: -50.5,-32.5
       parent: 2
   - uid: 779
     components:
     - type: Transform
-      pos: -46.5,-29.5
+      pos: -50.5,-31.5
       parent: 2
   - uid: 780
     components:
     - type: Transform
-      pos: -46.5,-28.5
+      pos: -50.5,-30.5
       parent: 2
   - uid: 781
     components:
     - type: Transform
-      pos: -46.5,-27.5
+      pos: -50.5,-29.5
       parent: 2
   - uid: 782
     components:
     - type: Transform
-      pos: -46.5,-26.5
+      pos: -50.5,-28.5
       parent: 2
   - uid: 783
     components:
     - type: Transform
-      pos: -46.5,-25.5
+      pos: -50.5,-27.5
       parent: 2
   - uid: 784
     components:
     - type: Transform
-      pos: -46.5,-24.5
+      pos: -50.5,-26.5
       parent: 2
   - uid: 785
     components:
     - type: Transform
-      pos: -46.5,-23.5
+      pos: -50.5,-25.5
       parent: 2
   - uid: 786
     components:
     - type: Transform
-      pos: -46.5,-22.5
+      pos: -50.5,-24.5
       parent: 2
   - uid: 787
     components:
     - type: Transform
-      pos: -47.5,-22.5
+      pos: -50.5,-23.5
       parent: 2
   - uid: 788
     components:
     - type: Transform
-      pos: -48.5,-22.5
+      pos: -48.5,-23.5
       parent: 2
   - uid: 789
     components:
     - type: Transform
-      pos: -49.5,-22.5
+      pos: -48.5,-24.5
       parent: 2
   - uid: 790
     components:
     - type: Transform
-      pos: -50.5,-22.5
+      pos: -48.5,-25.5
       parent: 2
   - uid: 791
     components:
     - type: Transform
-      pos: -45.5,-22.5
+      pos: -48.5,-26.5
       parent: 2
   - uid: 792
     components:
     - type: Transform
-      pos: -45.5,-21.5
+      pos: -48.5,-27.5
       parent: 2
   - uid: 793
     components:
     - type: Transform
-      pos: -37.5,-0.5
+      pos: -48.5,-28.5
       parent: 2
   - uid: 794
     components:
     - type: Transform
-      pos: -36.5,-0.5
+      pos: -48.5,-29.5
       parent: 2
   - uid: 795
     components:
     - type: Transform
-      pos: -35.5,-0.5
+      pos: -48.5,-30.5
       parent: 2
   - uid: 796
     components:
     - type: Transform
-      pos: -34.5,-0.5
+      pos: -48.5,-31.5
       parent: 2
   - uid: 797
     components:
     - type: Transform
-      pos: -33.5,-0.5
+      pos: -48.5,-32.5
       parent: 2
   - uid: 798
     components:
     - type: Transform
-      pos: -32.5,-0.5
+      pos: -46.5,-32.5
       parent: 2
   - uid: 799
     components:
     - type: Transform
-      pos: -31.5,-0.5
+      pos: -46.5,-31.5
       parent: 2
   - uid: 800
     components:
     - type: Transform
-      pos: -31.5,0.5
+      pos: -46.5,-30.5
       parent: 2
   - uid: 801
     components:
     - type: Transform
-      pos: -31.5,1.5
+      pos: -46.5,-29.5
       parent: 2
   - uid: 802
     components:
     - type: Transform
-      pos: -31.5,2.5
+      pos: -46.5,-28.5
       parent: 2
   - uid: 803
     components:
     - type: Transform
-      pos: -31.5,3.5
+      pos: -46.5,-27.5
       parent: 2
   - uid: 804
     components:
     - type: Transform
-      pos: -30.5,-0.5
+      pos: -46.5,-26.5
       parent: 2
   - uid: 805
     components:
     - type: Transform
-      pos: -29.5,-0.5
+      pos: -46.5,-25.5
       parent: 2
   - uid: 806
     components:
     - type: Transform
-      pos: -28.5,-0.5
+      pos: -46.5,-24.5
       parent: 2
   - uid: 807
     components:
     - type: Transform
-      pos: -27.5,-0.5
+      pos: -46.5,-23.5
       parent: 2
   - uid: 808
     components:
     - type: Transform
-      pos: -26.5,-0.5
+      pos: -46.5,-22.5
       parent: 2
   - uid: 809
     components:
     - type: Transform
-      pos: -25.5,-0.5
+      pos: -47.5,-22.5
       parent: 2
   - uid: 810
     components:
     - type: Transform
-      pos: -24.5,-0.5
+      pos: -48.5,-22.5
       parent: 2
   - uid: 811
     components:
     - type: Transform
-      pos: -23.5,-0.5
+      pos: -49.5,-22.5
       parent: 2
   - uid: 812
     components:
     - type: Transform
-      pos: -22.5,-0.5
+      pos: -50.5,-22.5
       parent: 2
   - uid: 813
     components:
     - type: Transform
-      pos: -21.5,-0.5
+      pos: -45.5,-22.5
       parent: 2
   - uid: 814
     components:
     - type: Transform
-      pos: -21.5,0.5
+      pos: -45.5,-21.5
       parent: 2
   - uid: 815
     components:
     - type: Transform
-      pos: -21.5,1.5
+      pos: -37.5,-0.5
       parent: 2
   - uid: 816
     components:
     - type: Transform
-      pos: -20.5,1.5
+      pos: -36.5,-0.5
       parent: 2
   - uid: 817
     components:
     - type: Transform
-      pos: -19.5,1.5
+      pos: -35.5,-0.5
       parent: 2
   - uid: 818
     components:
     - type: Transform
-      pos: -18.5,1.5
+      pos: -34.5,-0.5
       parent: 2
   - uid: 819
     components:
     - type: Transform
-      pos: -18.5,0.5
+      pos: -33.5,-0.5
       parent: 2
   - uid: 820
     components:
     - type: Transform
-      pos: -21.5,-1.5
+      pos: -32.5,-0.5
       parent: 2
   - uid: 821
     components:
     - type: Transform
-      pos: -20.5,-1.5
+      pos: -31.5,-0.5
       parent: 2
   - uid: 822
     components:
     - type: Transform
-      pos: -19.5,-1.5
+      pos: -31.5,0.5
       parent: 2
   - uid: 823
     components:
     - type: Transform
-      pos: -18.5,-1.5
+      pos: -31.5,1.5
       parent: 2
   - uid: 824
     components:
     - type: Transform
-      pos: -17.5,-1.5
+      pos: -31.5,2.5
       parent: 2
   - uid: 825
     components:
     - type: Transform
-      pos: -16.5,-1.5
+      pos: -31.5,3.5
       parent: 2
   - uid: 826
     components:
     - type: Transform
-      pos: -15.5,-1.5
+      pos: -30.5,-0.5
       parent: 2
   - uid: 827
     components:
     - type: Transform
-      pos: -14.5,-1.5
+      pos: -29.5,-0.5
       parent: 2
   - uid: 828
     components:
     - type: Transform
-      pos: -13.5,-1.5
+      pos: -28.5,-0.5
       parent: 2
   - uid: 829
     components:
     - type: Transform
-      pos: -12.5,-1.5
+      pos: -27.5,-0.5
       parent: 2
   - uid: 830
     components:
     - type: Transform
-      pos: -17.5,-2.5
+      pos: -26.5,-0.5
       parent: 2
   - uid: 831
     components:
     - type: Transform
-      pos: -17.5,-3.5
+      pos: -25.5,-0.5
       parent: 2
   - uid: 832
     components:
     - type: Transform
-      pos: -17.5,-4.5
+      pos: -24.5,-0.5
       parent: 2
   - uid: 833
     components:
     - type: Transform
-      pos: -17.5,-5.5
+      pos: -23.5,-0.5
       parent: 2
   - uid: 834
     components:
     - type: Transform
-      pos: -17.5,-6.5
+      pos: -22.5,-0.5
       parent: 2
   - uid: 835
     components:
     - type: Transform
-      pos: -11.5,-1.5
+      pos: -21.5,-0.5
       parent: 2
   - uid: 836
     components:
     - type: Transform
-      pos: -10.5,-1.5
+      pos: -21.5,0.5
       parent: 2
   - uid: 837
     components:
     - type: Transform
-      pos: -9.5,-1.5
+      pos: -21.5,1.5
       parent: 2
   - uid: 838
     components:
     - type: Transform
-      pos: -8.5,-1.5
+      pos: -20.5,1.5
       parent: 2
   - uid: 839
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      pos: -19.5,1.5
       parent: 2
   - uid: 840
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      pos: -18.5,1.5
       parent: 2
   - uid: 841
     components:
     - type: Transform
-      pos: -5.5,-1.5
+      pos: -18.5,0.5
       parent: 2
   - uid: 842
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      pos: -21.5,-1.5
       parent: 2
   - uid: 843
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: -20.5,-1.5
       parent: 2
   - uid: 844
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -19.5,-1.5
       parent: 2
   - uid: 845
     components:
     - type: Transform
-      pos: -37.5,-1.5
+      pos: -18.5,-1.5
       parent: 2
   - uid: 846
     components:
     - type: Transform
-      pos: -37.5,-2.5
+      pos: -17.5,-1.5
       parent: 2
   - uid: 847
     components:
     - type: Transform
-      pos: -37.5,-3.5
+      pos: -16.5,-1.5
       parent: 2
   - uid: 848
     components:
     - type: Transform
-      pos: -37.5,-4.5
+      pos: -15.5,-1.5
       parent: 2
   - uid: 849
     components:
     - type: Transform
-      pos: -37.5,-5.5
+      pos: -14.5,-1.5
       parent: 2
   - uid: 850
     components:
     - type: Transform
-      pos: -37.5,-6.5
+      pos: -13.5,-1.5
       parent: 2
   - uid: 851
     components:
     - type: Transform
-      pos: -37.5,-7.5
+      pos: -12.5,-1.5
       parent: 2
   - uid: 852
     components:
     - type: Transform
-      pos: -37.5,-8.5
+      pos: -17.5,-2.5
       parent: 2
   - uid: 853
     components:
     - type: Transform
-      pos: -37.5,-9.5
+      pos: -17.5,-3.5
       parent: 2
   - uid: 854
     components:
     - type: Transform
-      pos: -37.5,-10.5
+      pos: -17.5,-4.5
       parent: 2
   - uid: 855
     components:
     - type: Transform
-      pos: -37.5,-11.5
+      pos: -17.5,-5.5
       parent: 2
   - uid: 856
     components:
     - type: Transform
-      pos: -37.5,-12.5
+      pos: -17.5,-6.5
       parent: 2
   - uid: 857
     components:
     - type: Transform
-      pos: -37.5,-13.5
+      pos: -11.5,-1.5
       parent: 2
   - uid: 858
     components:
     - type: Transform
-      pos: -37.5,-14.5
+      pos: -10.5,-1.5
       parent: 2
   - uid: 859
     components:
     - type: Transform
-      pos: -38.5,-14.5
+      pos: -9.5,-1.5
       parent: 2
   - uid: 860
     components:
     - type: Transform
-      pos: -39.5,-14.5
+      pos: -8.5,-1.5
       parent: 2
   - uid: 861
     components:
     - type: Transform
-      pos: -39.5,-13.5
+      pos: -7.5,-1.5
       parent: 2
   - uid: 862
     components:
     - type: Transform
-      pos: -39.5,-12.5
+      pos: -6.5,-1.5
       parent: 2
   - uid: 863
     components:
     - type: Transform
-      pos: -37.5,-15.5
+      pos: -5.5,-1.5
       parent: 2
   - uid: 864
     components:
     - type: Transform
-      pos: -37.5,-16.5
+      pos: -5.5,-0.5
       parent: 2
   - uid: 865
     components:
     - type: Transform
-      pos: -37.5,-17.5
+      pos: -5.5,0.5
       parent: 2
   - uid: 866
     components:
     - type: Transform
-      pos: -36.5,-17.5
+      pos: -5.5,1.5
       parent: 2
   - uid: 867
     components:
     - type: Transform
-      pos: -35.5,-17.5
+      pos: -37.5,-1.5
       parent: 2
   - uid: 868
     components:
     - type: Transform
-      pos: -34.5,-17.5
+      pos: -37.5,-2.5
       parent: 2
   - uid: 869
     components:
     - type: Transform
-      pos: -33.5,-17.5
+      pos: -37.5,-3.5
       parent: 2
   - uid: 870
     components:
     - type: Transform
-      pos: -32.5,-17.5
+      pos: -37.5,-4.5
       parent: 2
   - uid: 871
     components:
     - type: Transform
-      pos: -32.5,-18.5
+      pos: -37.5,-5.5
       parent: 2
   - uid: 872
     components:
     - type: Transform
-      pos: -32.5,-19.5
+      pos: -37.5,-6.5
       parent: 2
   - uid: 873
     components:
     - type: Transform
-      pos: -32.5,-20.5
+      pos: -37.5,-7.5
       parent: 2
   - uid: 874
     components:
     - type: Transform
-      pos: -37.5,-18.5
+      pos: -37.5,-8.5
       parent: 2
   - uid: 875
     components:
     - type: Transform
-      pos: -37.5,-19.5
+      pos: -37.5,-9.5
       parent: 2
   - uid: 876
     components:
     - type: Transform
-      pos: -37.5,-20.5
+      pos: -37.5,-10.5
       parent: 2
   - uid: 877
     components:
     - type: Transform
-      pos: -37.5,-21.5
+      pos: -37.5,-11.5
       parent: 2
   - uid: 878
     components:
     - type: Transform
-      pos: -37.5,-22.5
+      pos: -37.5,-12.5
       parent: 2
   - uid: 879
     components:
     - type: Transform
-      pos: -37.5,-23.5
+      pos: -37.5,-13.5
       parent: 2
   - uid: 880
     components:
     - type: Transform
-      pos: -38.5,-23.5
+      pos: -37.5,-14.5
       parent: 2
   - uid: 881
     components:
     - type: Transform
-      pos: -39.5,-23.5
+      pos: -38.5,-14.5
       parent: 2
   - uid: 882
     components:
     - type: Transform
-      pos: -40.5,-23.5
+      pos: -39.5,-14.5
       parent: 2
   - uid: 883
     components:
     - type: Transform
-      pos: -40.5,-24.5
+      pos: -39.5,-13.5
       parent: 2
   - uid: 884
     components:
     - type: Transform
-      pos: -41.5,-24.5
+      pos: -39.5,-12.5
       parent: 2
   - uid: 885
     components:
     - type: Transform
-      pos: -38.5,-18.5
+      pos: -37.5,-15.5
       parent: 2
   - uid: 886
     components:
     - type: Transform
-      pos: -39.5,-18.5
+      pos: -37.5,-16.5
       parent: 2
   - uid: 887
     components:
     - type: Transform
-      pos: -40.5,-18.5
+      pos: -37.5,-17.5
       parent: 2
   - uid: 888
     components:
     - type: Transform
-      pos: -41.5,-18.5
+      pos: -36.5,-17.5
       parent: 2
   - uid: 889
     components:
     - type: Transform
-      pos: -42.5,-18.5
+      pos: -35.5,-17.5
       parent: 2
   - uid: 890
     components:
     - type: Transform
-      pos: -43.5,-18.5
+      pos: -34.5,-17.5
       parent: 2
   - uid: 891
     components:
     - type: Transform
-      pos: -43.5,-17.5
+      pos: -33.5,-17.5
       parent: 2
   - uid: 892
     components:
     - type: Transform
-      pos: -43.5,-16.5
+      pos: -32.5,-17.5
       parent: 2
   - uid: 893
     components:
     - type: Transform
-      pos: -41.5,-1.5
+      pos: -32.5,-18.5
       parent: 2
   - uid: 894
     components:
     - type: Transform
-      pos: -45.5,-18.5
+      pos: -32.5,-19.5
       parent: 2
   - uid: 895
     components:
     - type: Transform
-      pos: -44.5,-18.5
+      pos: -32.5,-20.5
       parent: 2
   - uid: 896
     components:
     - type: Transform
-      pos: -36.5,-7.5
+      pos: -37.5,-18.5
       parent: 2
   - uid: 897
     components:
     - type: Transform
-      pos: -35.5,-7.5
+      pos: -37.5,-19.5
       parent: 2
   - uid: 898
     components:
     - type: Transform
-      pos: -34.5,-7.5
+      pos: -37.5,-20.5
       parent: 2
   - uid: 899
     components:
     - type: Transform
-      pos: -28.5,-4.5
+      pos: -37.5,-21.5
       parent: 2
   - uid: 900
     components:
     - type: Transform
-      pos: -28.5,-3.5
+      pos: -37.5,-22.5
       parent: 2
   - uid: 901
     components:
     - type: Transform
-      pos: -28.5,-2.5
+      pos: -37.5,-23.5
       parent: 2
   - uid: 902
     components:
     - type: Transform
+      pos: -38.5,-23.5
+      parent: 2
+  - uid: 903
+    components:
+    - type: Transform
+      pos: -39.5,-23.5
+      parent: 2
+  - uid: 904
+    components:
+    - type: Transform
+      pos: -40.5,-23.5
+      parent: 2
+  - uid: 905
+    components:
+    - type: Transform
+      pos: -40.5,-24.5
+      parent: 2
+  - uid: 906
+    components:
+    - type: Transform
+      pos: -41.5,-24.5
+      parent: 2
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -38.5,-18.5
+      parent: 2
+  - uid: 908
+    components:
+    - type: Transform
+      pos: -39.5,-18.5
+      parent: 2
+  - uid: 909
+    components:
+    - type: Transform
+      pos: -40.5,-18.5
+      parent: 2
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -41.5,-18.5
+      parent: 2
+  - uid: 911
+    components:
+    - type: Transform
+      pos: -42.5,-18.5
+      parent: 2
+  - uid: 912
+    components:
+    - type: Transform
+      pos: -43.5,-18.5
+      parent: 2
+  - uid: 913
+    components:
+    - type: Transform
+      pos: -43.5,-17.5
+      parent: 2
+  - uid: 914
+    components:
+    - type: Transform
+      pos: -43.5,-16.5
+      parent: 2
+  - uid: 915
+    components:
+    - type: Transform
+      pos: -41.5,-1.5
+      parent: 2
+  - uid: 916
+    components:
+    - type: Transform
+      pos: -45.5,-18.5
+      parent: 2
+  - uid: 917
+    components:
+    - type: Transform
+      pos: -44.5,-18.5
+      parent: 2
+  - uid: 918
+    components:
+    - type: Transform
+      pos: -36.5,-7.5
+      parent: 2
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -35.5,-7.5
+      parent: 2
+  - uid: 920
+    components:
+    - type: Transform
+      pos: -34.5,-7.5
+      parent: 2
+  - uid: 921
+    components:
+    - type: Transform
+      pos: -28.5,-4.5
+      parent: 2
+  - uid: 922
+    components:
+    - type: Transform
+      pos: -28.5,-3.5
+      parent: 2
+  - uid: 923
+    components:
+    - type: Transform
+      pos: -28.5,-2.5
+      parent: 2
+  - uid: 924
+    components:
+    - type: Transform
       pos: -28.5,-1.5
       parent: 2
-  - uid: 3732
+  - uid: 925
     components:
     - type: Transform
       pos: -46.5,-1.5
       parent: 2
-  - uid: 3733
+  - uid: 926
     components:
     - type: Transform
       pos: -46.5,-0.5
       parent: 2
-  - uid: 3734
+  - uid: 927
     components:
     - type: Transform
       pos: -46.5,0.5
       parent: 2
-  - uid: 3735
+  - uid: 928
     components:
     - type: Transform
       pos: -46.5,1.5
       parent: 2
-  - uid: 3736
+  - uid: 929
     components:
     - type: Transform
       pos: -47.5,1.5
       parent: 2
-  - uid: 3737
+  - uid: 930
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
-  - uid: 3738
+  - uid: 931
     components:
     - type: Transform
       pos: -51.5,4.5
       parent: 2
-  - uid: 3739
+  - uid: 932
     components:
     - type: Transform
       pos: -50.5,4.5
       parent: 2
-  - uid: 3740
+  - uid: 933
     components:
     - type: Transform
       pos: -49.5,1.5
       parent: 2
-  - uid: 3741
+  - uid: 934
     components:
     - type: Transform
       pos: -48.5,2.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 903
+  - uid: 935
     components:
     - type: Transform
       pos: -28.5,-3.5
       parent: 2
-  - uid: 904
+  - uid: 936
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
-  - uid: 905
+  - uid: 937
     components:
     - type: Transform
       pos: -26.5,-4.5
       parent: 2
-  - uid: 906
+  - uid: 938
     components:
     - type: Transform
       pos: -28.5,-4.5
       parent: 2
-  - uid: 907
-    components:
-    - type: Transform
-      pos: -39.5,-12.5
-      parent: 2
-  - uid: 908
-    components:
-    - type: Transform
-      pos: -17.5,-6.5
-      parent: 2
-  - uid: 909
-    components:
-    - type: Transform
-      pos: -16.5,-6.5
-      parent: 2
-  - uid: 910
-    components:
-    - type: Transform
-      pos: -16.5,-7.5
-      parent: 2
-  - uid: 911
-    components:
-    - type: Transform
-      pos: -15.5,-7.5
-      parent: 2
-  - uid: 912
-    components:
-    - type: Transform
-      pos: -14.5,-7.5
-      parent: 2
-  - uid: 913
-    components:
-    - type: Transform
-      pos: -13.5,-7.5
-      parent: 2
-  - uid: 914
-    components:
-    - type: Transform
-      pos: -12.5,-7.5
-      parent: 2
-  - uid: 915
-    components:
-    - type: Transform
-      pos: -11.5,-7.5
-      parent: 2
-  - uid: 916
-    components:
-    - type: Transform
-      pos: -11.5,-6.5
-      parent: 2
-  - uid: 917
-    components:
-    - type: Transform
-      pos: -10.5,-7.5
-      parent: 2
-  - uid: 918
-    components:
-    - type: Transform
-      pos: -9.5,-7.5
-      parent: 2
-  - uid: 919
-    components:
-    - type: Transform
-      pos: -8.5,-7.5
-      parent: 2
-  - uid: 920
-    components:
-    - type: Transform
-      pos: -7.5,-7.5
-      parent: 2
-  - uid: 921
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 2
-  - uid: 922
-    components:
-    - type: Transform
-      pos: -6.5,-8.5
-      parent: 2
-  - uid: 923
-    components:
-    - type: Transform
-      pos: -5.5,-8.5
-      parent: 2
-  - uid: 924
-    components:
-    - type: Transform
-      pos: -4.5,-8.5
-      parent: 2
-  - uid: 925
-    components:
-    - type: Transform
-      pos: -3.5,-8.5
-      parent: 2
-  - uid: 926
-    components:
-    - type: Transform
-      pos: -2.5,-8.5
-      parent: 2
-  - uid: 927
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
-      parent: 2
-  - uid: 928
-    components:
-    - type: Transform
-      pos: -2.5,-6.5
-      parent: 2
-  - uid: 929
-    components:
-    - type: Transform
-      pos: -5.5,1.5
-      parent: 2
-  - uid: 930
-    components:
-    - type: Transform
-      pos: -4.5,1.5
-      parent: 2
-  - uid: 931
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 2
-  - uid: 932
-    components:
-    - type: Transform
-      pos: -39.5,-13.5
-      parent: 2
-  - uid: 933
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 2
-  - uid: 934
-    components:
-    - type: Transform
-      pos: -18.5,0.5
-      parent: 2
-  - uid: 935
-    components:
-    - type: Transform
-      pos: -17.5,0.5
-      parent: 2
-  - uid: 936
-    components:
-    - type: Transform
-      pos: -18.5,1.5
-      parent: 2
-  - uid: 937
-    components:
-    - type: Transform
-      pos: -18.5,2.5
-      parent: 2
-  - uid: 938
-    components:
-    - type: Transform
-      pos: -19.5,2.5
-      parent: 2
   - uid: 939
     components:
     - type: Transform
-      pos: -20.5,2.5
+      pos: -39.5,-12.5
       parent: 2
   - uid: 940
     components:
     - type: Transform
-      pos: -21.5,2.5
+      pos: -17.5,-6.5
       parent: 2
   - uid: 941
     components:
     - type: Transform
-      pos: -22.5,2.5
+      pos: -16.5,-6.5
       parent: 2
   - uid: 942
     components:
     - type: Transform
-      pos: -22.5,3.5
+      pos: -16.5,-7.5
       parent: 2
   - uid: 943
     components:
     - type: Transform
-      pos: -23.5,3.5
+      pos: -15.5,-7.5
       parent: 2
   - uid: 944
     components:
     - type: Transform
-      pos: -31.5,3.5
+      pos: -14.5,-7.5
       parent: 2
   - uid: 945
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: -13.5,-7.5
       parent: 2
   - uid: 946
     components:
     - type: Transform
-      pos: -30.5,3.5
+      pos: -12.5,-7.5
       parent: 2
   - uid: 947
     components:
     - type: Transform
-      pos: -29.5,3.5
+      pos: -11.5,-7.5
       parent: 2
   - uid: 948
     components:
     - type: Transform
-      pos: -28.5,3.5
+      pos: -11.5,-6.5
       parent: 2
   - uid: 949
     components:
     - type: Transform
-      pos: -27.5,3.5
+      pos: -10.5,-7.5
       parent: 2
   - uid: 950
     components:
     - type: Transform
-      pos: -26.5,3.5
+      pos: -9.5,-7.5
       parent: 2
   - uid: 951
     components:
     - type: Transform
-      pos: -26.5,4.5
+      pos: -8.5,-7.5
       parent: 2
   - uid: 952
     components:
     - type: Transform
-      pos: -26.5,5.5
+      pos: -7.5,-7.5
       parent: 2
   - uid: 953
     components:
     - type: Transform
-      pos: -26.5,6.5
+      pos: -6.5,-7.5
       parent: 2
   - uid: 954
     components:
     - type: Transform
-      pos: -27.5,6.5
+      pos: -6.5,-8.5
       parent: 2
   - uid: 955
     components:
     - type: Transform
-      pos: -31.5,4.5
+      pos: -5.5,-8.5
       parent: 2
   - uid: 956
     components:
     - type: Transform
-      pos: -31.5,5.5
+      pos: -4.5,-8.5
       parent: 2
   - uid: 957
     components:
     - type: Transform
-      pos: -32.5,5.5
+      pos: -3.5,-8.5
       parent: 2
   - uid: 958
     components:
     - type: Transform
-      pos: -33.5,5.5
+      pos: -2.5,-8.5
       parent: 2
   - uid: 959
     components:
     - type: Transform
-      pos: -34.5,5.5
+      pos: -2.5,-7.5
       parent: 2
   - uid: 960
     components:
     - type: Transform
-      pos: -35.5,5.5
+      pos: -2.5,-6.5
       parent: 2
   - uid: 961
     components:
     - type: Transform
-      pos: -35.5,6.5
+      pos: -5.5,1.5
       parent: 2
   - uid: 962
     components:
     - type: Transform
-      pos: -35.5,7.5
+      pos: -4.5,1.5
       parent: 2
   - uid: 963
     components:
     - type: Transform
-      pos: -31.5,6.5
+      pos: -3.5,1.5
       parent: 2
   - uid: 964
     components:
     - type: Transform
-      pos: -31.5,7.5
+      pos: -39.5,-13.5
       parent: 2
   - uid: 965
     components:
     - type: Transform
-      pos: -31.5,8.5
+      pos: -1.5,1.5
       parent: 2
   - uid: 966
     components:
     - type: Transform
-      pos: -31.5,9.5
+      pos: -18.5,0.5
       parent: 2
   - uid: 967
     components:
     - type: Transform
-      pos: -31.5,10.5
+      pos: -17.5,0.5
       parent: 2
   - uid: 968
     components:
     - type: Transform
-      pos: -32.5,10.5
+      pos: -18.5,1.5
       parent: 2
   - uid: 969
     components:
     - type: Transform
-      pos: -33.5,10.5
+      pos: -18.5,2.5
       parent: 2
   - uid: 970
     components:
     - type: Transform
-      pos: -34.5,10.5
+      pos: -19.5,2.5
       parent: 2
   - uid: 971
     components:
     - type: Transform
-      pos: -35.5,10.5
+      pos: -20.5,2.5
       parent: 2
   - uid: 972
     components:
     - type: Transform
-      pos: -36.5,10.5
+      pos: -21.5,2.5
       parent: 2
   - uid: 973
     components:
     - type: Transform
-      pos: -36.5,9.5
+      pos: -22.5,2.5
       parent: 2
   - uid: 974
     components:
     - type: Transform
-      pos: -37.5,9.5
+      pos: -22.5,3.5
       parent: 2
   - uid: 975
     components:
     - type: Transform
-      pos: -41.5,-1.5
+      pos: -23.5,3.5
       parent: 2
   - uid: 976
     components:
     - type: Transform
-      pos: -42.5,-1.5
+      pos: -31.5,3.5
       parent: 2
   - uid: 977
     components:
     - type: Transform
-      pos: -41.5,-0.5
+      pos: -32.5,3.5
       parent: 2
   - uid: 978
     components:
     - type: Transform
-      pos: -41.5,0.5
+      pos: -30.5,3.5
       parent: 2
   - uid: 979
     components:
     - type: Transform
-      pos: -41.5,1.5
+      pos: -29.5,3.5
       parent: 2
   - uid: 980
     components:
     - type: Transform
-      pos: -41.5,2.5
+      pos: -28.5,3.5
       parent: 2
   - uid: 981
     components:
     - type: Transform
-      pos: -41.5,3.5
+      pos: -27.5,3.5
       parent: 2
   - uid: 982
     components:
     - type: Transform
-      pos: -41.5,4.5
+      pos: -26.5,3.5
       parent: 2
   - uid: 983
     components:
     - type: Transform
-      pos: -41.5,5.5
+      pos: -26.5,4.5
       parent: 2
   - uid: 984
     components:
     - type: Transform
-      pos: -41.5,6.5
+      pos: -26.5,5.5
       parent: 2
   - uid: 985
     components:
     - type: Transform
-      pos: -41.5,7.5
+      pos: -26.5,6.5
       parent: 2
   - uid: 986
     components:
     - type: Transform
-      pos: -41.5,8.5
+      pos: -27.5,6.5
       parent: 2
   - uid: 987
     components:
     - type: Transform
-      pos: -41.5,9.5
+      pos: -31.5,4.5
       parent: 2
   - uid: 988
     components:
     - type: Transform
-      pos: -41.5,10.5
+      pos: -31.5,5.5
       parent: 2
   - uid: 989
     components:
     - type: Transform
-      pos: -42.5,10.5
+      pos: -32.5,5.5
       parent: 2
   - uid: 990
     components:
     - type: Transform
-      pos: -42.5,11.5
+      pos: -33.5,5.5
       parent: 2
   - uid: 991
     components:
     - type: Transform
-      pos: -42.5,12.5
+      pos: -34.5,5.5
       parent: 2
   - uid: 992
     components:
     - type: Transform
-      pos: -42.5,8.5
+      pos: -35.5,5.5
       parent: 2
   - uid: 993
     components:
     - type: Transform
-      pos: -43.5,8.5
+      pos: -35.5,6.5
       parent: 2
   - uid: 994
     components:
     - type: Transform
-      pos: -44.5,8.5
+      pos: -35.5,7.5
       parent: 2
   - uid: 995
     components:
     - type: Transform
-      pos: -45.5,8.5
+      pos: -31.5,6.5
       parent: 2
   - uid: 996
     components:
     - type: Transform
-      pos: -40.5,-13.5
+      pos: -31.5,7.5
       parent: 2
   - uid: 997
     components:
     - type: Transform
-      pos: -34.5,-6.5
+      pos: -31.5,8.5
       parent: 2
   - uid: 998
     components:
     - type: Transform
-      pos: -33.5,-6.5
+      pos: -31.5,9.5
       parent: 2
   - uid: 999
     components:
     - type: Transform
-      pos: -43.5,-16.5
+      pos: -31.5,10.5
       parent: 2
   - uid: 1000
     components:
     - type: Transform
-      pos: -42.5,-16.5
+      pos: -32.5,10.5
       parent: 2
   - uid: 1001
     components:
     - type: Transform
-      pos: -41.5,-24.5
+      pos: -33.5,10.5
       parent: 2
   - uid: 1002
     components:
     - type: Transform
-      pos: -41.5,-25.5
+      pos: -34.5,10.5
       parent: 2
   - uid: 1003
     components:
     - type: Transform
-      pos: -40.5,-24.5
+      pos: -35.5,10.5
       parent: 2
   - uid: 1004
     components:
     - type: Transform
-      pos: -39.5,-24.5
+      pos: -36.5,10.5
       parent: 2
   - uid: 1005
     components:
     - type: Transform
-      pos: -39.5,-25.5
+      pos: -36.5,9.5
       parent: 2
   - uid: 1006
     components:
     - type: Transform
-      pos: -39.5,-26.5
+      pos: -37.5,9.5
       parent: 2
   - uid: 1007
     components:
     - type: Transform
-      pos: -38.5,-26.5
+      pos: -41.5,-1.5
       parent: 2
   - uid: 1008
     components:
     - type: Transform
-      pos: -37.5,-26.5
+      pos: -42.5,-1.5
       parent: 2
   - uid: 1009
     components:
     - type: Transform
-      pos: -36.5,-26.5
+      pos: -41.5,-0.5
       parent: 2
   - uid: 1010
     components:
     - type: Transform
-      pos: -35.5,-26.5
+      pos: -41.5,0.5
       parent: 2
   - uid: 1011
     components:
     - type: Transform
-      pos: -34.5,-26.5
+      pos: -41.5,1.5
       parent: 2
   - uid: 1012
     components:
     - type: Transform
-      pos: -33.5,-26.5
+      pos: -41.5,2.5
       parent: 2
   - uid: 1013
     components:
     - type: Transform
-      pos: -33.5,-25.5
+      pos: -41.5,3.5
       parent: 2
   - uid: 1014
     components:
     - type: Transform
-      pos: -39.5,-27.5
+      pos: -41.5,4.5
       parent: 2
   - uid: 1015
     components:
     - type: Transform
-      pos: -40.5,-27.5
+      pos: -41.5,5.5
       parent: 2
   - uid: 1016
     components:
     - type: Transform
-      pos: -41.5,-27.5
+      pos: -41.5,6.5
       parent: 2
   - uid: 1017
     components:
     - type: Transform
-      pos: -41.5,-23.5
+      pos: -41.5,7.5
       parent: 2
   - uid: 1018
     components:
     - type: Transform
-      pos: -41.5,-22.5
+      pos: -41.5,8.5
       parent: 2
   - uid: 1019
     components:
     - type: Transform
-      pos: -32.5,-20.5
+      pos: -41.5,9.5
       parent: 2
   - uid: 1020
     components:
     - type: Transform
-      pos: -31.5,-20.5
+      pos: -41.5,10.5
       parent: 2
   - uid: 1021
     components:
     - type: Transform
-      pos: -31.5,-19.5
+      pos: -42.5,10.5
       parent: 2
   - uid: 1022
     components:
     - type: Transform
-      pos: -31.5,-18.5
+      pos: -42.5,11.5
       parent: 2
   - uid: 1023
     components:
     - type: Transform
-      pos: -31.5,-17.5
+      pos: -42.5,8.5
       parent: 2
   - uid: 1024
     components:
     - type: Transform
-      pos: -31.5,-16.5
+      pos: -43.5,8.5
       parent: 2
   - uid: 1025
     components:
     - type: Transform
-      pos: -31.5,-15.5
+      pos: -44.5,8.5
       parent: 2
   - uid: 1026
     components:
     - type: Transform
-      pos: -31.5,-14.5
+      pos: -45.5,8.5
       parent: 2
   - uid: 1027
     components:
     - type: Transform
-      pos: -30.5,-14.5
+      pos: -40.5,-13.5
       parent: 2
   - uid: 1028
     components:
     - type: Transform
-      pos: -29.5,-14.5
+      pos: -34.5,-6.5
       parent: 2
   - uid: 1029
     components:
     - type: Transform
-      pos: -28.5,-14.5
+      pos: -33.5,-6.5
       parent: 2
   - uid: 1030
     components:
     - type: Transform
-      pos: -28.5,-15.5
+      pos: -43.5,-16.5
       parent: 2
   - uid: 1031
     components:
     - type: Transform
-      pos: -32.5,-6.5
+      pos: -42.5,-16.5
       parent: 2
   - uid: 1032
     components:
     - type: Transform
-      pos: -28.5,-5.5
+      pos: -41.5,-24.5
       parent: 2
   - uid: 1033
     components:
     - type: Transform
-      pos: -28.5,-6.5
+      pos: -41.5,-25.5
       parent: 2
   - uid: 1034
     components:
     - type: Transform
-      pos: -28.5,-7.5
+      pos: -40.5,-24.5
       parent: 2
   - uid: 1035
     components:
     - type: Transform
-      pos: -27.5,-7.5
+      pos: -39.5,-24.5
       parent: 2
   - uid: 1036
     components:
     - type: Transform
-      pos: -26.5,-7.5
+      pos: -39.5,-25.5
       parent: 2
   - uid: 1037
     components:
     - type: Transform
-      pos: -25.5,-7.5
+      pos: -39.5,-26.5
       parent: 2
   - uid: 1038
     components:
     - type: Transform
-      pos: -34.5,-7.5
+      pos: -38.5,-26.5
       parent: 2
   - uid: 1039
     components:
     - type: Transform
-      pos: -29.5,-3.5
+      pos: -37.5,-26.5
       parent: 2
   - uid: 1040
     components:
     - type: Transform
-      pos: -39.5,-11.5
+      pos: -36.5,-26.5
       parent: 2
   - uid: 1041
     components:
     - type: Transform
-      pos: -39.5,-12.5
+      pos: -35.5,-26.5
       parent: 2
   - uid: 1042
     components:
     - type: Transform
-      pos: -30.5,-4.5
+      pos: -34.5,-26.5
       parent: 2
   - uid: 1043
     components:
     - type: Transform
-      pos: -41.5,-13.5
+      pos: -33.5,-26.5
       parent: 2
   - uid: 1044
     components:
     - type: Transform
-      pos: -42.5,-13.5
+      pos: -33.5,-25.5
       parent: 2
   - uid: 1045
     components:
     - type: Transform
-      pos: -42.5,-12.5
+      pos: -39.5,-27.5
       parent: 2
   - uid: 1046
     components:
     - type: Transform
-      pos: -40.5,-12.5
+      pos: -40.5,-27.5
       parent: 2
   - uid: 1047
     components:
     - type: Transform
-      pos: -31.5,-6.5
+      pos: -41.5,-27.5
       parent: 2
   - uid: 1048
     components:
     - type: Transform
-      pos: -31.5,-7.5
+      pos: -41.5,-23.5
       parent: 2
   - uid: 1049
     components:
     - type: Transform
-      pos: -30.5,-3.5
+      pos: -41.5,-22.5
       parent: 2
   - uid: 1050
     components:
     - type: Transform
-      pos: -27.5,-5.5
+      pos: -32.5,-20.5
       parent: 2
   - uid: 1051
     components:
     - type: Transform
-      pos: -26.5,-5.5
+      pos: -31.5,-20.5
       parent: 2
   - uid: 1052
     components:
     - type: Transform
-      pos: -3.5,0.5
+      pos: -31.5,-19.5
       parent: 2
   - uid: 1053
     components:
     - type: Transform
-      pos: -2.5,0.5
+      pos: -31.5,-18.5
       parent: 2
   - uid: 1054
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -31.5,-17.5
       parent: 2
   - uid: 1055
     components:
     - type: Transform
+      pos: -31.5,-16.5
+      parent: 2
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: -31.5,-15.5
+      parent: 2
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: -31.5,-14.5
+      parent: 2
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: -30.5,-14.5
+      parent: 2
+  - uid: 1059
+    components:
+    - type: Transform
+      pos: -29.5,-14.5
+      parent: 2
+  - uid: 1060
+    components:
+    - type: Transform
+      pos: -28.5,-14.5
+      parent: 2
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: -28.5,-15.5
+      parent: 2
+  - uid: 1062
+    components:
+    - type: Transform
+      pos: -32.5,-6.5
+      parent: 2
+  - uid: 1063
+    components:
+    - type: Transform
+      pos: -28.5,-5.5
+      parent: 2
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: -28.5,-6.5
+      parent: 2
+  - uid: 1065
+    components:
+    - type: Transform
+      pos: -28.5,-7.5
+      parent: 2
+  - uid: 1066
+    components:
+    - type: Transform
+      pos: -27.5,-7.5
+      parent: 2
+  - uid: 1067
+    components:
+    - type: Transform
+      pos: -27.5,-8.5
+      parent: 2
+  - uid: 1068
+    components:
+    - type: Transform
+      pos: -34.5,-7.5
+      parent: 2
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: -29.5,-3.5
+      parent: 2
+  - uid: 1070
+    components:
+    - type: Transform
+      pos: -39.5,-11.5
+      parent: 2
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: -39.5,-12.5
+      parent: 2
+  - uid: 1072
+    components:
+    - type: Transform
+      pos: -30.5,-4.5
+      parent: 2
+  - uid: 1073
+    components:
+    - type: Transform
+      pos: -41.5,-13.5
+      parent: 2
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: -42.5,-13.5
+      parent: 2
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: -42.5,-12.5
+      parent: 2
+  - uid: 1076
+    components:
+    - type: Transform
+      pos: -40.5,-12.5
+      parent: 2
+  - uid: 1077
+    components:
+    - type: Transform
+      pos: -31.5,-6.5
+      parent: 2
+  - uid: 1078
+    components:
+    - type: Transform
+      pos: -31.5,-7.5
+      parent: 2
+  - uid: 1079
+    components:
+    - type: Transform
+      pos: -30.5,-3.5
+      parent: 2
+  - uid: 1080
+    components:
+    - type: Transform
+      pos: -27.5,-5.5
+      parent: 2
+  - uid: 1081
+    components:
+    - type: Transform
+      pos: -26.5,-5.5
+      parent: 2
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 1083
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 1085
+    components:
+    - type: Transform
       pos: -33.5,-7.5
+      parent: 2
+  - uid: 1086
+    components:
+    - type: Transform
+      pos: -44.5,12.5
+      parent: 2
+  - uid: 1087
+    components:
+    - type: Transform
+      pos: -43.5,11.5
+      parent: 2
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: -44.5,11.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 1056
+  - uid: 1089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,1.5
       parent: 2
-  - uid: 1057
+  - uid: 1090
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7778,28 +7988,34 @@ entities:
       parent: 2
 - proto: CameraHandheld
   entities:
-  - uid: 3578
+  - uid: 7
     components:
     - type: Transform
-      parent: 3575
+      parent: 3
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+      storage: 3
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: -4.37685,3.4880257
+      parent: 2
 - proto: CandleBlack
   entities:
-  - uid: 1058
+  - uid: 1092
     components:
     - type: Transform
       pos: -33.30044,-8.534201
       parent: 2
 - proto: CandleBlueInfinite
   entities:
-  - uid: 1059
+  - uid: 1093
     components:
     - type: Transform
       pos: -3.3034647,-2.2374141
       parent: 2
-  - uid: 1060
+  - uid: 1094
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7807,13 +8023,13 @@ entities:
       parent: 2
 - proto: CandleGreenInfinite
   entities:
-  - uid: 1061
+  - uid: 1095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.966235,0.82983565
       parent: 2
-  - uid: 1062
+  - uid: 1096
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7821,29 +8037,29 @@ entities:
       parent: 2
 - proto: CandleInfinite
   entities:
-  - uid: 1063
+  - uid: 1097
     components:
     - type: Transform
       pos: -14.633198,-4.445827
       parent: 2
-  - uid: 1064
+  - uid: 1098
     components:
     - type: Transform
       pos: -14.461323,-4.633327
       parent: 2
-  - uid: 1065
+  - uid: 1099
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.268848,-5.301596
       parent: 2
-  - uid: 1066
+  - uid: 1100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.441708,6.814955
       parent: 2
-  - uid: 1067
+  - uid: 1101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7851,452 +8067,461 @@ entities:
       parent: 2
 - proto: CandleRedInfinite
   entities:
-  - uid: 1068
+  - uid: 1102
     components:
     - type: Transform
       pos: -18.593899,-4.461452
       parent: 2
-  - uid: 1069
+  - uid: 1103
     components:
     - type: Transform
       pos: -18.781399,-4.695827
       parent: 2
-  - uid: 1070
+  - uid: 1104
     components:
     - type: Transform
       pos: -3.2097147,-2.4405391
       parent: 2
-  - uid: 1071
+  - uid: 1105
     components:
     - type: Transform
       pos: -12.00559,0.7335477
       parent: 2
-  - uid: 1072
+  - uid: 1106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.271545,-20.207375
       parent: 2
-- proto: CardBoxBlack
+- proto: CapacitorStockPart
   entities:
-  - uid: 3576
+  - uid: 1108
     components:
     - type: Transform
-      parent: 3575
+      parent: 1107
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+      storage: 1107
+- proto: CardBoxBlack
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      parent: 3
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 3
 - proto: CargoMailTeleporter
   entities:
-  - uid: 2512
+  - uid: 1109
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 2
 - proto: Carpet
   entities:
-  - uid: 1073
+  - uid: 1110
     components:
     - type: Transform
-      pos: -7.5,1.5
-      parent: 2
-  - uid: 1074
-    components:
-    - type: Transform
-      pos: -8.5,1.5
-      parent: 2
-  - uid: 1075
-    components:
-    - type: Transform
-      pos: -9.5,1.5
-      parent: 2
-  - uid: 1076
-    components:
-    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -10.5,1.5
       parent: 2
-  - uid: 1078
+  - uid: 1111
     components:
     - type: Transform
-      pos: -11.5,1.5
+      rot: 3.141592653589793 rad
+      pos: -9.5,1.5
       parent: 2
-  - uid: 1081
+  - uid: 1112
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 1113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -10.5,2.5
       parent: 2
-  - uid: 1082
+  - uid: 1114
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -9.5,2.5
       parent: 2
-  - uid: 1083
+  - uid: 1115
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -8.5,2.5
       parent: 2
-  - uid: 1084
+  - uid: 1116
     components:
     - type: Transform
-      pos: -7.5,2.5
+      rot: 3.141592653589793 rad
+      pos: -11.5,1.5
       parent: 2
-  - uid: 2521
+  - uid: 1117
     components:
     - type: Transform
       pos: -17.5,-5.5
       parent: 2
-  - uid: 2781
+  - uid: 1118
     components:
     - type: Transform
       pos: -17.5,-4.5
       parent: 2
-  - uid: 3675
+  - uid: 1119
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -11.5,2.5
       parent: 2
-  - uid: 3747
+  - uid: 1120
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
-  - uid: 3748
+  - uid: 1121
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
 - proto: CarpetBlack
   entities:
-  - uid: 1085
+  - uid: 1122
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-  - uid: 1086
+  - uid: 1123
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-  - uid: 1087
+  - uid: 1124
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 2
-  - uid: 1088
+  - uid: 1125
     components:
     - type: Transform
       pos: -25.5,-1.5
       parent: 2
-  - uid: 1089
+  - uid: 1126
     components:
     - type: Transform
       pos: -26.5,-0.5
       parent: 2
-  - uid: 1090
+  - uid: 1127
     components:
     - type: Transform
       pos: -26.5,-1.5
       parent: 2
-  - uid: 1091
+  - uid: 1128
     components:
     - type: Transform
       pos: -46.5,-20.5
       parent: 2
-  - uid: 1092
+  - uid: 1129
     components:
     - type: Transform
       pos: -47.5,-20.5
       parent: 2
-  - uid: 1093
+  - uid: 1130
     components:
     - type: Transform
       pos: -48.5,-20.5
       parent: 2
-  - uid: 1094
+  - uid: 1131
     components:
     - type: Transform
       pos: -43.5,-20.5
       parent: 2
-  - uid: 1095
+  - uid: 1132
     components:
     - type: Transform
       pos: -42.5,-20.5
       parent: 2
-  - uid: 1096
+  - uid: 1133
     components:
     - type: Transform
       pos: -41.5,-20.5
       parent: 2
-  - uid: 1097
+  - uid: 1134
     components:
     - type: Transform
       pos: -44.5,-20.5
       parent: 2
-  - uid: 1098
+  - uid: 1135
     components:
     - type: Transform
       pos: -45.5,-20.5
       parent: 2
 - proto: CarpetWhite
   entities:
-  - uid: 3749
+  - uid: 1136
     components:
     - type: Transform
       pos: -14.5,-4.5
       parent: 2
-  - uid: 3750
+  - uid: 1137
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 2
-  - uid: 3751
+  - uid: 1138
     components:
     - type: Transform
       pos: -15.5,-5.5
       parent: 2
-  - uid: 3752
+  - uid: 1139
     components:
     - type: Transform
       pos: -15.5,-4.5
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 188
+  - uid: 1140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,2.5
       parent: 2
-  - uid: 1099
+  - uid: 1141
     components:
     - type: Transform
       pos: -49.5,7.5
       parent: 2
-  - uid: 1100
+  - uid: 1142
     components:
     - type: Transform
       pos: -45.5,7.5
       parent: 2
-  - uid: 1101
+  - uid: 1143
     components:
     - type: Transform
       pos: -46.5,7.5
       parent: 2
-  - uid: 1102
+  - uid: 1144
     components:
     - type: Transform
       pos: -47.5,7.5
       parent: 2
-  - uid: 1103
+  - uid: 1145
     components:
     - type: Transform
       pos: -48.5,7.5
       parent: 2
-  - uid: 1104
+  - uid: 1146
     components:
     - type: Transform
       pos: -50.5,7.5
       parent: 2
-  - uid: 1105
+  - uid: 1147
     components:
     - type: Transform
       pos: -50.5,8.5
       parent: 2
-  - uid: 1106
+  - uid: 1148
     components:
     - type: Transform
       pos: -50.5,9.5
       parent: 2
-  - uid: 1107
+  - uid: 1149
     components:
     - type: Transform
       pos: -50.5,10.5
       parent: 2
-  - uid: 1108
+  - uid: 1150
     components:
     - type: Transform
       pos: -50.5,11.5
       parent: 2
-  - uid: 1109
+  - uid: 1151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,10.5
       parent: 2
-  - uid: 1110
+  - uid: 1152
     components:
     - type: Transform
       pos: -28.5,-24.5
       parent: 2
-  - uid: 1111
+  - uid: 1153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,12.5
       parent: 2
-  - uid: 1112
+  - uid: 1154
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,13.5
       parent: 2
-  - uid: 1113
+  - uid: 1155
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,13.5
       parent: 2
-  - uid: 1114
+  - uid: 1156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,13.5
       parent: 2
-  - uid: 1115
+  - uid: 1157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.5,13.5
       parent: 2
-  - uid: 1116
+  - uid: 1158
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,13.5
       parent: 2
-  - uid: 1117
+  - uid: 1159
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,13.5
       parent: 2
-  - uid: 1118
+  - uid: 1160
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,14.5
       parent: 2
-  - uid: 1119
+  - uid: 1161
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,15.5
       parent: 2
-  - uid: 1120
+  - uid: 1162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,15.5
       parent: 2
-  - uid: 1121
+  - uid: 1163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,15.5
       parent: 2
-  - uid: 1122
+  - uid: 1164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,15.5
       parent: 2
-  - uid: 1123
+  - uid: 1165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,15.5
       parent: 2
-  - uid: 1124
+  - uid: 1166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,15.5
       parent: 2
-  - uid: 1125
+  - uid: 1167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,15.5
       parent: 2
-  - uid: 1126
+  - uid: 1168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,14.5
       parent: 2
-  - uid: 1127
+  - uid: 1169
     components:
     - type: Transform
       pos: -52.5,4.5
       parent: 2
-  - uid: 1128
+  - uid: 1170
     components:
     - type: Transform
       pos: -51.5,4.5
       parent: 2
-  - uid: 1129
+  - uid: 1171
     components:
     - type: Transform
       pos: -50.5,4.5
       parent: 2
-  - uid: 1130
+  - uid: 1172
     components:
     - type: Transform
       pos: -50.5,3.5
       parent: 2
-  - uid: 1133
+  - uid: 1173
     components:
     - type: Transform
       pos: -49.5,1.5
       parent: 2
-  - uid: 1134
+  - uid: 1174
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
-  - uid: 1135
+  - uid: 1175
     components:
     - type: Transform
       pos: -47.5,1.5
       parent: 2
-  - uid: 1136
+  - uid: 1176
     components:
     - type: Transform
       pos: -46.5,1.5
       parent: 2
-  - uid: 1137
+  - uid: 1177
     components:
     - type: Transform
       pos: -46.5,0.5
       parent: 2
-  - uid: 1139
+  - uid: 1178
     components:
     - type: Transform
       pos: -46.5,-1.5
       parent: 2
-  - uid: 1140
+  - uid: 1179
     components:
     - type: Transform
       pos: -46.5,-2.5
       parent: 2
-  - uid: 1141
+  - uid: 1180
     components:
     - type: Transform
       pos: -27.5,-24.5
       parent: 2
-  - uid: 1142
+  - uid: 1181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,11.5
       parent: 2
-  - uid: 1143
+  - uid: 1182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 2
-  - uid: 1144
+  - uid: 1183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8304,58 +8529,58 @@ entities:
       parent: 2
 - proto: Chair
   entities:
-  - uid: 1145
+  - uid: 1184
     components:
     - type: Transform
       pos: -17.5,3.5
       parent: 2
-  - uid: 1146
+  - uid: 1185
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 1147
+  - uid: 1186
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
-  - uid: 1148
+  - uid: 1187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-3.5
       parent: 2
-  - uid: 1149
+  - uid: 1188
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-3.5
       parent: 2
-  - uid: 1151
+  - uid: 1189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,1.5
       parent: 2
-  - uid: 1152
+  - uid: 1190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,0.5
       parent: 2
-  - uid: 1153
+  - uid: 1191
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,1.5
       parent: 2
-  - uid: 1154
+  - uid: 1192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,0.5
       parent: 2
-  - uid: 3697
+  - uid: 1193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8363,7 +8588,13 @@ entities:
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 1155
+  - uid: 1194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -43.56247,-4.3052955
+      parent: 2
+  - uid: 1195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8371,13 +8602,13 @@ entities:
       parent: 2
     - type: Pullable
       prevFixedRotation: True
-  - uid: 1156
+  - uid: 1196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,9.5
       parent: 2
-  - uid: 1157
+  - uid: 1197
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8385,91 +8616,100 @@ entities:
       parent: 2
 - proto: ChairOfficeLight
   entities:
-  - uid: 1158
+  - uid: 1198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-7.5
       parent: 2
-  - uid: 1159
+  - uid: 1199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-16.5
       parent: 2
-  - uid: 1160
+  - uid: 1200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-17.5
       parent: 2
-  - uid: 1161
+  - uid: 1201
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,4.5
       parent: 2
-  - uid: 1162
-    components:
-    - type: Transform
-      rot: 4.71238898038469 rad
-      pos: -42.468933,-5.283333
-      parent: 2
-    - type: Pullable
-      prevFixedRotation: True
-  - uid: 1163
+  - uid: 1202
     components:
     - type: Transform
       pos: -36.5,-28.5
       parent: 2
-  - uid: 1164
+  - uid: 1203
     components:
     - type: Transform
       pos: -34.5,-28.5
       parent: 2
-  - uid: 1165
+  - uid: 1204
     components:
     - type: Transform
       pos: -32.5,-28.5
       parent: 2
+  - uid: 1205
+    components:
+    - type: Transform
+      pos: -39.411312,-28.55995
+      parent: 2
+  - uid: 1206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.4276378,2.8341408
+      parent: 2
+  - uid: 1207
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -40.346344,-4.2473607
+      parent: 2
 - proto: ChairWood
   entities:
-  - uid: 1166
+  - uid: 1208
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 1167
+  - uid: 1209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-5.5
       parent: 2
-  - uid: 1168
+  - uid: 1210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-4.5
       parent: 2
-  - uid: 1169
+  - uid: 1211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-5.5
       parent: 2
-  - uid: 1170
+  - uid: 1212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-4.5
       parent: 2
-  - uid: 1171
+  - uid: 1213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-6.5
       parent: 2
-  - uid: 1172
+  - uid: 1214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8477,47 +8717,47 @@ entities:
       parent: 2
 - proto: CheckerBoard
   entities:
-  - uid: 1173
+  - uid: 1215
     components:
     - type: Transform
       pos: -41.412315,0.6339854
       parent: 2
 - proto: ChemDispenser
   entities:
-  - uid: 1174
+  - uid: 1216
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
 - proto: ChemistryBottleUnstableMutagen
   entities:
-  - uid: 1175
+  - uid: 1217
     components:
     - type: Transform
       pos: -23.585087,2.4960952
       parent: 2
 - proto: ChemistryHotplate
   entities:
-  - uid: 1176
+  - uid: 1218
     components:
     - type: Transform
       pos: -24.5,4.5
       parent: 2
 - proto: ChemMaster
   entities:
-  - uid: 1177
+  - uid: 1219
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 2
-  - uid: 2472
+  - uid: 1220
     components:
     - type: Transform
       pos: -26.5,7.5
       parent: 2
 - proto: ChessBoard
   entities:
-  - uid: 1179
+  - uid: 1221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8525,14 +8765,14 @@ entities:
       parent: 2
 - proto: CircuitImprinter
   entities:
-  - uid: 1180
+  - uid: 1222
     components:
     - type: Transform
       pos: -39.5,-5.5
       parent: 2
 - proto: CleanerDispenser
   entities:
-  - uid: 1181
+  - uid: 1223
     components:
     - type: Transform
       pos: -41.5,-12.5
@@ -8541,95 +8781,114 @@ entities:
       fixtures: {}
 - proto: ClosetChefFilled
   entities:
-  - uid: 1182
+  - uid: 1617
     components:
     - type: Transform
-      pos: -15.5,8.5
+      pos: -14.5,-2.5
       parent: 2
 - proto: ClosetEmergencyFilledRandom
   entities:
-  - uid: 1183
-    components:
-    - type: Transform
-      pos: -40.5,-29.5
-      parent: 2
-  - uid: 1184
+  - uid: 1225
     components:
     - type: Transform
       pos: -40.5,-20.5
       parent: 2
-  - uid: 1185
+  - uid: 1226
     components:
     - type: Transform
       pos: -33.5,-3.5
       parent: 2
-  - uid: 1186
+  - uid: 1227
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 2
-  - uid: 1187
+  - uid: 1228
     components:
     - type: Transform
       pos: -39.5,-20.5
       parent: 2
 - proto: ClosetEmergencyN2FilledRandom
   entities:
-  - uid: 1188
-    components:
-    - type: Transform
-      pos: -39.5,-29.5
-      parent: 2
-  - uid: 1189
+  - uid: 1229
     components:
     - type: Transform
       pos: -31.5,-3.5
       parent: 2
-  - uid: 1190
+  - uid: 1230
     components:
     - type: Transform
       pos: -38.5,-20.5
       parent: 2
-- proto: ClosetFireFilled
+- proto: ClosetEmergencyN2FilledWinter
   entities:
-  - uid: 1191
+  - uid: 1236
     components:
     - type: Transform
-      pos: -38.5,-29.5
+      pos: -47.5,2.5
       parent: 2
-  - uid: 1192
+- proto: ClosetFireFilled
+  entities:
+  - uid: 1231
     components:
     - type: Transform
       pos: -27.5,-0.5
       parent: 2
 - proto: ClosetJanitorFilled
   entities:
-  - uid: 1193
+  - uid: 1232
     components:
     - type: Transform
       anchored: True
       pos: -39.5,-13.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: Physics
       bodyType: Static
 - proto: ClosetMaintenanceFilledRandom
   entities:
-  - uid: 1194
+  - uid: 1107
     components:
     - type: Transform
-      pos: -29.5,-6.5
+      pos: -26.5,-5.5
       parent: 2
-  - uid: 1195
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1108
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1233
     components:
     - type: Transform
-      pos: -29.5,-5.5
+      pos: -12.5,5.5
       parent: 2
-  - uid: 1196
+  - uid: 1234
     components:
     - type: Transform
       pos: -28.5,-23.5
       parent: 2
-  - uid: 1197
+  - uid: 1235
     components:
     - type: Transform
       pos: -46.5,2.5
@@ -8642,43 +8901,25 @@ entities:
         moles:
           Oxygen: 1.7459903
           Nitrogen: 6.568249
-  - uid: 1198
-    components:
-    - type: Transform
-      pos: -47.5,2.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-  - uid: 1199
-    components:
-    - type: Transform
-      pos: -49.5,2.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-  - uid: 1200
+  - uid: 1238
     components:
     - type: Transform
       pos: -40.5,16.5
       parent: 2
-  - uid: 1201
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+  - uid: 1239
     components:
     - type: Transform
       pos: -38.5,16.5
       parent: 2
-  - uid: 1202
+  - uid: 1240
     components:
     - type: Transform
       pos: 0.5,-8.5
@@ -8693,61 +8934,94 @@ entities:
           Nitrogen: 6.568249
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 1213
+  - uid: 1241
     components:
     - type: Transform
       pos: -46.5,8.5
       parent: 2
 - proto: ClosetSteelBase
   entities:
-  - uid: 1204
+  - uid: 1242
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 2
-  - uid: 1205
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+- proto: ClosetWallEmergencyFilledRandom
+  entities:
+  - uid: 1243
     components:
     - type: Transform
-      pos: -2.5,3.5
+      rot: 3.141592653589793 rad
+      pos: -38.5,-30.5
+      parent: 2
+- proto: ClosetWallEmergencyN2FilledRandom
+  entities:
+  - uid: 1244
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -40.5,-30.5
+      parent: 2
+- proto: ClosetWallFireFilledRandom
+  entities:
+  - uid: 1245
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -39.5,-30.5
+      parent: 2
+  - uid: 1246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -42.5,-10.5
       parent: 2
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 1206
+  - uid: 1247
     components:
     - type: Transform
       pos: -22.447153,-6.379816
       parent: 2
 - proto: ClothingEyesGlassesChemical
   entities:
-  - uid: 1207
+  - uid: 1248
     components:
     - type: Transform
       pos: -27.517773,5.746095
       parent: 2
 - proto: ClothingEyesHudBeer
   entities:
-  - uid: 1208
+  - uid: 1249
     components:
     - type: Transform
       pos: -11.81809,0.5772977
       parent: 2
 - proto: ClothingHandsGlovesNitrile
   entities:
-  - uid: 1209
+  - uid: 1250
     components:
     - type: Transform
       pos: -27.455273,5.48047
       parent: 2
 - proto: ClothingHeadFishAlt
   entities:
-  - uid: 3756
+  - uid: 1251
     components:
     - type: Transform
       pos: -42.517662,-29.083908
       parent: 2
 - proto: Cobweb1
   entities:
-  - uid: 1210
+  - uid: 1252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8755,7 +9029,7 @@ entities:
       parent: 2
 - proto: ComputerAlert
   entities:
-  - uid: 1233
+  - uid: 1253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8763,7 +9037,7 @@ entities:
       parent: 2
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 1211
+  - uid: 1254
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8771,7 +9045,7 @@ entities:
       parent: 2
 - proto: ComputerAtmosMonitoring
   entities:
-  - uid: 1212
+  - uid: 1255
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8779,26 +9053,21 @@ entities:
       parent: 2
 - proto: ComputerCargoBounty
   entities:
-  - uid: 1218
-    components:
-    - type: Transform
-      pos: -17.5,-7.5
-      parent: 2
-  - uid: 1219
+  - uid: 1256
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
 - proto: ComputerCargoOrders
   entities:
-  - uid: 1220
+  - uid: 1257
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 2
 - proto: ComputerComms
   entities:
-  - uid: 1221
+  - uid: 1258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8806,13 +9075,13 @@ entities:
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 1222
+  - uid: 1259
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,8.5
       parent: 2
-  - uid: 1223
+  - uid: 1260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8820,13 +9089,13 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 1224
+  - uid: 1261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-17.5
       parent: 2
-  - uid: 1225
+  - uid: 1262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8834,12 +9103,12 @@ entities:
       parent: 2
 - proto: ComputerId
   entities:
-  - uid: 1227
+  - uid: 1263
     components:
     - type: Transform
       pos: -33.5,-21.5
       parent: 2
-  - uid: 1228
+  - uid: 1264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8847,20 +9116,20 @@ entities:
       parent: 2
 - proto: ComputerMassMedia
   entities:
-  - uid: 1229
+  - uid: 1265
     components:
     - type: Transform
-      pos: -4.5,3.5
+      pos: -2.5,3.5
       parent: 2
 - proto: ComputerMedicalRecords
   entities:
-  - uid: 1230
+  - uid: 1266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,9.5
       parent: 2
-  - uid: 1231
+  - uid: 1267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8868,19 +9137,19 @@ entities:
       parent: 2
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 1203
+  - uid: 1268
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,0.5
       parent: 2
-  - uid: 1232
+  - uid: 1269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-29.5
       parent: 2
-  - uid: 2579
+  - uid: 1270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8888,13 +9157,13 @@ entities:
       parent: 2
 - proto: ComputerRadar
   entities:
-  - uid: 1234
+  - uid: 1271
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,-9.5
       parent: 2
-  - uid: 1235
+  - uid: 1272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8902,22 +9171,35 @@ entities:
       parent: 2
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 1236
+  - uid: 1273
     components:
     - type: Transform
-      pos: -42.5,-4.5
+      rot: -1.5707963267948966 rad
+      pos: -39.5,-4.5
       parent: 2
+    - type: TechnologyDatabase
+      supportedDisciplines:
+      - Industrial
+      - Arsenal
+      - Experimental
+      - CivilianServices
 - proto: ComputerRoboticsControl
   entities:
-  - uid: 1237
+  - uid: 1274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -41.5,-10.5
+      pos: -44.5,-4.5
+      parent: 2
+  - uid: 1275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -38.5,-29.5
       parent: 2
 - proto: ComputerSalvageExpedition
   entities:
-  - uid: 1238
+  - uid: 1276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8925,7 +9207,7 @@ entities:
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
-  - uid: 1240
+  - uid: 1277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8933,13 +9215,13 @@ entities:
       parent: 2
 - proto: ComputerStationRecords
   entities:
-  - uid: 1241
+  - uid: 1278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-24.5
       parent: 2
-  - uid: 1242
+  - uid: 1279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8947,7 +9229,7 @@ entities:
       parent: 2
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 1243
+  - uid: 1280
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8955,70 +9237,93 @@ entities:
       parent: 2
 - proto: ComputerTechnologyDiskTerminal
   entities:
-  - uid: 1244
+  - uid: 1281
     components:
     - type: Transform
-      pos: -44.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: -39.5,-6.5
       parent: 2
 - proto: ComputerTelevision
   entities:
-  - uid: 1245
+  - uid: 1282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-14.5
+      parent: 2
+  - uid: 1283
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
-  - uid: 1246
-    components:
-    - type: Transform
-      pos: -26.5,-14.5
-      parent: 2
 - proto: ConveyorBelt
   entities:
-  - uid: 1247
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-7.5
-      parent: 2
-  - uid: 1248
+  - uid: 1284
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-7.5
       parent: 2
-  - uid: 1249
+  - uid: 1285
     components:
     - type: Transform
       pos: -28.5,-8.5
       parent: 2
-  - uid: 1250
+  - uid: 1286
     components:
     - type: Transform
       pos: -28.5,-9.5
       parent: 2
-  - uid: 1251
+  - uid: 1287
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,-7.5
+      pos: -16.5,-7.5
       parent: 2
+- proto: CrabCube
+  entities:
+  - uid: 3740
+    components:
+    - type: Transform
+      parent: 3737
+    - type: Physics
+      canCollide: False
+  - uid: 3741
+    components:
+    - type: Transform
+      parent: 3737
+    - type: Physics
+      canCollide: False
+  - uid: 3742
+    components:
+    - type: Transform
+      parent: 3737
+    - type: Physics
+      canCollide: False
 - proto: CrateEngineeringMiniJetpack
   entities:
-  - uid: 1252
+  - uid: 1288
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-- proto: CrateFunLizardPlushieBulk
+- proto: CrateFunArtSupplies
   entities:
-  - uid: 1255
+  - uid: 1289
     components:
     - type: Transform
-      pos: -26.5,11.5
+      pos: -31.5,-12.5
+      parent: 2
+- proto: CrateFunLizardPlushieBulk
+  entities:
+  - uid: 2803
+    components:
+    - type: Transform
+      pos: -48.5,2.5
       parent: 2
 - proto: CrateGenericSteel
   entities:
-  - uid: 1256
+  - uid: 1291
     components:
     - type: MetaData
       desc: A robust supply of basic materials.
@@ -9040,37 +9345,77 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1257
-          - 1258
-          - 1259
+          - 1292
+          - 1293
+          - 1294
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1295
+    components:
+    - type: MetaData
+      name: craft supplies crate
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1301
+          - 1297
+          - 1298
+          - 1296
+          - 1300
+          - 1299
+          - 1302
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CrateMedicalSurgery
   entities:
-  - uid: 1260
+  - uid: 1303
     components:
     - type: Transform
       pos: -36.5,8.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: CrateTrashCart
   entities:
-  - uid: 1265
+  - uid: 1304
     components:
     - type: Transform
       pos: -28.5,-10.5
       parent: 2
 - proto: CrayonBox
   entities:
-  - uid: 1266
+  - uid: 1305
     components:
     - type: Transform
       pos: -49.539207,-16.249985
       parent: 2
 - proto: Crematorium
   entities:
-  - uid: 1267
+  - uid: 1306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9078,21 +9423,21 @@ entities:
       parent: 2
 - proto: CrewMonitoringServer
   entities:
-  - uid: 1268
+  - uid: 1307
     components:
     - type: Transform
       pos: -42.5,-25.5
       parent: 2
 - proto: CryogenicSleepUnitPrisoner
   entities:
-  - uid: 177
+  - uid: 1308
     components:
     - type: Transform
       pos: -28.5,-14.5
       parent: 2
 - proto: CryogenicSleepUnitSpawnerLateJoin
   entities:
-  - uid: 1269
+  - uid: 1309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9100,47 +9445,40 @@ entities:
       parent: 2
 - proto: CryoPod
   entities:
-  - uid: 1270
+  - uid: 1310
     components:
     - type: Transform
       pos: -31.5,11.5
       parent: 2
 - proto: CryoxadoneBeakerSmall
   entities:
-  - uid: 1271
+  - uid: 1311
     components:
     - type: Transform
       pos: -28.751982,11.497647
       parent: 2
-- proto: CurtainsCyanOpen
-  entities:
-  - uid: 1273
-    components:
-    - type: Transform
-      pos: -34.5,-5.5
-      parent: 2
-  - uid: 1274
-    components:
-    - type: Transform
-      pos: -34.5,-6.5
-      parent: 2
 - proto: CurtainsGreen
   entities:
-  - uid: 1275
+  - uid: 1314
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 2
 - proto: CurtainsGreenOpen
   entities:
-  - uid: 1276
+  - uid: 1315
     components:
     - type: Transform
       pos: -46.5,-14.5
       parent: 2
+  - uid: 1316
+    components:
+    - type: Transform
+      pos: -46.5,-13.5
+      parent: 2
 - proto: CurtainsRedOpenDirectional
   entities:
-  - uid: 1272
+  - uid: 1317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9148,614 +9486,225 @@ entities:
       parent: 2
 - proto: CutterMachine
   entities:
-  - uid: 1277
+  - uid: 1318
     components:
     - type: Transform
-      pos: -12.5,-6.5
+      pos: -3.5,3.5
       parent: 2
 - proto: d6Dice
   entities:
-  - uid: 1278
+  - uid: 1319
     components:
     - type: Transform
       pos: -3.4299238,-2.4249141
       parent: 2
 - proto: DecalSpawnerBurns
   entities:
-  - uid: 1279
-    components:
-    - type: Transform
-      pos: -44.5,16.5
-      parent: 2
-  - uid: 1280
-    components:
-    - type: Transform
-      pos: -41.5,14.5
-      parent: 2
-  - uid: 1281
-    components:
-    - type: Transform
-      pos: -44.5,16.5
-      parent: 2
-  - uid: 1282
-    components:
-    - type: Transform
-      pos: -41.5,14.5
-      parent: 2
-- proto: DecalSpawnerDirtNear
-  entities:
-  - uid: 1283
-    components:
-    - type: Transform
-      pos: -24.5,-2.5
-      parent: 2
-  - uid: 1284
-    components:
-    - type: Transform
-      pos: -34.5,-1.5
-      parent: 2
-  - uid: 1285
-    components:
-    - type: Transform
-      pos: -36.5,-19.5
-      parent: 2
-  - uid: 1286
-    components:
-    - type: Transform
-      pos: -48.5,-18.5
-      parent: 2
-  - uid: 1287
-    components:
-    - type: Transform
-      pos: -38.5,-28.5
-      parent: 2
-  - uid: 1288
-    components:
-    - type: Transform
-      pos: -33.5,-28.5
-      parent: 2
-  - uid: 1289
-    components:
-    - type: Transform
-      pos: -42.5,2.5
-      parent: 2
-  - uid: 1290
-    components:
-    - type: Transform
-      pos: -43.5,6.5
-      parent: 2
-  - uid: 1291
-    components:
-    - type: Transform
-      pos: -42.5,10.5
-      parent: 2
-  - uid: 1292
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 2
-  - uid: 1293
-    components:
-    - type: Transform
-      pos: -31.5,-17.5
-      parent: 2
-- proto: DecalSpawnerDirtSingle
-  entities:
-  - uid: 1294
-    components:
-    - type: Transform
-      pos: -35.5,-6.5
-      parent: 2
-  - uid: 1295
-    components:
-    - type: Transform
-      pos: -36.5,-8.5
-      parent: 2
-  - uid: 1296
-    components:
-    - type: Transform
-      pos: -36.5,-10.5
-      parent: 2
-  - uid: 1297
-    components:
-    - type: Transform
-      pos: -35.5,-11.5
-      parent: 2
-  - uid: 1298
-    components:
-    - type: Transform
-      pos: -37.5,-7.5
-      parent: 2
-  - uid: 1299
-    components:
-    - type: Transform
-      pos: -37.5,-5.5
-      parent: 2
-  - uid: 1300
-    components:
-    - type: Transform
-      pos: -37.5,-14.5
-      parent: 2
-  - uid: 1301
-    components:
-    - type: Transform
-      pos: -29.5,-2.5
-      parent: 2
-  - uid: 1302
-    components:
-    - type: Transform
-      pos: -28.5,-3.5
-      parent: 2
-  - uid: 1303
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
-      parent: 2
-  - uid: 1304
-    components:
-    - type: Transform
-      pos: -11.5,-5.5
-      parent: 2
-  - uid: 1305
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 2
-  - uid: 1306
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 2
-  - uid: 1307
-    components:
-    - type: Transform
-      pos: -15.5,-1.5
-      parent: 2
-  - uid: 1308
-    components:
-    - type: Transform
-      pos: -20.5,-1.5
-      parent: 2
-- proto: DecalSpawnerDirtWide
-  entities:
-  - uid: 1309
-    components:
-    - type: Transform
-      pos: -41.5,-5.5
-      parent: 2
-  - uid: 1310
-    components:
-    - type: Transform
-      pos: -42.5,-7.5
-      parent: 2
-  - uid: 1311
-    components:
-    - type: Transform
-      pos: -42.5,-7.5
-      parent: 2
-  - uid: 1312
-    components:
-    - type: Transform
-      pos: -40.5,-9.5
-      parent: 2
-  - uid: 1313
-    components:
-    - type: Transform
-      pos: -40.5,-9.5
-      parent: 2
-  - uid: 1314
-    components:
-    - type: Transform
-      pos: -43.5,9.5
-      parent: 2
-  - uid: 1315
-    components:
-    - type: Transform
-      pos: -43.5,3.5
-      parent: 2
-  - uid: 1316
-    components:
-    - type: Transform
-      pos: -43.5,3.5
-      parent: 2
-  - uid: 1317
-    components:
-    - type: Transform
-      pos: -37.5,2.5
-      parent: 2
-  - uid: 1318
-    components:
-    - type: Transform
-      pos: -37.5,2.5
-      parent: 2
-  - uid: 1319
-    components:
-    - type: Transform
-      pos: -34.5,5.5
-      parent: 2
   - uid: 1320
     components:
     - type: Transform
-      pos: -31.5,10.5
+      pos: -44.5,16.5
       parent: 2
   - uid: 1321
     components:
     - type: Transform
-      pos: -31.5,10.5
+      pos: -41.5,14.5
       parent: 2
   - uid: 1322
     components:
     - type: Transform
-      pos: -29.5,2.5
+      pos: -44.5,16.5
       parent: 2
   - uid: 1323
     components:
     - type: Transform
-      pos: -29.5,2.5
-      parent: 2
-  - uid: 1324
-    components:
-    - type: Transform
-      pos: -30.5,5.5
-      parent: 2
-  - uid: 1325
-    components:
-    - type: Transform
-      pos: -30.5,5.5
-      parent: 2
-  - uid: 1326
-    components:
-    - type: Transform
-      pos: -26.5,5.5
-      parent: 2
-  - uid: 1327
-    components:
-    - type: Transform
-      pos: -26.5,3.5
-      parent: 2
-  - uid: 1328
-    components:
-    - type: Transform
-      pos: -21.5,6.5
-      parent: 2
-  - uid: 1329
-    components:
-    - type: Transform
-      pos: -21.5,4.5
-      parent: 2
-  - uid: 1330
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 2
-  - uid: 1331
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 2
-  - uid: 1332
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 2
-  - uid: 1333
-    components:
-    - type: Transform
-      pos: -8.5,-2.5
-      parent: 2
-  - uid: 1334
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
-      parent: 2
-  - uid: 1335
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
-      parent: 2
-  - uid: 1336
-    components:
-    - type: Transform
-      pos: -15.5,-1.5
-      parent: 2
-  - uid: 1337
-    components:
-    - type: Transform
-      pos: -15.5,-1.5
-      parent: 2
-  - uid: 1338
-    components:
-    - type: Transform
-      pos: -35.5,-0.5
-      parent: 2
-  - uid: 1339
-    components:
-    - type: Transform
-      pos: -36.5,-1.5
-      parent: 2
-  - uid: 1340
-    components:
-    - type: Transform
-      pos: -36.5,-1.5
-      parent: 2
-  - uid: 1341
-    components:
-    - type: Transform
-      pos: -42.5,-18.5
-      parent: 2
-  - uid: 1342
-    components:
-    - type: Transform
-      pos: -48.5,-18.5
-      parent: 2
-  - uid: 1343
-    components:
-    - type: Transform
-      pos: -48.5,-18.5
-      parent: 2
-  - uid: 1344
-    components:
-    - type: Transform
-      pos: -36.5,-19.5
-      parent: 2
-  - uid: 1345
-    components:
-    - type: Transform
-      pos: -36.5,-19.5
-      parent: 2
-  - uid: 1346
-    components:
-    - type: Transform
-      pos: -40.5,-23.5
-      parent: 2
-  - uid: 1347
-    components:
-    - type: Transform
-      pos: -39.5,-27.5
-      parent: 2
-  - uid: 1348
-    components:
-    - type: Transform
-      pos: -42.5,-6.5
-      parent: 2
-  - uid: 3590
-    components:
-    - type: Transform
-      pos: -36.5,-13.5
-      parent: 2
-  - uid: 3674
-    components:
-    - type: Transform
-      pos: -36.5,-9.5
-      parent: 2
-  - uid: 3676
-    components:
-    - type: Transform
-      pos: -36.5,-13.5
-      parent: 2
-  - uid: 3677
-    components:
-    - type: Transform
-      pos: -36.5,-9.5
-      parent: 2
-  - uid: 3678
-    components:
-    - type: Transform
-      pos: -36.5,-10.5
-      parent: 2
-  - uid: 3679
-    components:
-    - type: Transform
-      pos: -44.5,-18.5
-      parent: 2
-  - uid: 3680
-    components:
-    - type: Transform
-      pos: -44.5,-18.5
-      parent: 2
-  - uid: 3681
-    components:
-    - type: Transform
-      pos: -28.5,-6.5
-      parent: 2
-  - uid: 3682
-    components:
-    - type: Transform
-      pos: -28.5,-6.5
-      parent: 2
-  - uid: 3683
-    components:
-    - type: Transform
-      pos: -28.5,-6.5
+      pos: -41.5,14.5
       parent: 2
 - proto: DefaultStationBeacon
   entities:
-  - uid: 1349
-    components:
-    - type: Transform
-      pos: -32.5,-5.5
-      parent: 2
-  - uid: 1350
-    components:
-    - type: Transform
-      pos: -23.5,-8.5
-      parent: 2
-  - uid: 1351
+  - uid: 1324
     components:
     - type: Transform
       pos: -44.5,-14.5
       parent: 2
 - proto: DefaultStationBeaconAnchor
   entities:
-  - uid: 1352
+  - uid: 1325
     components:
     - type: Transform
       pos: -35.5,14.5
       parent: 2
 - proto: DefaultStationBeaconArrivals
   entities:
-  - uid: 1353
+  - uid: 1326
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 2
 - proto: DefaultStationBeaconAtmospherics
   entities:
-  - uid: 1354
+  - uid: 1327
     components:
     - type: Transform
       pos: -43.5,15.5
       parent: 2
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 1355
+  - uid: 1328
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
 - proto: DefaultStationBeaconBotany
   entities:
-  - uid: 1356
+  - uid: 1329
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
 - proto: DefaultStationBeaconBridge
   entities:
-  - uid: 1357
+  - uid: 1330
     components:
     - type: Transform
       pos: -35.5,-27.5
       parent: 2
 - proto: DefaultStationBeaconBrig
   entities:
-  - uid: 1358
+  - uid: 1331
     components:
     - type: Transform
       pos: -30.5,-13.5
       parent: 2
 - proto: DefaultStationBeaconCaptainsQuarters
   entities:
-  - uid: 1359
+  - uid: 1332
     components:
     - type: Transform
       pos: -42.5,-28.5
       parent: 2
 - proto: DefaultStationBeaconCargoBay
   entities:
-  - uid: 1360
+  - uid: 1333
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 2
 - proto: DefaultStationBeaconChapel
   entities:
-  - uid: 1361
+  - uid: 1334
     components:
     - type: Transform
       pos: -32.5,-9.5
       parent: 2
 - proto: DefaultStationBeaconChemistry
   entities:
-  - uid: 1362
+  - uid: 1335
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
 - proto: DefaultStationBeaconDisposals
   entities:
-  - uid: 1363
+  - uid: 1336
     components:
     - type: Transform
       pos: -28.5,-7.5
       parent: 2
 - proto: DefaultStationBeaconEngineering
   entities:
-  - uid: 1364
+  - uid: 1337
     components:
     - type: Transform
       pos: -42.5,4.5
       parent: 2
 - proto: DefaultStationBeaconEvac
   entities:
-  - uid: 1365
+  - uid: 1338
     components:
     - type: Transform
       pos: -48.5,-18.5
       parent: 2
 - proto: DefaultStationBeaconEVAStorage
   entities:
-  - uid: 1366
+  - uid: 1339
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
 - proto: DefaultStationBeaconGravGen
   entities:
-  - uid: 1367
+  - uid: 1340
     components:
     - type: Transform
       pos: -47.5,9.5
       parent: 2
 - proto: DefaultStationBeaconHOPOffice
   entities:
-  - uid: 1368
+  - uid: 1341
     components:
     - type: Transform
       pos: -31.5,-23.5
       parent: 2
 - proto: DefaultStationBeaconKitchen
   entities:
-  - uid: 1369
+  - uid: 1342
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 2
+- proto: DefaultStationBeaconLibrary
+  entities:
+  - uid: 1343
+    components:
+    - type: Transform
+      pos: -32.5,-5.5
+      parent: 2
 - proto: DefaultStationBeaconMedical
   entities:
-  - uid: 1370
+  - uid: 1344
     components:
     - type: Transform
       pos: -30.5,7.5
       parent: 2
 - proto: DefaultStationBeaconMorgue
   entities:
-  - uid: 1371
+  - uid: 1345
     components:
     - type: Transform
       pos: -35.5,5.5
       parent: 2
 - proto: DefaultStationBeaconSalvage
   entities:
-  - uid: 1372
+  - uid: 1346
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 2
 - proto: DefaultStationBeaconSecurity
   entities:
-  - uid: 1373
+  - uid: 1347
     components:
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
 - proto: DefaultStationBeaconSurgery
   entities:
-  - uid: 1374
+  - uid: 1348
     components:
     - type: Transform
       pos: -34.5,9.5
       parent: 2
 - proto: DefaultStationBeaconTelecoms
   entities:
-  - uid: 1375
+  - uid: 1349
     components:
     - type: Transform
       pos: -42.5,-23.5
       parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1376
+  - uid: 1350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9765,95 +9714,106 @@ entities:
       fixtures: {}
 - proto: DeskBell
   entities:
-  - uid: 1378
+  - uid: 1351
+    components:
+    - type: Transform
+      pos: -34.615498,-22.305218
+      parent: 2
+  - uid: 1352
+    components:
+    - type: Transform
+      pos: -8.713566,-6.3592463
+      parent: 2
+  - uid: 1353
     components:
     - type: Transform
       pos: -8.756487,0.62805533
       parent: 2
 - proto: DiceBag
   entities:
-  - uid: 1379
+  - uid: 1354
     components:
     - type: Transform
-      pos: -41.67388,1.646246
+      rot: 12.566370614359172 rad
+      pos: -41.774265,1.4261494
       parent: 2
 - proto: DisposalBend
   entities:
-  - uid: 1380
+  - uid: 1355
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 1381
+  - uid: 1356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,-20.5
       parent: 2
-  - uid: 1382
+  - uid: 1357
     components:
     - type: Transform
       pos: -30.5,-27.5
       parent: 2
-  - uid: 1383
+  - uid: 1358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-27.5
       parent: 2
-  - uid: 1384
+  - uid: 1359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,-22.5
       parent: 2
-  - uid: 1385
+  - uid: 1360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,-22.5
       parent: 2
-  - uid: 1386
+  - uid: 1361
     components:
     - type: Transform
       pos: -33.5,-2.5
       parent: 2
-  - uid: 1387
+  - uid: 1362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-3.5
       parent: 2
-  - uid: 1388
+  - uid: 1363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-2.5
       parent: 2
-  - uid: 1389
+  - uid: 1364
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-2.5
       parent: 2
-  - uid: 1390
+  - uid: 1365
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 2
-  - uid: 1391
+  - uid: 1366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-3.5
       parent: 2
-  - uid: 1392
+  - uid: 1367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,-5.5
       parent: 2
-  - uid: 1393
+  - uid: 1368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9861,26 +9821,26 @@ entities:
       parent: 2
 - proto: DisposalJunction
   entities:
-  - uid: 1394
+  - uid: 1369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-2.5
       parent: 2
-  - uid: 1395
+  - uid: 1370
     components:
     - type: Transform
       pos: -27.5,-3.5
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1396
+  - uid: 1371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-20.5
       parent: 2
-  - uid: 1397
+  - uid: 1372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9888,440 +9848,440 @@ entities:
       parent: 2
 - proto: DisposalPipe
   entities:
-  - uid: 1398
+  - uid: 1373
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
-  - uid: 1399
+  - uid: 1374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 2
-  - uid: 1400
+  - uid: 1375
     components:
     - type: Transform
       pos: -41.5,-18.5
       parent: 2
-  - uid: 1401
+  - uid: 1376
     components:
     - type: Transform
       pos: -41.5,-19.5
       parent: 2
-  - uid: 1402
+  - uid: 1377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,-20.5
       parent: 2
-  - uid: 1403
+  - uid: 1378
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-20.5
       parent: 2
-  - uid: 1404
+  - uid: 1379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-20.5
       parent: 2
-  - uid: 1405
+  - uid: 1380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-19.5
       parent: 2
-  - uid: 1406
+  - uid: 1381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-18.5
       parent: 2
-  - uid: 1407
+  - uid: 1382
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-17.5
       parent: 2
-  - uid: 1408
+  - uid: 1383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-16.5
       parent: 2
-  - uid: 1409
+  - uid: 1384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-15.5
       parent: 2
-  - uid: 1410
+  - uid: 1385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-14.5
       parent: 2
-  - uid: 1411
+  - uid: 1386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-13.5
       parent: 2
-  - uid: 1412
+  - uid: 1387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-12.5
       parent: 2
-  - uid: 1413
+  - uid: 1388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-11.5
       parent: 2
-  - uid: 1414
+  - uid: 1389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-10.5
       parent: 2
-  - uid: 1415
+  - uid: 1390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-9.5
       parent: 2
-  - uid: 1416
+  - uid: 1391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-8.5
       parent: 2
-  - uid: 1417
+  - uid: 1392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-7.5
       parent: 2
-  - uid: 1418
+  - uid: 1393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-6.5
       parent: 2
-  - uid: 1419
+  - uid: 1394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-5.5
       parent: 2
-  - uid: 1420
+  - uid: 1395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-4.5
       parent: 2
-  - uid: 1421
+  - uid: 1396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-3.5
       parent: 2
-  - uid: 1422
+  - uid: 1397
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,-2.5
       parent: 2
-  - uid: 1423
+  - uid: 1398
     components:
     - type: Transform
       pos: -30.5,-28.5
       parent: 2
-  - uid: 1424
+  - uid: 1399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-27.5
       parent: 2
-  - uid: 1425
+  - uid: 1400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-27.5
       parent: 2
-  - uid: 1426
+  - uid: 1401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-27.5
       parent: 2
-  - uid: 1427
+  - uid: 1402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-27.5
       parent: 2
-  - uid: 1428
+  - uid: 1403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-27.5
       parent: 2
-  - uid: 1429
+  - uid: 1404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,-27.5
       parent: 2
-  - uid: 1430
+  - uid: 1405
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,-27.5
       parent: 2
-  - uid: 1431
+  - uid: 1406
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-27.5
       parent: 2
-  - uid: 1432
+  - uid: 1407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-27.5
       parent: 2
-  - uid: 1433
+  - uid: 1408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-26.5
       parent: 2
-  - uid: 1434
+  - uid: 1409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-25.5
       parent: 2
-  - uid: 1435
+  - uid: 1410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-24.5
       parent: 2
-  - uid: 1436
+  - uid: 1411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-23.5
       parent: 2
-  - uid: 1437
+  - uid: 1412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,-22.5
       parent: 2
-  - uid: 1438
+  - uid: 1413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,-22.5
       parent: 2
-  - uid: 1439
+  - uid: 1414
     components:
     - type: Transform
       pos: -37.5,-21.5
       parent: 2
-  - uid: 1440
+  - uid: 1415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,-2.5
       parent: 2
-  - uid: 1441
+  - uid: 1416
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-3.5
       parent: 2
-  - uid: 1442
+  - uid: 1417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-3.5
       parent: 2
-  - uid: 1443
+  - uid: 1418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-3.5
       parent: 2
-  - uid: 1444
+  - uid: 1419
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-3.5
       parent: 2
-  - uid: 1445
+  - uid: 1420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-3.5
       parent: 2
-  - uid: 1446
+  - uid: 1421
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,-3.5
       parent: 2
-  - uid: 1447
+  - uid: 1422
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,-3.5
       parent: 2
-  - uid: 1448
+  - uid: 1423
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,-3.5
       parent: 2
-  - uid: 1449
+  - uid: 1424
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,-3.5
       parent: 2
-  - uid: 1450
+  - uid: 1425
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-3.5
       parent: 2
-  - uid: 1451
+  - uid: 1426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-3.5
       parent: 2
-  - uid: 1452
+  - uid: 1427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-3.5
       parent: 2
-  - uid: 1453
+  - uid: 1428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-3.5
       parent: 2
-  - uid: 1454
+  - uid: 1429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-3.5
       parent: 2
-  - uid: 1455
+  - uid: 1430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-3.5
       parent: 2
-  - uid: 1456
+  - uid: 1431
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-3.5
       parent: 2
-  - uid: 1457
+  - uid: 1432
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-3.5
       parent: 2
-  - uid: 1458
+  - uid: 1433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 2
-  - uid: 1459
+  - uid: 1434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-3.5
       parent: 2
-  - uid: 1460
+  - uid: 1435
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-3.5
       parent: 2
-  - uid: 1461
+  - uid: 1436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-3.5
       parent: 2
-  - uid: 1462
+  - uid: 1437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 2
-  - uid: 1463
+  - uid: 1438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
-  - uid: 1464
+  - uid: 1439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,-4.5
       parent: 2
-  - uid: 1465
+  - uid: 1440
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
 - proto: DisposalTrunk
   entities:
-  - uid: 1466
+  - uid: 1441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-5.5
       parent: 2
-  - uid: 1467
+  - uid: 1442
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-29.5
       parent: 2
-  - uid: 1468
+  - uid: 1443
     components:
     - type: Transform
       pos: -41.5,-17.5
       parent: 2
-  - uid: 1469
+  - uid: 1444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-3.5
       parent: 2
-  - uid: 1470
+  - uid: 1445
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-4.5
       parent: 2
-  - uid: 1471
+  - uid: 1446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10329,276 +10289,316 @@ entities:
       parent: 2
 - proto: DisposalUnit
   entities:
-  - uid: 1472
+  - uid: 1447
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 1473
+  - uid: 1448
     components:
     - type: Transform
       pos: -25.5,1.5
       parent: 2
-  - uid: 1474
+  - uid: 1449
     components:
     - type: Transform
       pos: -41.5,-17.5
       parent: 2
-  - uid: 1475
+  - uid: 1450
     components:
     - type: Transform
       pos: -34.5,-3.5
       parent: 2
-  - uid: 1476
+  - uid: 1451
     components:
     - type: Transform
       pos: -30.5,-29.5
       parent: 2
-  - uid: 1477
+  - uid: 1452
     components:
     - type: Transform
       pos: -22.5,-4.5
       parent: 2
 - proto: DogBed
   entities:
-  - uid: 1131
+  - uid: 1453
     components:
     - type: Transform
       pos: -24.5,5.5
       parent: 2
-  - uid: 1261
+  - uid: 1454
     components:
+    - type: MetaData
+      desc: A comfy-looking fox bed. You can even strap your pet in, in case the gravity turns off.
+      name: fox bed
     - type: Transform
       pos: -43.5,-29.5
       parent: 2
-  - uid: 1478
+  - uid: 1455
     components:
+    - type: MetaData
+      desc: A comfy-looking spider bed. You can even strap your pet in, in case the gravity turns off.
+      name: spider bed
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
-  - uid: 1479
+  - uid: 1456
     components:
+    - type: MetaData
+      desc: A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.
+      name: Frank bed
     - type: Transform
       pos: -47.5,4.5
       parent: 2
-  - uid: 1480
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 2
-  - uid: 1482
+  - uid: 1457
     components:
     - type: Transform
       pos: -31.5,-24.5
       parent: 2
+  - uid: 1458
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
 - proto: DresserCaptainFilledSyndie
   entities:
-  - uid: 1377
+  - uid: 1459
     components:
     - type: Transform
       pos: -42.5,-29.5
       parent: 2
 - proto: DrinkBeerCan
   entities:
-  - uid: 1484
+  - uid: 1460
     components:
     - type: Transform
       pos: -41.257214,1.6840987
       parent: 2
+- proto: DrinkHoneyJarFull
+  entities:
+  - uid: 1510
+    components:
+    - type: Transform
+      pos: -12.519238,3.650896
+      parent: 2
+- proto: DrinkHotCocoImitation
+  entities:
+  - uid: 2550
+    components:
+    - type: Transform
+      pos: -42.710636,-25.26153
+      parent: 2
 - proto: DrinkHotCoffee
   entities:
-  - uid: 1485
+  - uid: 1461
     components:
     - type: Transform
       pos: -45.240295,-20.25425
       parent: 2
-  - uid: 1486
+  - uid: 1462
     components:
     - type: Transform
       pos: -45.50592,-20.50425
       parent: 2
 - proto: DrinkLemonadeGlass
   entities:
-  - uid: 1487
+  - uid: 1463
     components:
     - type: Transform
       pos: -9.256038,0.69865453
       parent: 2
+- proto: DrinkMilkCarton
+  entities:
+  - uid: 3738
+    components:
+    - type: Transform
+      parent: 3737
+    - type: Physics
+      canCollide: False
+- proto: DrinkSoyMilkCarton
+  entities:
+  - uid: 3739
+    components:
+    - type: Transform
+      parent: 3737
+    - type: Physics
+      canCollide: False
 - proto: DrinkStarkistCan
   entities:
-  - uid: 1488
+  - uid: 1464
     components:
     - type: Transform
       pos: -35.993813,-25.228668
       parent: 2
 - proto: EmergencyLight
   entities:
-  - uid: 1489
+  - uid: 1465
     components:
     - type: Transform
       pos: -44.5,-13.5
       parent: 2
-  - uid: 1492
+  - uid: 1466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-4.5
       parent: 2
-  - uid: 1493
+  - uid: 1467
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-3.5
       parent: 2
-  - uid: 1494
+  - uid: 1468
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-3.5
       parent: 2
-  - uid: 1495
+  - uid: 1469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-5.5
       parent: 2
-  - uid: 1496
+  - uid: 1470
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
-  - uid: 1497
+  - uid: 1471
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 2
-  - uid: 1498
+  - uid: 1472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,6.5
       parent: 2
-  - uid: 1499
+  - uid: 1473
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
-  - uid: 1500
+  - uid: 1474
     components:
     - type: Transform
       pos: -34.5,11.5
       parent: 2
-  - uid: 1501
+  - uid: 1475
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 2
-  - uid: 1502
+  - uid: 1476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,9.5
       parent: 2
-  - uid: 1503
+  - uid: 1477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,3.5
       parent: 2
-  - uid: 1504
+  - uid: 1478
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 2
-  - uid: 1505
+  - uid: 1479
     components:
     - type: Transform
       pos: -40.5,-13.5
       parent: 2
-  - uid: 1506
+  - uid: 1480
     components:
     - type: Transform
       pos: -46.5,-17.5
       parent: 2
-  - uid: 1507
+  - uid: 1481
     components:
     - type: Transform
       pos: -39.5,-17.5
       parent: 2
-  - uid: 1508
+  - uid: 1482
     components:
     - type: Transform
       pos: -38.5,-26.5
       parent: 2
-  - uid: 1509
+  - uid: 1483
     components:
     - type: Transform
       pos: -30.5,-26.5
       parent: 2
-  - uid: 1510
+  - uid: 1484
     components:
     - type: Transform
       pos: -32.5,-21.5
       parent: 2
-  - uid: 1511
-    components:
-    - type: Transform
-      pos: -42.5,-22.5
-      parent: 2
-  - uid: 1512
+  - uid: 1485
     components:
     - type: Transform
       pos: -42.5,-27.5
       parent: 2
-  - uid: 1513
+  - uid: 1486
     components:
     - type: Transform
       pos: -31.5,-8.5
       parent: 2
-  - uid: 1514
+  - uid: 1487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-11.5
       parent: 2
-  - uid: 1515
+  - uid: 1488
     components:
     - type: Transform
       pos: -15.5,-7.5
       parent: 2
-  - uid: 1516
+  - uid: 1489
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 2
-  - uid: 1517
+  - uid: 1490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 2
-  - uid: 3695
+  - uid: 1491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-11.5
       parent: 2
-  - uid: 3696
+  - uid: 1492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-21.5
       parent: 2
-- proto: ExosuitFabricator
-  entities:
-  - uid: 1518
+  - uid: 1493
     components:
     - type: Transform
-      pos: -39.5,-6.5
+      rot: 1.5707963267948966 rad
+      pos: -43.5,-23.5
+      parent: 2
+- proto: ExosuitFabricator
+  entities:
+  - uid: 1494
+    components:
+    - type: Transform
+      pos: -44.5,-2.5
       parent: 2
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 3719
+  - uid: 1495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10608,40 +10608,44 @@ entities:
       fixtures: {}
 - proto: FaxMachineBase
   entities:
-  - uid: 1519
+  - uid: 1496
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 2
-  - uid: 1520
+    - type: FaxMachine
+      name: Logistics
+  - uid: 1497
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
+    - type: FaxMachine
+      name: Banana Main
 - proto: FaxMachineCaptain
   entities:
-  - uid: 1521
+  - uid: 1498
     components:
     - type: Transform
       pos: -35.5,-25.5
       parent: 2
 - proto: FaxMachineFlatpack
   entities:
-  - uid: 1522
+  - uid: 1499
     components:
     - type: Transform
       pos: -26.628168,-12.600563
       parent: 2
 - proto: filingCabinetRandom
   entities:
-  - uid: 1264
+  - uid: 1500
     components:
     - type: Transform
       pos: -33.5,-26.5
       parent: 2
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 1523
+  - uid: 1501
     components:
     - type: Transform
       pos: -37.5,3.5
@@ -10650,17 +10654,17 @@ entities:
       fixtures: {}
 - proto: FireExtinguisher
   entities:
-  - uid: 1524
+  - uid: 1502
     components:
     - type: Transform
-      pos: -16.352192,-7.2561145
+      pos: -15.327406,-10.302918
       parent: 2
     - type: CollisionWake
       enabled: False
     - type: Conveyed
 - proto: FirelockEdge
   entities:
-  - uid: 1525
+  - uid: 1503
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10668,9 +10672,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 21
-  - uid: 1526
+      - 27
+      - 28
+  - uid: 1504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10678,8 +10682,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 1527
+      - 22
+  - uid: 1505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10687,8 +10691,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 1528
+      - 22
+  - uid: 1506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10696,8 +10700,8 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 1529
+      - 22
+  - uid: 1507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10705,850 +10709,848 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 1530
+      - 22
+  - uid: 1508
     components:
     - type: Transform
       pos: -17.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 37
-  - uid: 1531
+      - 14
+      - 43
+  - uid: 1509
     components:
     - type: Transform
       pos: -15.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 37
+      - 14
+      - 43
 - proto: FirelockGlass
   entities:
-  - uid: 1532
-    components:
-    - type: Transform
-      pos: -16.5,6.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 36
-      - 22
-  - uid: 1533
+  - uid: 1511
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 7
-  - uid: 1534
+      - 11
+      - 14
+  - uid: 1512
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 7
-  - uid: 1535
+      - 11
+      - 14
+  - uid: 1513
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 7
-  - uid: 1536
+      - 11
+      - 14
+  - uid: 1514
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 7
-  - uid: 1537
+      - 11
+      - 14
+  - uid: 1515
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 7
-  - uid: 1538
+      - 11
+      - 14
+  - uid: 1516
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 7
-  - uid: 1539
+      - 11
+      - 14
+  - uid: 1517
     components:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-  - uid: 1540
+      - 14
+  - uid: 1518
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-  - uid: 1541
+      - 14
+  - uid: 1519
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-  - uid: 1542
+      - 14
+  - uid: 1520
     components:
     - type: Transform
       pos: -30.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 9
-  - uid: 1543
+      - 15
+      - 16
+  - uid: 1521
     components:
     - type: Transform
       pos: -30.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 9
-  - uid: 1544
+      - 15
+      - 16
+  - uid: 1522
     components:
     - type: Transform
       pos: -30.5,-2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 9
-  - uid: 1545
+      - 15
+      - 16
+  - uid: 1523
     components:
     - type: Transform
       pos: -30.5,-3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 9
-  - uid: 1546
+      - 15
+      - 16
+  - uid: 1524
     components:
     - type: Transform
       pos: -35.5,-4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 10
-  - uid: 1547
+      - 16
+      - 17
+  - uid: 1525
     components:
     - type: Transform
       pos: -36.5,-4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 10
-  - uid: 1548
+      - 16
+      - 17
+  - uid: 1526
     components:
     - type: Transform
       pos: -37.5,-4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-      - 10
-  - uid: 1549
+      - 16
+      - 17
+  - uid: 1527
     components:
     - type: Transform
       pos: -35.5,-15.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 10
-  - uid: 1550
+      - 18
+      - 17
+  - uid: 1528
     components:
     - type: Transform
       pos: -36.5,-15.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 10
-  - uid: 1551
+      - 18
+      - 17
+  - uid: 1529
     components:
     - type: Transform
       pos: -37.5,-15.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
-      - 10
-  - uid: 1552
+      - 18
+      - 17
+  - uid: 1530
     components:
     - type: Transform
       pos: -43.5,-17.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 11
-  - uid: 1553
+      - 19
+      - 18
+  - uid: 1531
     components:
     - type: Transform
       pos: -43.5,-18.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 11
-  - uid: 1554
+      - 19
+      - 18
+  - uid: 1532
     components:
     - type: Transform
       pos: -43.5,-19.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 11
-  - uid: 1555
+      - 19
+      - 18
+  - uid: 1533
     components:
     - type: Transform
       pos: -43.5,-20.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 11
-  - uid: 1556
+      - 19
+      - 18
+  - uid: 1534
     components:
     - type: Transform
       pos: -34.5,-17.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 29
-      - 11
-  - uid: 1557
+      - 35
+      - 18
+  - uid: 1535
     components:
     - type: Transform
       pos: -31.5,-15.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
-      - 29
-  - uid: 1558
+      - 34
+      - 35
+  - uid: 1536
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 31
-      - 11
-  - uid: 1559
+      - 37
+      - 18
+  - uid: 1537
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 31
-      - 11
-  - uid: 1560
+      - 37
+      - 18
+  - uid: 1538
     components:
     - type: Transform
       pos: -41.5,-23.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 31
-      - 32
-  - uid: 1561
+      - 37
+      - 38
+  - uid: 1539
     components:
     - type: Transform
       pos: -32.5,-25.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 30
-      - 31
-  - uid: 1562
+      - 36
+      - 37
+  - uid: 1540
     components:
     - type: Transform
       pos: -41.5,-28.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 31
-      - 33
-  - uid: 1563
+      - 37
+      - 39
+  - uid: 1541
     components:
     - type: Transform
       pos: -38.5,-14.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-  - uid: 1564
+      - 21
+  - uid: 1542
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
-      - 3
-  - uid: 1565
+      - 17
+      - 1237
+  - uid: 1543
     components:
     - type: Transform
       pos: -38.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
-      - 3
-  - uid: 1566
+      - 17
+      - 1237
+  - uid: 1544
     components:
     - type: Transform
       pos: -38.5,-7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
-      - 3
-  - uid: 1567
+      - 17
+      - 1237
+  - uid: 1545
     components:
     - type: Transform
       pos: -34.5,-9.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
-      - 10
-  - uid: 1568
+      - 12
+      - 17
+  - uid: 1546
     components:
     - type: Transform
       pos: -34.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 34
-      - 10
-  - uid: 1569
+      - 40
+      - 17
+  - uid: 1547
     components:
     - type: Transform
       pos: -43.5,-9.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 3
-  - uid: 1570
+      - 1237
+  - uid: 1548
     components:
     - type: Transform
       pos: -38.5,-0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-      - 9
-  - uid: 1571
+      - 22
+      - 16
+  - uid: 1549
     components:
     - type: Transform
       pos: -36.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-      - 9
-  - uid: 1572
+      - 22
+      - 16
+  - uid: 1550
     components:
     - type: Transform
       pos: -35.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-      - 9
-  - uid: 1573
+      - 22
+      - 16
+  - uid: 1551
     components:
     - type: Transform
       pos: -33.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
-      - 17
-  - uid: 1574
+      - 26
+      - 24
+  - uid: 1552
     components:
     - type: Transform
       pos: -32.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-  - uid: 1575
+      - 16
+  - uid: 1553
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
-  - uid: 1576
+      - 16
+  - uid: 1554
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
-  - uid: 1577
+      - 24
+  - uid: 1555
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
-  - uid: 1578
+      - 24
+  - uid: 1556
     components:
     - type: Transform
       pos: -33.5,10.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
-      - 17
-  - uid: 1579
+      - 25
+      - 24
+  - uid: 1557
     components:
     - type: Transform
       pos: -27.5,5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 17
-  - uid: 1580
+      - 27
+      - 24
+  - uid: 1558
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 17
-  - uid: 1581
+      - 27
+      - 24
+  - uid: 1559
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 17
-  - uid: 1582
+      - 27
+      - 24
+  - uid: 1560
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
-      - 17
-  - uid: 1583
+      - 27
+      - 24
+  - uid: 1561
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 20
-  - uid: 1584
+      - 28
+      - 27
+  - uid: 1562
     components:
     - type: Transform
       pos: -23.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 20
-  - uid: 1586
+      - 28
+      - 27
+  - uid: 1563
     components:
     - type: Transform
       pos: -45.5,7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 1587
+      - 22
+  - uid: 1564
     components:
     - type: Transform
       pos: -49.5,7.5
       parent: 2
-  - uid: 1588
+  - uid: 1565
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-      - 21
-  - uid: 1589
+      - 29
+      - 28
+  - uid: 1566
     components:
     - type: Transform
       pos: -19.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-      - 21
-  - uid: 1590
+      - 29
+      - 28
+  - uid: 1567
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-      - 21
-  - uid: 1591
+      - 29
+      - 28
+  - uid: 1568
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-      - 23
-  - uid: 1592
+      - 29
+      - 30
+  - uid: 1569
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 22
-  - uid: 1593
+      - 14
+      - 29
+  - uid: 1570
     components:
     - type: Transform
       pos: -15.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 22
-  - uid: 1594
+      - 14
+      - 29
+  - uid: 1571
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 23
-  - uid: 1595
+      - 14
+      - 30
+  - uid: 1572
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 23
-  - uid: 1596
+      - 14
+      - 30
+  - uid: 1573
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 23
-  - uid: 1597
+      - 14
+      - 30
+  - uid: 1574
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 23
-  - uid: 1598
+      - 14
+      - 30
+  - uid: 1575
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 23
-  - uid: 1599
+      - 14
+      - 30
+  - uid: 1576
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
-      - 23
-  - uid: 1600
+      - 14
+      - 30
+  - uid: 1577
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
-      - 24
-  - uid: 1601
+      - 30
+      - 41
+  - uid: 1578
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
-      - 24
-  - uid: 1602
+      - 11
+      - 41
+  - uid: 1579
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-      - 4
-  - uid: 1603
+      - 33
+      - 11
+  - uid: 1580
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
-      - 27
-  - uid: 1604
+      - 32
+      - 33
+  - uid: 1581
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
-      - 7
-  - uid: 1605
+      - 32
+      - 14
+  - uid: 1582
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
-      - 7
-  - uid: 1606
-    components:
-    - type: Transform
-      pos: -12.5,-6.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 26
-      - 7
-  - uid: 1607
+      - 32
+      - 14
+  - uid: 1583
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
-      - 7
-  - uid: 1608
+      - 32
+      - 14
+  - uid: 1584
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 26
-  - uid: 1609
+      - 31
+      - 32
+  - uid: 1585
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-      - 26
-  - uid: 1610
+      - 31
+      - 32
+  - uid: 1586
     components:
     - type: Transform
       pos: -19.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 1611
+      - 31
+  - uid: 1587
     components:
     - type: Transform
       pos: -19.5,-9.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 1612
+      - 31
+  - uid: 1588
     components:
     - type: Transform
       pos: -19.5,-10.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 1613
+      - 31
+  - uid: 1589
     components:
     - type: Transform
       pos: -17.5,-11.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 1614
+      - 31
+  - uid: 1590
     components:
     - type: Transform
       pos: -16.5,-11.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
-  - uid: 1615
+      - 31
+  - uid: 1591
     components:
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-  - uid: 1616
+      - 15
+  - uid: 1592
     components:
     - type: Transform
       pos: -27.5,-4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-      - 6
-  - uid: 1617
+      - 15
+      - 13
+  - uid: 1593
     components:
     - type: Transform
       pos: -44.5,-16.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
-      - 13
-  - uid: 1618
+      - 19
+      - 20
+  - uid: 1594
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
-      - 4
-  - uid: 1619
+      - 33
+      - 11
+  - uid: 1595
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
-      - 23
-  - uid: 1620
+      - 29
+      - 30
+  - uid: 1596
     components:
     - type: Transform
       pos: -20.5,-4.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-  - uid: 1621
+      - 15
+  - uid: 1597
     components:
     - type: Transform
       pos: -21.5,0.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
-  - uid: 1622
+      - 15
+  - uid: 1598
     components:
     - type: Transform
       pos: -34.5,-22.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 30
-      - 11
-  - uid: 1623
+      - 36
+      - 18
+  - uid: 1599
     components:
     - type: Transform
       pos: -34.5,-23.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 30
-      - 11
-  - uid: 1624
+      - 36
+      - 18
+  - uid: 1600
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
-      - 36
+      - 28
+      - 42
+  - uid: 2996
+    components:
+    - type: Transform
+      pos: -15.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 42
+      - 29
 - proto: FloorDrain
   entities:
-  - uid: 1079
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -14.5,7.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1601
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1625
+  - uid: 1602
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1626
+  - uid: 1603
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11556,14 +11558,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1627
-    components:
-    - type: Transform
-      pos: -14.5,8.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 1628
+  - uid: 1605
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11573,94 +11568,144 @@ entities:
       fixtures: {}
 - proto: FoodBakedBunHoney
   entities:
-  - uid: 1629
+  - uid: 1606
     components:
     - type: Transform
-      pos: -17.44486,1.7194142
+      pos: -16.534956,4.6707582
       parent: 2
+- proto: FoodBakedMuffinBanana
+  entities:
+  - uid: 1607
+    components:
+    - type: Transform
+      pos: -45.232662,-13.395407
+      parent: 2
+- proto: FoodBowlBig
+  entities:
+  - uid: 2806
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
+  - uid: 2807
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
 - proto: FoodBoxDonkpocket
   entities:
-  - uid: 1630
+  - uid: 1608
     components:
     - type: Transform
       pos: -32.38039,-14.471336
       parent: 2
 - proto: FoodBoxDonkpocketTeriyaki
   entities:
-  - uid: 1631
+  - uid: 1609
     components:
     - type: Transform
-      pos: -32.856968,-14.455711
+      pos: -32.466057,-14.377119
       parent: 2
 - proto: FoodCakeAppleSlice
   entities:
-  - uid: 1632
+  - uid: 1610
     components:
     - type: Transform
       pos: -15.369254,0.6866727
       parent: 2
 - proto: FoodCakeCarrotSlice
   entities:
-  - uid: 1633
+  - uid: 1611
     components:
     - type: Transform
       pos: -15.174825,0.5616727
       parent: 2
 - proto: FoodCakeLemonSlice
   entities:
-  - uid: 1634
+  - uid: 1612
     components:
     - type: Transform
       pos: -15.533039,0.5147977
       parent: 2
 - proto: FoodCakeLimeSlice
   entities:
-  - uid: 1635
+  - uid: 1613
     components:
     - type: Transform
       pos: -15.783039,0.6866727
       parent: 2
+- proto: FoodCondimentBottleEnzyme
+  entities:
+  - uid: 2814
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
 - proto: FoodLemon
   entities:
-  - uid: 3701
+  - uid: 1614
     components:
     - type: Transform
-      pos: -15.38124,5.4861636
+      pos: -16.659956,5.2182035
       parent: 2
-- proto: FoodPieBananaCream
+- proto: FoodPlateTin
   entities:
-  - uid: 1636
+  - uid: 2808
     components:
     - type: Transform
-      pos: -5.213787,3.629878
-      parent: 2
+      parent: 2805
+    - type: Physics
+      canCollide: False
+  - uid: 2809
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
+- proto: FoodShakerPepper
+  entities:
+  - uid: 2811
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
+- proto: FoodShakerSalt
+  entities:
+  - uid: 2810
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
 - proto: FoodTacoShell
   entities:
-  - uid: 3755
+  - uid: 1615
     components:
     - type: Transform
       pos: -43.497486,-29.684261
       parent: 2
 - proto: Fork
   entities:
-  - uid: 1637
+  - uid: 1616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.576687,-14.191739
       parent: 2
-- proto: FuelDispenser
+- proto: GasCanisterBrokenBase
   entities:
-  - uid: 1638
+  - uid: 1618
     components:
     - type: Transform
-      pos: -24.5,8.5
+      pos: -46.5,16.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: GasFilter
   entities:
-  - uid: 1639
+  - uid: 1619
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11670,7 +11715,7 @@ entities:
       color: '#FF0000FF'
     - type: GasFilter
       filteredGas: WaterVapor
-  - uid: 1640
+  - uid: 1620
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11680,7 +11725,7 @@ entities:
       color: '#FF0000FF'
     - type: GasFilter
       filteredGas: Plasma
-  - uid: 1641
+  - uid: 1621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11690,9 +11735,21 @@ entities:
       filteredGas: CarbonDioxide
     - type: AtmosPipeColor
       color: '#FF0000FF'
+- proto: GasFilterFlipped
+  entities:
+  - uid: 1622
+    components:
+    - type: MetaData
+      name: artifact vent pump & filter
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -42.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#947507FF'
 - proto: GasMinerNitrogenStation
   entities:
-  - uid: 1642
+  - uid: 1623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11700,7 +11757,7 @@ entities:
       parent: 2
 - proto: GasMinerOxygenStation
   entities:
-  - uid: 1643
+  - uid: 1624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11708,7 +11765,7 @@ entities:
       parent: 2
 - proto: GasMixerFlipped
   entities:
-  - uid: 1645
+  - uid: 1625
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11718,7 +11775,7 @@ entities:
       color: '#00FFFFFF'
 - proto: GasOutletInjector
   entities:
-  - uid: 1585
+  - uid: 1626
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11726,7 +11783,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1644
+  - uid: 1627
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11736,7 +11793,7 @@ entities:
       color: '#FF0000FF'
 - proto: GasPassiveVent
   entities:
-  - uid: 1646
+  - uid: 1628
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11744,34 +11801,34 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 1649
+  - uid: 1629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,13.5
       parent: 2
-  - uid: 1650
+  - uid: 1630
     components:
     - type: Transform
       pos: -39.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 1651
+  - uid: 1631
     components:
     - type: Transform
       pos: -39.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1652
+  - uid: 1632
     components:
     - type: Transform
       pos: -39.5,8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1653
+  - uid: 1633
     components:
     - type: Transform
       pos: -39.5,10.5
@@ -11780,7 +11837,7 @@ entities:
       color: '#00FFFFFF'
 - proto: GasPipeBend
   entities:
-  - uid: 1654
+  - uid: 1634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11790,7 +11847,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1655
+  - uid: 1635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11798,14 +11855,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1656
+  - uid: 1636
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1657
+  - uid: 1637
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11813,7 +11870,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1658
+  - uid: 1638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11821,7 +11878,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1659
+  - uid: 1639
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11829,7 +11886,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1660
+  - uid: 1640
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11837,7 +11894,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1662
+  - uid: 1641
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11845,7 +11902,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1663
+  - uid: 1642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11853,7 +11910,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1664
+  - uid: 1643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11861,7 +11918,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1665
+  - uid: 1644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11869,7 +11926,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1666
+  - uid: 1645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11877,7 +11934,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1667
+  - uid: 1646
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11885,7 +11942,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 1668
+  - uid: 1647
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11893,21 +11950,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1669
+  - uid: 1648
     components:
     - type: Transform
       pos: -35.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1670
+  - uid: 1649
     components:
     - type: Transform
       pos: -36.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1671
+  - uid: 1650
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11915,7 +11972,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1672
+  - uid: 1651
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11923,7 +11980,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1673
+  - uid: 1652
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11931,7 +11988,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1674
+  - uid: 1653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11939,7 +11996,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1675
+  - uid: 1654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11947,14 +12004,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1676
+  - uid: 1655
     components:
     - type: Transform
       pos: -32.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1677
+  - uid: 1656
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11962,7 +12019,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1678
+  - uid: 1657
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11970,7 +12027,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1679
+  - uid: 1658
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11978,7 +12035,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1680
+  - uid: 1659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11986,7 +12043,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1681
+  - uid: 1660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11994,7 +12051,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1682
+  - uid: 1661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12002,7 +12059,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1683
+  - uid: 1662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12010,7 +12067,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1684
+  - uid: 1663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12018,7 +12075,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1685
+  - uid: 1664
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12026,7 +12083,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1686
+  - uid: 1665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12034,14 +12091,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1687
+  - uid: 1666
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1688
+  - uid: 1667
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12049,21 +12106,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1689
+  - uid: 1668
     components:
     - type: Transform
       pos: -28.5,5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1690
+  - uid: 1669
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1691
+  - uid: 1670
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12071,14 +12128,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 1692
+  - uid: 1671
     components:
     - type: Transform
       pos: -30.5,10.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 1693
+  - uid: 1672
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12086,13 +12143,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1694
+  - uid: 1673
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,16.5
       parent: 2
-  - uid: 1695
+  - uid: 1674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12100,7 +12157,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1696
+  - uid: 1675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12108,7 +12165,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1697
+  - uid: 1676
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12116,7 +12173,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1990
+  - uid: 1677
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12124,7 +12181,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 2137
+  - uid: 1678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12132,7 +12189,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 3689
+  - uid: 1679
     components:
     - type: Transform
       pos: -15.5,-3.5
@@ -12141,7 +12198,7 @@ entities:
       color: '#FFF200FF'
 - proto: GasPipeBendAlt2
   entities:
-  - uid: 1698
+  - uid: 1680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12149,7 +12206,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 1699
+  - uid: 1681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12157,7 +12214,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 1700
+  - uid: 1682
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12167,42 +12224,42 @@ entities:
       color: '#FF52DCFF'
 - proto: GasPipeFourway
   entities:
-  - uid: 1701
+  - uid: 1683
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1702
+  - uid: 1684
     components:
     - type: Transform
       pos: -15.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1703
+  - uid: 1685
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1704
+  - uid: 1686
     components:
     - type: Transform
       pos: -32.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1705
+  - uid: 1687
     components:
     - type: Transform
       pos: -36.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1706
+  - uid: 1688
     components:
     - type: Transform
       pos: -35.5,-13.5
@@ -12211,13 +12268,13 @@ entities:
       color: '#FF0000FF'
 - proto: GasPipeManifold
   entities:
-  - uid: 1707
+  - uid: 1689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,13.5
       parent: 2
-  - uid: 1708
+  - uid: 1690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12225,7 +12282,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 1709
+  - uid: 1691
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12235,7 +12292,7 @@ entities:
       color: '#FF0000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 35
+  - uid: 1692
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12243,21 +12300,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1710
+  - uid: 1693
     components:
     - type: Transform
       pos: -45.5,-16.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1711
+  - uid: 1694
     components:
     - type: Transform
       pos: -45.5,-17.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1712
+  - uid: 1695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12265,40 +12322,40 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1713
+  - uid: 1696
     components:
     - type: Transform
       pos: -21.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1714
+  - uid: 1697
     components:
     - type: Transform
       pos: -16.5,5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1716
+  - uid: 1698
     components:
     - type: Transform
       pos: -43.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 1717
+  - uid: 1699
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
-  - uid: 1718
+  - uid: 1700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,7.5
       parent: 2
-  - uid: 1719
+  - uid: 1701
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12306,14 +12363,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1720
+  - uid: 1702
     components:
     - type: Transform
       pos: -35.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1721
+  - uid: 1703
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12321,7 +12378,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1722
+  - uid: 1704
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12329,7 +12386,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1723
+  - uid: 1705
     components:
     - type: Transform
       pos: -41.5,12.5
@@ -12338,7 +12395,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1724
+  - uid: 1706
     components:
     - type: Transform
       pos: -41.5,11.5
@@ -12347,7 +12404,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1725
+  - uid: 1707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12355,7 +12412,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1726
+  - uid: 1708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12363,7 +12420,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 1727
+  - uid: 1709
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12371,7 +12428,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1728
+  - uid: 1710
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12379,7 +12436,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1729
+  - uid: 1711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12387,7 +12444,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1730
+  - uid: 1712
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12395,7 +12452,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1731
+  - uid: 1713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12403,7 +12460,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1732
+  - uid: 1714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12411,7 +12468,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1733
+  - uid: 1715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12419,7 +12476,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1734
+  - uid: 1716
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12427,7 +12484,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1735
+  - uid: 1717
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12435,7 +12492,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1736
+  - uid: 1718
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12443,7 +12500,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1737
+  - uid: 1719
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12451,7 +12508,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1738
+  - uid: 1720
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12459,7 +12516,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1739
+  - uid: 1721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12467,7 +12524,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1740
+  - uid: 1722
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12475,7 +12532,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1741
+  - uid: 1723
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12483,7 +12540,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1742
+  - uid: 1724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12491,7 +12548,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1743
+  - uid: 1725
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12499,7 +12556,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1744
+  - uid: 1726
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12507,7 +12564,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1745
+  - uid: 1727
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12515,7 +12572,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1746
+  - uid: 1728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12523,7 +12580,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1747
+  - uid: 1729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12531,7 +12588,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1748
+  - uid: 1730
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12539,7 +12596,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1749
+  - uid: 1731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12547,7 +12604,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1750
+  - uid: 1732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12555,7 +12612,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1751
+  - uid: 1733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12563,7 +12620,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1752
+  - uid: 1734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12571,7 +12628,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1753
+  - uid: 1735
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12579,7 +12636,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1754
+  - uid: 1736
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12587,7 +12644,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1755
+  - uid: 1737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12595,7 +12652,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1756
+  - uid: 1738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12603,7 +12660,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1757
+  - uid: 1739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12611,7 +12668,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1758
+  - uid: 1740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12619,7 +12676,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1759
+  - uid: 1741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12627,7 +12684,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1760
+  - uid: 1742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12635,7 +12692,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1761
+  - uid: 1743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12643,7 +12700,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1762
+  - uid: 1744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12651,7 +12708,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1763
+  - uid: 1745
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12659,7 +12716,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1764
+  - uid: 1746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12667,28 +12724,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1765
+  - uid: 1747
     components:
     - type: Transform
       pos: -14.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1766
+  - uid: 1748
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1767
+  - uid: 1749
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1768
+  - uid: 1750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12696,7 +12753,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1769
+  - uid: 1751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12704,7 +12761,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1770
+  - uid: 1752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12712,7 +12769,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1771
+  - uid: 1753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12720,7 +12777,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1772
+  - uid: 1754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12728,7 +12785,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1773
+  - uid: 1755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12736,7 +12793,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1774
+  - uid: 1756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12744,7 +12801,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1775
+  - uid: 1757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12752,7 +12809,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1776
+  - uid: 1758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12760,7 +12817,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1777
+  - uid: 1759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12768,7 +12825,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1778
+  - uid: 1760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12776,7 +12833,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1779
+  - uid: 1761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12784,7 +12841,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1780
+  - uid: 1762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12792,7 +12849,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1781
+  - uid: 1763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12800,7 +12857,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1782
+  - uid: 1764
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12808,35 +12865,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1783
+  - uid: 1765
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1784
+  - uid: 1766
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1785
+  - uid: 1767
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1786
+  - uid: 1768
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1787
+  - uid: 1769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12844,7 +12901,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1788
+  - uid: 1770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12852,77 +12909,77 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1789
+  - uid: 1771
     components:
     - type: Transform
       pos: -10.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1790
+  - uid: 1772
     components:
     - type: Transform
       pos: -10.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1791
+  - uid: 1773
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1792
+  - uid: 1774
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1793
+  - uid: 1775
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1794
+  - uid: 1776
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1795
+  - uid: 1777
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1796
+  - uid: 1778
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1797
+  - uid: 1779
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1798
+  - uid: 1780
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1799
+  - uid: 1781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12930,7 +12987,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1800
+  - uid: 1782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12938,7 +12995,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1801
+  - uid: 1783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12946,7 +13003,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1802
+  - uid: 1784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12954,7 +13011,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1803
+  - uid: 1785
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12962,7 +13019,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1804
+  - uid: 1786
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12970,7 +13027,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1805
+  - uid: 1787
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12978,7 +13035,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1806
+  - uid: 1788
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12986,7 +13043,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1807
+  - uid: 1789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12994,7 +13051,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1808
+  - uid: 1790
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13002,7 +13059,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1809
+  - uid: 1791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13010,7 +13067,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1810
+  - uid: 1792
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13018,7 +13075,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1811
+  - uid: 1793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13026,7 +13083,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1812
+  - uid: 1794
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13034,7 +13091,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1813
+  - uid: 1795
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13042,7 +13099,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1814
+  - uid: 1796
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13050,7 +13107,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1815
+  - uid: 1797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13058,7 +13115,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1816
+  - uid: 1798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13066,7 +13123,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1817
+  - uid: 1799
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13074,7 +13131,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1818
+  - uid: 1800
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13082,7 +13139,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1819
+  - uid: 1801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13090,7 +13147,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1820
+  - uid: 1802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13098,7 +13155,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1821
+  - uid: 1803
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13106,7 +13163,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1822
+  - uid: 1804
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13114,7 +13171,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1823
+  - uid: 1805
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13122,7 +13179,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1824
+  - uid: 1806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13130,7 +13187,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1825
+  - uid: 1807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13138,7 +13195,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1826
+  - uid: 1808
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13146,7 +13203,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1827
+  - uid: 1809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13154,7 +13211,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1828
+  - uid: 1810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13162,7 +13219,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1829
+  - uid: 1811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13170,7 +13227,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1830
+  - uid: 1812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13178,7 +13235,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1831
+  - uid: 1813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13186,7 +13243,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1832
+  - uid: 1814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13194,7 +13251,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1833
+  - uid: 1815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13202,7 +13259,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1834
+  - uid: 1816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13210,7 +13267,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1835
+  - uid: 1817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13218,14 +13275,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1836
+  - uid: 1818
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1837
+  - uid: 1819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13233,7 +13290,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1838
+  - uid: 1820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13241,7 +13298,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1839
+  - uid: 1821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13249,14 +13306,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1840
+  - uid: 1822
     components:
     - type: Transform
       pos: -15.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1841
+  - uid: 1823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13264,7 +13321,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1842
+  - uid: 1824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13272,7 +13329,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1843
+  - uid: 1825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13280,7 +13337,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1844
+  - uid: 1826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13288,7 +13345,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1845
+  - uid: 1827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13296,7 +13353,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1846
+  - uid: 1828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13304,7 +13361,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1847
+  - uid: 1829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13312,7 +13369,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1848
+  - uid: 1830
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13320,14 +13377,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1849
+  - uid: 1831
     components:
     - type: Transform
       pos: -35.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1850
+  - uid: 1832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13335,7 +13392,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1851
+  - uid: 1833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13343,14 +13400,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1852
+  - uid: 1834
     components:
     - type: Transform
       pos: -42.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1853
+  - uid: 1835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13360,7 +13417,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1854
+  - uid: 1836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13368,7 +13425,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1855
+  - uid: 1837
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13376,7 +13433,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1856
+  - uid: 1838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13384,7 +13441,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1857
+  - uid: 1839
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13392,35 +13449,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1858
+  - uid: 1840
     components:
     - type: Transform
       pos: -35.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1859
+  - uid: 1841
     components:
     - type: Transform
       pos: -35.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1860
+  - uid: 1842
     components:
     - type: Transform
       pos: -35.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1861
+  - uid: 1843
     components:
     - type: Transform
       pos: -35.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1862
+  - uid: 1844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13428,7 +13485,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1863
+  - uid: 1845
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13436,7 +13493,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1864
+  - uid: 1846
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13444,7 +13501,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1865
+  - uid: 1847
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13452,7 +13509,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1866
+  - uid: 1848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13460,7 +13517,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1867
+  - uid: 1849
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13468,7 +13525,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1868
+  - uid: 1850
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13476,7 +13533,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1869
+  - uid: 1851
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13484,7 +13541,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1870
+  - uid: 1852
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13492,7 +13549,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1871
+  - uid: 1853
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13500,7 +13557,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1872
+  - uid: 1854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13508,7 +13565,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1873
+  - uid: 1855
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13516,7 +13573,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1874
+  - uid: 1856
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13524,7 +13581,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-  - uid: 1875
+  - uid: 1857
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13532,63 +13589,63 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1876
+  - uid: 1858
     components:
     - type: Transform
       pos: -35.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1877
+  - uid: 1859
     components:
     - type: Transform
       pos: -35.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1878
+  - uid: 1860
     components:
     - type: Transform
       pos: -35.5,-10.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1879
+  - uid: 1861
     components:
     - type: Transform
       pos: -35.5,-12.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1880
+  - uid: 1862
     components:
     - type: Transform
       pos: -35.5,-14.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1881
+  - uid: 1863
     components:
     - type: Transform
       pos: -35.5,-15.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1882
+  - uid: 1864
     components:
     - type: Transform
       pos: -35.5,-16.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1883
+  - uid: 1865
     components:
     - type: Transform
       pos: -35.5,-17.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1884
+  - uid: 1866
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13596,7 +13653,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1885
+  - uid: 1867
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13604,7 +13661,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1886
+  - uid: 1868
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13612,7 +13669,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1887
+  - uid: 1869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13620,7 +13677,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1888
+  - uid: 1870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13628,7 +13685,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1889
+  - uid: 1871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13636,7 +13693,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1890
+  - uid: 1872
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13644,7 +13701,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1891
+  - uid: 1873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13652,7 +13709,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1892
+  - uid: 1874
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13660,7 +13717,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1893
+  - uid: 1875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13668,7 +13725,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1894
+  - uid: 1876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13676,7 +13733,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1895
+  - uid: 1877
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13684,7 +13741,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1896
+  - uid: 1878
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13692,84 +13749,84 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1897
+  - uid: 1879
     components:
     - type: Transform
       pos: -36.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1898
+  - uid: 1880
     components:
     - type: Transform
       pos: -36.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1899
+  - uid: 1881
     components:
     - type: Transform
       pos: -36.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1900
+  - uid: 1882
     components:
     - type: Transform
       pos: -36.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1901
+  - uid: 1883
     components:
     - type: Transform
       pos: -36.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1902
+  - uid: 1884
     components:
     - type: Transform
       pos: -36.5,-9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1903
+  - uid: 1885
     components:
     - type: Transform
       pos: -36.5,-11.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1904
+  - uid: 1886
     components:
     - type: Transform
       pos: -36.5,-12.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1905
+  - uid: 1887
     components:
     - type: Transform
       pos: -36.5,-13.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1906
+  - uid: 1888
     components:
     - type: Transform
       pos: -36.5,-15.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1907
+  - uid: 1889
     components:
     - type: Transform
       pos: -36.5,-16.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1908
+  - uid: 1890
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13777,7 +13834,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1909
+  - uid: 1891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13785,7 +13842,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1910
+  - uid: 1892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13793,7 +13850,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1911
+  - uid: 1893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13801,7 +13858,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1912
+  - uid: 1894
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13809,7 +13866,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1913
+  - uid: 1895
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13817,7 +13874,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1914
+  - uid: 1896
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13825,7 +13882,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1915
+  - uid: 1897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13833,7 +13890,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1916
+  - uid: 1898
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13841,7 +13898,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1917
+  - uid: 1899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13849,7 +13906,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1918
+  - uid: 1900
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13857,7 +13914,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1919
+  - uid: 1901
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13865,7 +13922,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1920
+  - uid: 1902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13873,7 +13930,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1921
+  - uid: 1903
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13881,7 +13938,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1922
+  - uid: 1904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13889,7 +13946,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1923
+  - uid: 1905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13897,7 +13954,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1924
+  - uid: 1906
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13905,7 +13962,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1925
+  - uid: 1907
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13913,7 +13970,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1926
+  - uid: 1908
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13921,7 +13978,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1927
+  - uid: 1909
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13929,7 +13986,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1928
+  - uid: 1910
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13937,7 +13994,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1929
+  - uid: 1911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13945,7 +14002,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1930
+  - uid: 1912
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13953,7 +14010,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1931
+  - uid: 1913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13961,7 +14018,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1932
+  - uid: 1914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13969,7 +14026,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1933
+  - uid: 1915
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13977,7 +14034,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1934
+  - uid: 1916
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13985,7 +14042,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1935
+  - uid: 1917
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13993,7 +14050,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1936
+  - uid: 1918
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14001,7 +14058,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1937
+  - uid: 1919
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14009,7 +14066,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1938
+  - uid: 1920
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14017,7 +14074,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1939
+  - uid: 1921
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14025,7 +14082,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1940
+  - uid: 1922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14033,7 +14090,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1941
+  - uid: 1923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14041,7 +14098,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1942
+  - uid: 1924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14049,7 +14106,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1943
+  - uid: 1925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14057,7 +14114,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1944
+  - uid: 1926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14065,7 +14122,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1945
+  - uid: 1927
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14073,7 +14130,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1946
+  - uid: 1928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14081,7 +14138,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1947
+  - uid: 1929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14089,7 +14146,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1948
+  - uid: 1930
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14097,7 +14154,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1949
+  - uid: 1931
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14105,7 +14162,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1950
+  - uid: 1932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14113,7 +14170,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1951
+  - uid: 1933
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14121,7 +14178,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1952
+  - uid: 1934
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14129,7 +14186,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1953
+  - uid: 1935
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14137,7 +14194,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1954
+  - uid: 1936
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14145,7 +14202,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1955
+  - uid: 1937
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14153,7 +14210,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1956
+  - uid: 1938
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14161,7 +14218,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1957
+  - uid: 1939
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14169,7 +14226,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1958
+  - uid: 1940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14177,7 +14234,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1959
+  - uid: 1941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14185,7 +14242,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1960
+  - uid: 1942
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14193,7 +14250,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1961
+  - uid: 1943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14201,7 +14258,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1962
+  - uid: 1944
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14209,49 +14266,49 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1963
+  - uid: 1945
     components:
     - type: Transform
       pos: -39.5,-24.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1964
+  - uid: 1946
     components:
     - type: Transform
       pos: -40.5,-24.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1965
+  - uid: 1947
     components:
     - type: Transform
       pos: -40.5,-25.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1966
+  - uid: 1948
     components:
     - type: Transform
       pos: -39.5,-25.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1967
+  - uid: 1949
     components:
     - type: Transform
       pos: -39.5,-26.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1968
+  - uid: 1950
     components:
     - type: Transform
       pos: -40.5,-26.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1969
+  - uid: 1951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14259,7 +14316,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1970
+  - uid: 1952
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14267,7 +14324,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1971
+  - uid: 1953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14275,7 +14332,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1972
+  - uid: 1954
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14283,7 +14340,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1973
+  - uid: 1955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14291,7 +14348,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1974
+  - uid: 1956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14299,7 +14356,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1975
+  - uid: 1957
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14307,7 +14364,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1976
+  - uid: 1958
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14315,7 +14372,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1977
+  - uid: 1959
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14323,7 +14380,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1978
+  - uid: 1960
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14331,7 +14388,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1979
+  - uid: 1961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14339,7 +14396,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1980
+  - uid: 1962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14347,7 +14404,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1981
+  - uid: 1963
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14355,7 +14412,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1982
+  - uid: 1964
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14363,7 +14420,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1983
+  - uid: 1965
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14371,7 +14428,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1984
+  - uid: 1966
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14379,7 +14436,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1985
+  - uid: 1967
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14387,7 +14444,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1986
+  - uid: 1968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14395,7 +14452,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1987
+  - uid: 1969
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14403,7 +14460,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1988
+  - uid: 1970
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14411,7 +14468,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1989
+  - uid: 1971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14419,7 +14476,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1991
+  - uid: 1972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14427,42 +14484,42 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1992
+  - uid: 1973
     components:
     - type: Transform
       pos: -27.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1993
+  - uid: 1974
     components:
     - type: Transform
       pos: -27.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1994
+  - uid: 1975
     components:
     - type: Transform
       pos: -23.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1995
+  - uid: 1976
     components:
     - type: Transform
       pos: -23.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1996
+  - uid: 1977
     components:
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1997
+  - uid: 1978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14470,7 +14527,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1998
+  - uid: 1979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14478,7 +14535,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 1999
+  - uid: 1980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14486,28 +14543,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2000
+  - uid: 1981
     components:
     - type: Transform
       pos: -32.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2001
+  - uid: 1982
     components:
     - type: Transform
       pos: -32.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2002
+  - uid: 1983
     components:
     - type: Transform
       pos: -32.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2003
+  - uid: 1984
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14515,7 +14572,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2004
+  - uid: 1985
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14523,7 +14580,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2005
+  - uid: 1986
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14531,7 +14588,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2006
+  - uid: 1987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14539,7 +14596,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2007
+  - uid: 1988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14547,7 +14604,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2008
+  - uid: 1989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14555,7 +14612,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2009
+  - uid: 1990
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14563,7 +14620,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2010
+  - uid: 1991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14571,7 +14628,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2011
+  - uid: 1992
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14579,7 +14636,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2012
+  - uid: 1993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14587,28 +14644,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2013
+  - uid: 1994
     components:
     - type: Transform
       pos: -21.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2014
+  - uid: 1995
     components:
     - type: Transform
       pos: -21.5,5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2015
+  - uid: 1996
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2016
+  - uid: 1997
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14616,7 +14673,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2017
+  - uid: 1998
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14624,7 +14681,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2018
+  - uid: 1999
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14632,7 +14689,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2019
+  - uid: 2000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14640,7 +14697,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2020
+  - uid: 2001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14648,7 +14705,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2021
+  - uid: 2002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14656,7 +14713,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2022
+  - uid: 2003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14664,7 +14721,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2023
+  - uid: 2004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14672,7 +14729,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2024
+  - uid: 2005
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14680,38 +14737,38 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2025
+  - uid: 2006
     components:
     - type: Transform
       pos: -35.5,9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2026
+  - uid: 2007
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2027
+  - uid: 2008
     components:
     - type: Transform
       pos: -38.5,15.5
       parent: 2
-  - uid: 2028
+  - uid: 2009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,16.5
       parent: 2
-  - uid: 2029
+  - uid: 2010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,14.5
       parent: 2
-  - uid: 2030
+  - uid: 2011
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14719,7 +14776,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 2031
+  - uid: 2012
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14729,35 +14786,35 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2032
+  - uid: 2013
     components:
     - type: Transform
       pos: -43.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 2033
+  - uid: 2014
     components:
     - type: Transform
       pos: -43.5,7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 2034
+  - uid: 2015
     components:
     - type: Transform
       pos: -43.5,8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 2035
+  - uid: 2016
     components:
     - type: Transform
       pos: -43.5,9.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 2036
+  - uid: 2017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14765,7 +14822,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 3705
+  - uid: 2018
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14773,7 +14830,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 3710
+  - uid: 2019
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14781,7 +14838,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3712
+  - uid: 2020
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14789,7 +14846,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3713
+  - uid: 2021
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14797,7 +14854,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3714
+  - uid: 2022
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14805,7 +14862,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3715
+  - uid: 2023
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14815,7 +14872,7 @@ entities:
       color: '#FF0000FF'
 - proto: GasPipeStraightAlt2
   entities:
-  - uid: 2037
+  - uid: 2024
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14823,7 +14880,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2038
+  - uid: 2025
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14831,7 +14888,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2039
+  - uid: 2026
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14839,7 +14896,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2040
+  - uid: 2027
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14847,42 +14904,42 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2041
+  - uid: 2028
     components:
     - type: Transform
       pos: -43.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2042
+  - uid: 2029
     components:
     - type: Transform
       pos: -43.5,5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2043
+  - uid: 2030
     components:
     - type: Transform
       pos: -43.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2044
+  - uid: 2031
     components:
     - type: Transform
       pos: -43.5,7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2045
+  - uid: 2032
     components:
     - type: Transform
       pos: -43.5,8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF52DCFF'
-  - uid: 2046
+  - uid: 2033
     components:
     - type: Transform
       pos: -43.5,9.5
@@ -14891,14 +14948,14 @@ entities:
       color: '#FF52DCFF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 1647
+  - uid: 2034
     components:
     - type: Transform
       pos: -17.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 1648
+  - uid: 2035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14906,14 +14963,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 1661
+  - uid: 2036
     components:
     - type: Transform
       pos: -39.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2047
+  - uid: 2037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14921,13 +14978,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2048
+  - uid: 2038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,7.5
       parent: 2
-  - uid: 2049
+  - uid: 2039
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14935,7 +14992,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2050
+  - uid: 2040
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14943,7 +15000,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2051
+  - uid: 2041
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14951,35 +15008,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2052
+  - uid: 2042
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2053
+  - uid: 2043
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2054
+  - uid: 2044
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2055
+  - uid: 2045
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2056
+  - uid: 2046
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14987,7 +15044,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2057
+  - uid: 2047
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14995,7 +15052,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2058
+  - uid: 2048
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15003,7 +15060,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2059
+  - uid: 2049
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15011,7 +15068,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2060
+  - uid: 2050
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15019,7 +15076,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2061
+  - uid: 2051
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15027,28 +15084,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2062
+  - uid: 2052
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2063
+  - uid: 2053
     components:
     - type: Transform
       pos: -26.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2064
+  - uid: 2054
     components:
     - type: Transform
       pos: -27.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2065
+  - uid: 2055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15056,7 +15113,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2066
+  - uid: 2056
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15064,14 +15121,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2067
+  - uid: 2057
     components:
     - type: Transform
       pos: -18.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2068
+  - uid: 2058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15079,7 +15136,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2069
+  - uid: 2059
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15087,7 +15144,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2070
+  - uid: 2060
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15095,7 +15152,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2071
+  - uid: 2061
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15103,14 +15160,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2072
+  - uid: 2062
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2073
+  - uid: 2063
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15118,7 +15175,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2074
+  - uid: 2064
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15126,14 +15183,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2075
+  - uid: 2065
     components:
     - type: Transform
       pos: -38.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2076
+  - uid: 2066
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15141,7 +15198,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2077
+  - uid: 2067
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15149,7 +15206,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2078
+  - uid: 2068
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15157,7 +15214,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2079
+  - uid: 2069
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15165,7 +15222,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2080
+  - uid: 2070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15173,7 +15230,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2081
+  - uid: 2071
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15181,7 +15238,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2082
+  - uid: 2072
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15189,7 +15246,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2083
+  - uid: 2073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15197,7 +15254,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2084
+  - uid: 2074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15205,7 +15262,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2085
+  - uid: 2075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15213,7 +15270,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2086
+  - uid: 2076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15221,7 +15278,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2087
+  - uid: 2077
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15229,7 +15286,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2088
+  - uid: 2078
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15237,7 +15294,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2089
+  - uid: 2079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15245,14 +15302,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2090
+  - uid: 2080
     components:
     - type: Transform
       pos: -39.5,-18.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2091
+  - uid: 2081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15260,7 +15317,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2092
+  - uid: 2082
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15268,7 +15325,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2093
+  - uid: 2083
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15276,7 +15333,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2094
+  - uid: 2084
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15284,7 +15341,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2095
+  - uid: 2085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15292,21 +15349,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2096
+  - uid: 2086
     components:
     - type: Transform
       pos: -31.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2097
+  - uid: 2087
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2098
+  - uid: 2088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15314,7 +15371,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2099
+  - uid: 2089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15322,7 +15379,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2100
+  - uid: 2090
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15330,7 +15387,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2101
+  - uid: 2091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15338,13 +15395,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2102
+  - uid: 2092
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,9.5
       parent: 2
-  - uid: 2103
+  - uid: 2093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15352,7 +15409,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 2104
+  - uid: 2094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15360,19 +15417,19 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 2105
+  - uid: 2095
     components:
     - type: Transform
       pos: -42.5,16.5
       parent: 2
-  - uid: 3707
+  - uid: 2096
     components:
     - type: Transform
       pos: -41.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 3711
+  - uid: 2097
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15382,7 +15439,7 @@ entities:
       color: '#FF0000FF'
 - proto: GasPort
   entities:
-  - uid: 2106
+  - uid: 2098
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15390,7 +15447,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFF200FF'
-  - uid: 3706
+  - uid: 2099
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15400,7 +15457,7 @@ entities:
       color: '#947507FF'
 - proto: GasPressurePump
   entities:
-  - uid: 1715
+  - uid: 2100
     components:
     - type: MetaData
       name: artifact fill pump
@@ -15410,14 +15467,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2108
+  - uid: 2101
     components:
     - type: Transform
       pos: -42.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2109
+  - uid: 2102
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15427,7 +15484,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2110
+  - uid: 2103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15435,7 +15492,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2111
+  - uid: 2104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15443,26 +15500,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 3709
-    components:
-    - type: MetaData
-      name: artifact vent pump
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -42.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF0000FF'
-- proto: GasThermoMachineFreezer
+- proto: GasThermoMachineFreezerEnabled
   entities:
-  - uid: 2112
+  - uid: 2105
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-- proto: GasThermoMachineFreezerEnabled
-  entities:
-  - uid: 2113
+  - uid: 2106
     components:
     - type: Transform
       pos: -32.5,11.5
@@ -15471,27 +15516,27 @@ entities:
       color: '#0000FFFF'
 - proto: GasVentPump
   entities:
-  - uid: 2114
+  - uid: 2107
     components:
     - type: Transform
       pos: -45.5,-15.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2115
+  - uid: 2108
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24
+      - 41
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2116
+  - uid: 2109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15499,10 +15544,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 30
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2117
+  - uid: 2110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15510,30 +15555,30 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
+      - 33
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2118
+  - uid: 2111
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
+      - 32
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2119
+  - uid: 2112
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
+      - 29
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2120
+  - uid: 2113
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15541,10 +15586,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 31
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2121
+  - uid: 2114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15552,10 +15597,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 15
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2122
+  - uid: 2115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15563,10 +15608,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
+      - 11
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2123
+  - uid: 2116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15574,10 +15619,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 14
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2124
+  - uid: 2117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15585,10 +15630,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 14
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2125
+  - uid: 2118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15596,10 +15641,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2126
+  - uid: 2119
     components:
     - type: Transform
       pos: -20.5,2.5
@@ -15608,8 +15653,8 @@ entities:
       color: '#0055CCFF'
     - type: DeviceNetwork
       deviceLists:
-      - 21
-  - uid: 2127
+      - 28
+  - uid: 2120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15617,20 +15662,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
+      - 27
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2128
+  - uid: 2121
     components:
     - type: Transform
       pos: -32.5,-9.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2129
+  - uid: 2122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15638,10 +15683,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 34
+      - 40
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2130
+  - uid: 2123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15649,10 +15694,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
+      - 34
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2131
+  - uid: 2124
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15660,10 +15705,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 29
+      - 35
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2132
+  - uid: 2125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15671,10 +15716,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 30
+      - 36
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2133
+  - uid: 2126
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15682,10 +15727,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 31
+      - 37
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2134
+  - uid: 2127
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15693,10 +15738,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 19
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2135
+  - uid: 2128
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15704,10 +15749,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
+      - 18
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2136
+  - uid: 2129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15715,10 +15760,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 17
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2138
+  - uid: 2130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15726,7 +15771,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2139
+  - uid: 2131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15734,10 +15779,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2140
+  - uid: 2132
     components:
     - type: Transform
       pos: -39.5,2.5
@@ -15746,8 +15791,8 @@ entities:
       color: '#0055CCFF'
     - type: DeviceNetwork
       deviceLists:
-      - 15
-  - uid: 3708
+      - 22
+  - uid: 2133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15755,54 +15800,48 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 3
+      - 1237
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentPumpFreezer
   entities:
-  - uid: 2142
+  - uid: 3728
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -15.5,7.5
       parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 36
 - proto: GasVentPumpVox
   entities:
-  - uid: 2179
+  - uid: 2134
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -17.5,-4.5
       parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 37
     - type: AtmosPipeColor
-      color: '#FFF200FF'
-  - uid: 2181
+      color: '#FFFF00FF'
+  - uid: 2135
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -15.5,-4.5
       parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 37
     - type: AtmosPipeColor
-      color: '#FFF200FF'
+      color: '#FFFF00FF'
 - proto: GasVentScrubber
   entities:
-  - uid: 2107
+  - uid: 2136
     components:
     - type: Transform
       pos: -40.5,-6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 3
+      - 1237
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2144
+  - uid: 2137
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15810,20 +15849,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 26
+      - 32
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2145
+  - uid: 2138
     components:
     - type: Transform
       pos: -20.5,6.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
+      - 28
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2146
+  - uid: 2139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15831,10 +15870,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24
+      - 41
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2147
+  - uid: 2140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15842,10 +15881,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 23
+      - 30
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2148
+  - uid: 2141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15853,10 +15892,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 27
+      - 33
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2149
+  - uid: 2142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15864,10 +15903,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 22
+      - 29
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2150
+  - uid: 2143
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15875,20 +15914,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 25
+      - 31
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2151
+  - uid: 2144
     components:
     - type: Transform
       pos: -25.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 8
+      - 15
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2152
+  - uid: 2145
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15896,10 +15935,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 4
+      - 11
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2153
+  - uid: 2146
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15907,30 +15946,30 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 14
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2154
+  - uid: 2147
     components:
     - type: Transform
       pos: -16.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 7
+      - 14
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2155
+  - uid: 2148
     components:
     - type: Transform
       pos: -33.5,-1.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9
+      - 16
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2156
+  - uid: 2149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15938,10 +15977,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 20
+      - 27
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2157
+  - uid: 2150
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15949,10 +15988,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5
+      - 12
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2158
+  - uid: 2151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15960,10 +15999,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 34
+      - 40
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2159
+  - uid: 2152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15971,10 +16010,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 28
+      - 34
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2160
+  - uid: 2153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15982,10 +16021,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 29
+      - 35
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2161
+  - uid: 2154
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15993,10 +16032,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 30
+      - 36
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2162
+  - uid: 2155
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16004,10 +16043,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 32
+      - 38
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2163
+  - uid: 2156
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16015,10 +16054,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 33
+      - 39
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2164
+  - uid: 2157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16026,10 +16065,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 31
+      - 37
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2165
+  - uid: 2158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16037,40 +16076,40 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 21
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2166
+  - uid: 2159
     components:
     - type: Transform
       pos: -44.5,-13.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 13
+      - 20
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2167
+  - uid: 2160
     components:
     - type: Transform
       pos: -47.5,-18.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 12
+      - 19
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2168
+  - uid: 2161
     components:
     - type: Transform
       pos: -40.5,-18.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 11
+      - 18
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2169
+  - uid: 2162
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16078,10 +16117,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10
+      - 17
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2171
+  - uid: 2163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16089,10 +16128,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 6
+      - 13
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2172
+  - uid: 2164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16100,7 +16139,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2173
+  - uid: 2165
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16108,7 +16147,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2174
+  - uid: 2166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16116,20 +16155,20 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 17
+      - 24
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2175
+  - uid: 2167
     components:
     - type: Transform
       pos: -35.5,10.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 18
+      - 25
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2176
+  - uid: 2168
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16137,10 +16176,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 19
+      - 26
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2177
+  - uid: 2169
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16148,10 +16187,10 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 21
+      - 28
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 2178
+  - uid: 2170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16161,1473 +16200,1477 @@ entities:
       color: '#FF0000FF'
     - type: DeviceNetwork
       deviceLists:
-      - 15
+      - 22
 - proto: GasVentScrubberFreezer
   entities:
-  - uid: 2180
+  - uid: 2171
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 36
+      - 42
     - type: AtmosPipeColor
       color: '#FF0000FF'
 - proto: GasVentScrubberVox
   entities:
-  - uid: 2141
+  - uid: 2172
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -17.5,-5.5
       parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 37
     - type: AtmosPipeColor
-      color: '#FF0000FF'
-  - uid: 2143
+      color: '#FF1212FF'
+  - uid: 2173
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -15.5,-5.5
       parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 37
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#FF1212FF'
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 2183
+  - uid: 2174
     components:
     - type: Transform
       pos: -44.5,9.5
       parent: 2
-  - uid: 2184
+  - uid: 2175
     components:
     - type: Transform
       pos: -44.5,8.5
       parent: 2
 - proto: GravityGenerator
   entities:
-  - uid: 2185
+  - uid: 2176
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 2
 - proto: Grille
   entities:
-  - uid: 2186
+  - uid: 2177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -46.5,-13.5
+      parent: 2
+  - uid: 2178
     components:
     - type: Transform
       pos: -23.5,13.5
       parent: 2
-  - uid: 2187
+  - uid: 2179
     components:
     - type: Transform
       pos: -25.5,13.5
       parent: 2
-  - uid: 2188
+  - uid: 2180
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 2
-  - uid: 2189
+  - uid: 2181
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 2
-  - uid: 2190
+  - uid: 2182
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 2
-  - uid: 2191
+  - uid: 2183
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
-  - uid: 2192
+  - uid: 2184
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 2193
+  - uid: 2185
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 2194
+  - uid: 2186
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 2195
+  - uid: 2187
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 2196
+  - uid: 2188
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 2197
+  - uid: 2189
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
-  - uid: 2198
+  - uid: 2190
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 2
-  - uid: 2199
+  - uid: 2191
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
-  - uid: 2200
+  - uid: 2192
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 2
-  - uid: 2201
+  - uid: 2193
     components:
     - type: Transform
       pos: -10.5,-11.5
       parent: 2
-  - uid: 2204
+  - uid: 2194
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 2
-  - uid: 2205
+  - uid: 2195
     components:
     - type: Transform
       pos: -21.5,9.5
       parent: 2
-  - uid: 2206
+  - uid: 2196
     components:
     - type: Transform
       pos: -20.5,9.5
       parent: 2
-  - uid: 2207
+  - uid: 2197
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 2
-  - uid: 2208
+  - uid: 2198
     components:
     - type: Transform
       pos: -18.5,9.5
       parent: 2
-  - uid: 2209
+  - uid: 2199
     components:
     - type: Transform
       pos: -20.5,0.5
       parent: 2
-  - uid: 2210
+  - uid: 2200
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
-  - uid: 2211
+  - uid: 2201
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 2212
+  - uid: 2202
     components:
     - type: Transform
       pos: -32.5,-15.5
       parent: 2
-  - uid: 2213
+  - uid: 2203
     components:
     - type: Transform
       pos: -34.5,-14.5
       parent: 2
-  - uid: 2214
+  - uid: 2204
     components:
     - type: Transform
       pos: -34.5,-13.5
       parent: 2
-  - uid: 2215
+  - uid: 2205
     components:
     - type: Transform
       pos: -34.5,-19.5
       parent: 2
-  - uid: 2216
+  - uid: 2206
     components:
     - type: Transform
       pos: -34.5,-18.5
       parent: 2
-  - uid: 2218
+  - uid: 2207
     components:
     - type: Transform
       pos: -25.5,0.5
       parent: 2
-  - uid: 2219
+  - uid: 2208
     components:
     - type: Transform
       pos: -26.5,0.5
       parent: 2
-  - uid: 2220
+  - uid: 2209
     components:
     - type: Transform
       pos: -28.5,0.5
       parent: 2
-  - uid: 2221
+  - uid: 2210
     components:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
-  - uid: 2222
+  - uid: 2211
     components:
     - type: Transform
       pos: -28.5,12.5
       parent: 2
-  - uid: 2223
+  - uid: 2212
     components:
     - type: Transform
       pos: -29.5,12.5
       parent: 2
-  - uid: 2224
+  - uid: 2213
     components:
     - type: Transform
       pos: -30.5,12.5
       parent: 2
-  - uid: 2225
+  - uid: 2214
     components:
     - type: Transform
       pos: -31.5,12.5
       parent: 2
-  - uid: 2226
+  - uid: 2215
     components:
     - type: Transform
       pos: -32.5,12.5
       parent: 2
-  - uid: 2227
+  - uid: 2216
     components:
     - type: Transform
       pos: -45.5,4.5
       parent: 2
-  - uid: 2228
+  - uid: 2217
     components:
     - type: Transform
       pos: -45.5,5.5
       parent: 2
-  - uid: 2229
+  - uid: 2218
     components:
     - type: Transform
       pos: -45.5,6.5
       parent: 2
-  - uid: 2230
+  - uid: 2219
     components:
     - type: Transform
       pos: -46.5,19.5
       parent: 2
-  - uid: 2231
+  - uid: 2220
     components:
     - type: Transform
       pos: -45.5,-34.5
       parent: 2
-  - uid: 2232
+  - uid: 2221
     components:
     - type: Transform
       pos: -26.5,15.5
       parent: 2
-  - uid: 2233
+  - uid: 2222
     components:
     - type: Transform
       pos: -24.5,14.5
       parent: 2
-  - uid: 2234
+  - uid: 2223
     components:
     - type: Transform
       pos: -26.5,14.5
       parent: 2
-  - uid: 2235
+  - uid: 2224
     components:
     - type: Transform
       pos: -21.5,12.5
       parent: 2
-  - uid: 2236
+  - uid: 2225
     components:
     - type: Transform
       pos: -28.5,15.5
       parent: 2
-  - uid: 2237
+  - uid: 2226
     components:
     - type: Transform
       pos: -29.5,14.5
       parent: 2
-  - uid: 2238
+  - uid: 2227
     components:
     - type: Transform
       pos: -30.5,15.5
       parent: 2
-  - uid: 2239
+  - uid: 2228
     components:
     - type: Transform
       pos: -31.5,15.5
       parent: 2
-  - uid: 2240
+  - uid: 2229
     components:
     - type: Transform
       pos: -30.5,13.5
       parent: 2
-  - uid: 2241
+  - uid: 2230
     components:
     - type: Transform
       pos: -32.5,14.5
       parent: 2
-  - uid: 2242
+  - uid: 2231
     components:
     - type: Transform
       pos: -21.5,10.5
       parent: 2
-  - uid: 2243
+  - uid: 2232
     components:
     - type: Transform
       pos: -47.5,-11.5
       parent: 2
-  - uid: 2244
+  - uid: 2233
     components:
     - type: Transform
       pos: -46.5,-4.5
       parent: 2
-  - uid: 2245
+  - uid: 2234
     components:
     - type: Transform
       pos: -49.5,-6.5
       parent: 2
-  - uid: 2246
+  - uid: 2235
     components:
     - type: Transform
       pos: -49.5,-7.5
       parent: 2
-  - uid: 2247
+  - uid: 2236
     components:
     - type: Transform
       pos: -50.5,-14.5
       parent: 2
-  - uid: 2248
+  - uid: 2237
     components:
     - type: Transform
       pos: -48.5,-14.5
       parent: 2
-  - uid: 2249
-    components:
-    - type: Transform
-      pos: -34.5,-5.5
-      parent: 2
-  - uid: 2250
+  - uid: 2239
     components:
     - type: Transform
       pos: -34.5,-10.5
       parent: 2
-  - uid: 2251
+  - uid: 2240
     components:
     - type: Transform
       pos: -34.5,-8.5
       parent: 2
-  - uid: 2252
+  - uid: 2241
     components:
     - type: Transform
       pos: -45.5,-4.5
       parent: 2
-  - uid: 2253
+  - uid: 2242
     components:
     - type: Transform
       pos: -45.5,-5.5
       parent: 2
-  - uid: 2254
+  - uid: 2243
     components:
     - type: Transform
       pos: -46.5,-14.5
       parent: 2
-  - uid: 2255
+  - uid: 2244
     components:
     - type: Transform
       pos: -51.5,-23.5
       parent: 2
-  - uid: 2256
+  - uid: 2245
     components:
     - type: Transform
       pos: -42.5,17.5
       parent: 2
-  - uid: 2257
+  - uid: 2246
     components:
     - type: Transform
       pos: -43.5,17.5
       parent: 2
-  - uid: 2258
+  - uid: 2247
     components:
     - type: Transform
       pos: -51.5,-19.5
       parent: 2
-  - uid: 2259
+  - uid: 2248
     components:
     - type: Transform
       pos: -44.5,-9.5
       parent: 2
-  - uid: 2262
+  - uid: 2249
     components:
     - type: Transform
       pos: -35.5,-24.5
       parent: 2
-  - uid: 2263
+  - uid: 2250
     components:
     - type: Transform
       pos: -37.5,-24.5
       parent: 2
-  - uid: 2264
+  - uid: 2251
     components:
     - type: Transform
       pos: -36.5,-24.5
       parent: 2
-  - uid: 2265
+  - uid: 2252
     components:
     - type: Transform
       pos: -37.5,-30.5
       parent: 2
-  - uid: 2266
+  - uid: 2253
     components:
     - type: Transform
       pos: -36.5,-30.5
       parent: 2
-  - uid: 2267
+  - uid: 2254
     components:
     - type: Transform
       pos: -35.5,-30.5
       parent: 2
-  - uid: 2268
+  - uid: 2255
     components:
     - type: Transform
       pos: -34.5,-30.5
       parent: 2
-  - uid: 2269
+  - uid: 2256
     components:
     - type: Transform
       pos: -33.5,-30.5
       parent: 2
-  - uid: 2270
+  - uid: 2257
     components:
     - type: Transform
       pos: -32.5,-30.5
       parent: 2
-  - uid: 2271
+  - uid: 2258
     components:
     - type: Transform
       pos: -31.5,-30.5
       parent: 2
-  - uid: 2272
+  - uid: 2259
     components:
     - type: Transform
       pos: -29.5,-28.5
       parent: 2
-  - uid: 2273
+  - uid: 2260
     components:
     - type: Transform
       pos: -29.5,-27.5
       parent: 2
-  - uid: 2274
+  - uid: 2261
     components:
     - type: Transform
       pos: -31.5,-25.5
       parent: 2
-  - uid: 2275
+  - uid: 2262
     components:
     - type: Transform
       pos: -44.5,-28.5
       parent: 2
-  - uid: 2276
+  - uid: 2263
     components:
     - type: Transform
       pos: -50.5,-0.5
       parent: 2
-  - uid: 2277
+  - uid: 2264
     components:
     - type: Transform
       pos: -50.5,-1.5
       parent: 2
-  - uid: 2278
+  - uid: 2265
     components:
     - type: Transform
       pos: -50.5,-2.5
       parent: 2
-  - uid: 2279
+  - uid: 2266
     components:
     - type: Transform
       pos: -48.5,-2.5
       parent: 2
-  - uid: 2280
+  - uid: 2267
     components:
     - type: Transform
       pos: -48.5,-1.5
       parent: 2
-  - uid: 2281
+  - uid: 2268
     components:
     - type: Transform
       pos: -48.5,-3.5
       parent: 2
-  - uid: 2282
+  - uid: 2269
     components:
     - type: Transform
       pos: -49.5,-4.5
       parent: 2
-  - uid: 2283
+  - uid: 2270
     components:
     - type: Transform
       pos: -47.5,-6.5
       parent: 2
-  - uid: 2284
+  - uid: 2271
     components:
     - type: Transform
       pos: -47.5,-5.5
       parent: 2
-  - uid: 2285
+  - uid: 2272
     components:
     - type: Transform
       pos: -47.5,-8.5
       parent: 2
-  - uid: 2286
+  - uid: 2273
     components:
     - type: Transform
       pos: -48.5,-8.5
       parent: 2
-  - uid: 2287
+  - uid: 2274
     components:
     - type: Transform
       pos: -49.5,-9.5
       parent: 2
-  - uid: 2288
+  - uid: 2275
     components:
     - type: Transform
       pos: -49.5,-10.5
       parent: 2
-  - uid: 2289
+  - uid: 2276
     components:
     - type: Transform
       pos: -48.5,-12.5
       parent: 2
-  - uid: 2290
+  - uid: 2277
     components:
     - type: Transform
       pos: -49.5,-12.5
       parent: 2
-  - uid: 2291
+  - uid: 2278
     components:
     - type: Transform
       pos: -47.5,-10.5
       parent: 2
-  - uid: 2292
+  - uid: 2279
     components:
     - type: Transform
       pos: -15.5,10.5
       parent: 2
-  - uid: 2293
+  - uid: 2280
     components:
     - type: Transform
       pos: -15.5,12.5
       parent: 2
-  - uid: 2294
+  - uid: 2281
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
-  - uid: 2295
+  - uid: 2282
     components:
     - type: Transform
       pos: -14.5,12.5
       parent: 2
-  - uid: 2296
+  - uid: 2283
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 2
-  - uid: 2297
+  - uid: 2284
     components:
     - type: Transform
       pos: -19.5,11.5
       parent: 2
-  - uid: 2298
+  - uid: 2285
     components:
     - type: Transform
       pos: -17.5,10.5
       parent: 2
-  - uid: 2299
+  - uid: 2286
     components:
     - type: Transform
       pos: -18.5,10.5
       parent: 2
-  - uid: 2300
+  - uid: 2287
     components:
     - type: Transform
       pos: -19.5,12.5
       parent: 2
-  - uid: 2301
+  - uid: 2288
     components:
     - type: Transform
       pos: -52.5,11.5
       parent: 2
-  - uid: 2302
+  - uid: 2289
     components:
     - type: Transform
       pos: -20.5,12.5
       parent: 2
-  - uid: 2303
+  - uid: 2290
     components:
     - type: Transform
       pos: -22.5,10.5
       parent: 2
-  - uid: 2304
+  - uid: 2291
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 2
-  - uid: 2305
+  - uid: 2292
     components:
     - type: Transform
       pos: -23.5,11.5
       parent: 2
-  - uid: 2306
+  - uid: 2293
     components:
     - type: Transform
       pos: -12.5,12.5
       parent: 2
-  - uid: 2307
+  - uid: 2294
     components:
     - type: Transform
       pos: -11.5,12.5
       parent: 2
-  - uid: 2308
+  - uid: 2295
     components:
     - type: Transform
       pos: -13.5,12.5
       parent: 2
-  - uid: 2309
+  - uid: 2296
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 2
-  - uid: 2310
+  - uid: 2297
     components:
     - type: Transform
       pos: -8.5,12.5
       parent: 2
-  - uid: 2311
+  - uid: 2298
     components:
     - type: Transform
       pos: -9.5,12.5
       parent: 2
-  - uid: 2312
+  - uid: 2299
     components:
     - type: Transform
       pos: -6.5,13.5
       parent: 2
-  - uid: 2313
+  - uid: 2300
     components:
     - type: Transform
       pos: -52.5,12.5
       parent: 2
-  - uid: 2314
+  - uid: 2301
     components:
     - type: Transform
       pos: -52.5,14.5
       parent: 2
-  - uid: 2315
+  - uid: 2302
     components:
     - type: Transform
       pos: -51.5,15.5
       parent: 2
-  - uid: 2316
+  - uid: 2303
     components:
     - type: Transform
       pos: -50.5,15.5
       parent: 2
-  - uid: 2317
+  - uid: 2304
     components:
     - type: Transform
       pos: -48.5,16.5
       parent: 2
-  - uid: 2318
+  - uid: 2305
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 2
-  - uid: 2319
+  - uid: 2306
     components:
     - type: Transform
       pos: -53.5,10.5
       parent: 2
-  - uid: 2320
+  - uid: 2307
     components:
     - type: Transform
       pos: -54.5,9.5
       parent: 2
-  - uid: 2321
+  - uid: 2308
     components:
     - type: Transform
       pos: -54.5,8.5
       parent: 2
-  - uid: 2322
+  - uid: 2309
     components:
     - type: Transform
       pos: -55.5,10.5
       parent: 2
-  - uid: 2323
+  - uid: 2310
     components:
     - type: Transform
       pos: -55.5,11.5
       parent: 2
-  - uid: 2324
+  - uid: 2311
     components:
     - type: Transform
       pos: -54.5,12.5
       parent: 2
-  - uid: 2325
+  - uid: 2312
     components:
     - type: Transform
       pos: -55.5,6.5
       parent: 2
-  - uid: 2326
+  - uid: 2313
     components:
     - type: Transform
       pos: -54.5,5.5
       parent: 2
-  - uid: 2327
+  - uid: 2314
     components:
     - type: Transform
       pos: -54.5,4.5
       parent: 2
-  - uid: 2328
+  - uid: 2315
     components:
     - type: Transform
       pos: -54.5,7.5
       parent: 2
-  - uid: 2329
+  - uid: 2316
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-  - uid: 2330
+  - uid: 2317
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
-  - uid: 2331
+  - uid: 2318
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 2
-  - uid: 2332
+  - uid: 2319
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
-  - uid: 2333
+  - uid: 2320
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
-  - uid: 2334
+  - uid: 2321
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 2335
+  - uid: 2322
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 2336
+  - uid: 2323
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
-  - uid: 2337
+  - uid: 2324
     components:
     - type: Transform
       pos: -45.5,17.5
       parent: 2
-  - uid: 2338
+  - uid: 2325
     components:
     - type: Transform
       pos: -51.5,-22.5
       parent: 2
-  - uid: 2339
+  - uid: 2326
     components:
     - type: Transform
       pos: -51.5,-24.5
       parent: 2
-  - uid: 2340
+  - uid: 2327
     components:
     - type: Transform
       pos: -51.5,-25.5
       parent: 2
-  - uid: 2341
+  - uid: 2328
     components:
     - type: Transform
       pos: -48.5,-13.5
       parent: 2
-  - uid: 2342
+  - uid: 2329
     components:
     - type: Transform
       pos: -50.5,-13.5
       parent: 2
-  - uid: 2343
+  - uid: 2330
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 2
-  - uid: 2344
+  - uid: 2331
     components:
     - type: Transform
       pos: -33.5,8.5
       parent: 2
-  - uid: 2345
+  - uid: 2332
     components:
     - type: Transform
       pos: -51.5,-27.5
       parent: 2
-  - uid: 2346
+  - uid: 2333
     components:
     - type: Transform
       pos: -39.5,-31.5
       parent: 2
-  - uid: 2347
+  - uid: 2334
     components:
     - type: Transform
       pos: -41.5,-31.5
       parent: 2
-  - uid: 2348
+  - uid: 2335
     components:
     - type: Transform
       pos: -39.5,-32.5
       parent: 2
-  - uid: 2349
+  - uid: 2336
     components:
     - type: Transform
       pos: -40.5,-33.5
       parent: 2
-  - uid: 2350
+  - uid: 2337
     components:
     - type: Transform
       pos: -39.5,-33.5
       parent: 2
-  - uid: 2351
+  - uid: 2338
     components:
     - type: Transform
       pos: -37.5,-33.5
       parent: 2
-  - uid: 2352
+  - uid: 2339
     components:
     - type: Transform
       pos: -36.5,-31.5
       parent: 2
-  - uid: 2353
+  - uid: 2340
     components:
     - type: Transform
       pos: -36.5,-32.5
       parent: 2
-  - uid: 2354
+  - uid: 2341
     components:
     - type: Transform
       pos: -34.5,-33.5
       parent: 2
-  - uid: 2355
+  - uid: 2342
     components:
     - type: Transform
       pos: -32.5,-31.5
       parent: 2
-  - uid: 2356
+  - uid: 2343
     components:
     - type: Transform
       pos: -33.5,-32.5
       parent: 2
-  - uid: 2357
+  - uid: 2344
     components:
     - type: Transform
       pos: -31.5,-31.5
       parent: 2
-  - uid: 2358
+  - uid: 2345
     components:
     - type: Transform
       pos: -32.5,-33.5
       parent: 2
-  - uid: 2359
+  - uid: 2346
     components:
     - type: Transform
       pos: -31.5,-33.5
       parent: 2
-  - uid: 2360
+  - uid: 2347
     components:
     - type: Transform
       pos: -30.5,-33.5
       parent: 2
-  - uid: 2361
+  - uid: 2348
     components:
     - type: Transform
       pos: -29.5,-31.5
       parent: 2
-  - uid: 2362
+  - uid: 2349
     components:
     - type: Transform
       pos: -28.5,-33.5
       parent: 2
-  - uid: 2363
+  - uid: 2350
     components:
     - type: Transform
       pos: -28.5,-30.5
       parent: 2
-  - uid: 2364
+  - uid: 2351
     components:
     - type: Transform
       pos: -26.5,-29.5
       parent: 2
-  - uid: 2365
+  - uid: 2352
     components:
     - type: Transform
       pos: -26.5,-30.5
       parent: 2
-  - uid: 2366
+  - uid: 2353
     components:
     - type: Transform
       pos: -25.5,-31.5
       parent: 2
-  - uid: 2367
+  - uid: 2354
     components:
     - type: Transform
       pos: -26.5,-32.5
       parent: 2
-  - uid: 2368
+  - uid: 2355
     components:
     - type: Transform
       pos: -27.5,-32.5
       parent: 2
-  - uid: 2369
+  - uid: 2356
     components:
     - type: Transform
       pos: -34.5,-31.5
       parent: 2
-  - uid: 2370
+  - uid: 2357
     components:
     - type: Transform
       pos: -42.5,-33.5
       parent: 2
-  - uid: 2371
+  - uid: 2358
     components:
     - type: Transform
       pos: -44.5,-32.5
       parent: 2
-  - uid: 2372
+  - uid: 2359
     components:
     - type: Transform
       pos: -43.5,-31.5
       parent: 2
-  - uid: 2373
+  - uid: 2360
     components:
     - type: Transform
       pos: -43.5,-33.5
       parent: 2
-  - uid: 2374
+  - uid: 2361
     components:
     - type: Transform
       pos: -35.5,-33.5
       parent: 2
-  - uid: 2375
+  - uid: 2362
     components:
     - type: Transform
       pos: -38.5,-31.5
       parent: 2
-  - uid: 2376
+  - uid: 2363
     components:
     - type: Transform
       pos: -51.5,-28.5
       parent: 2
-  - uid: 2377
+  - uid: 2364
     components:
     - type: Transform
       pos: -51.5,-30.5
       parent: 2
-  - uid: 2378
+  - uid: 2365
     components:
     - type: Transform
       pos: -27.5,-17.5
       parent: 2
-  - uid: 2379
+  - uid: 2366
     components:
     - type: Transform
       pos: -27.5,-18.5
       parent: 2
-  - uid: 2380
+  - uid: 2367
     components:
     - type: Transform
       pos: -27.5,-19.5
       parent: 2
-  - uid: 2381
+  - uid: 2368
     components:
     - type: Transform
       pos: -49.5,-34.5
       parent: 2
-  - uid: 2382
+  - uid: 2369
     components:
     - type: Transform
       pos: -51.5,-31.5
       parent: 2
-  - uid: 2383
+  - uid: 2370
     components:
     - type: Transform
       pos: -51.5,-33.5
       parent: 2
-  - uid: 2384
+  - uid: 2371
     components:
     - type: Transform
       pos: -50.5,-35.5
       parent: 2
-  - uid: 2385
+  - uid: 2372
     components:
     - type: Transform
       pos: -48.5,-35.5
       parent: 2
-  - uid: 2386
+  - uid: 2373
     components:
     - type: Transform
       pos: -47.5,-34.5
       parent: 2
-  - uid: 2387
+  - uid: 2374
     components:
     - type: Transform
       pos: -47.5,-33.5
       parent: 2
-  - uid: 2388
+  - uid: 2375
     components:
     - type: Transform
       pos: -46.5,-35.5
       parent: 2
-  - uid: 2389
+  - uid: 2376
     components:
     - type: Transform
       pos: -39.5,17.5
       parent: 2
-  - uid: 2390
+  - uid: 2377
     components:
     - type: Transform
       pos: -40.5,17.5
       parent: 2
-  - uid: 2391
+  - uid: 2378
     components:
     - type: Transform
       pos: -44.5,19.5
       parent: 2
-  - uid: 2392
+  - uid: 2379
     components:
     - type: Transform
       pos: -43.5,19.5
       parent: 2
-  - uid: 2393
+  - uid: 2380
     components:
     - type: Transform
       pos: -38.5,19.5
       parent: 2
-  - uid: 2394
+  - uid: 2381
     components:
     - type: Transform
       pos: -41.5,19.5
       parent: 2
-  - uid: 2395
+  - uid: 2382
     components:
     - type: Transform
       pos: -38.5,18.5
       parent: 2
-  - uid: 2396
+  - uid: 2383
     components:
     - type: Transform
       pos: -35.5,18.5
       parent: 2
-  - uid: 2397
+  - uid: 2384
     components:
     - type: Transform
       pos: -34.5,18.5
       parent: 2
-  - uid: 2398
+  - uid: 2385
     components:
     - type: Transform
       pos: -36.5,19.5
       parent: 2
-  - uid: 2399
+  - uid: 2386
     components:
     - type: Transform
       pos: -49.5,18.5
       parent: 2
-  - uid: 2400
+  - uid: 2387
     components:
     - type: Transform
       pos: -49.5,17.5
       parent: 2
-  - uid: 2401
+  - uid: 2388
     components:
     - type: Transform
       pos: -51.5,10.5
       parent: 2
-  - uid: 2402
+  - uid: 2389
     components:
     - type: Transform
       pos: -29.5,15.5
       parent: 2
-  - uid: 2403
+  - uid: 2390
     components:
     - type: Transform
       pos: -28.5,13.5
       parent: 2
-  - uid: 2404
+  - uid: 2391
     components:
     - type: Transform
       pos: -32.5,15.5
       parent: 2
-  - uid: 2405
+  - uid: 2392
     components:
     - type: Transform
       pos: -31.5,13.5
       parent: 2
-  - uid: 2406
+  - uid: 2393
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 2
-  - uid: 2407
+  - uid: 2394
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 2
-  - uid: 2408
+  - uid: 2395
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 2
-  - uid: 2409
+  - uid: 2396
     components:
     - type: Transform
       pos: -7.5,13.5
       parent: 2
-  - uid: 2410
+  - uid: 2397
     components:
     - type: Transform
       pos: -45.5,19.5
       parent: 2
-  - uid: 2411
+  - uid: 2398
     components:
     - type: Transform
       pos: -47.5,19.5
       parent: 2
-  - uid: 2412
+  - uid: 2399
     components:
     - type: Transform
       pos: -40.5,19.5
       parent: 2
-  - uid: 2413
+  - uid: 2400
     components:
     - type: Transform
       pos: -24.5,13.5
       parent: 2
-  - uid: 2414
+  - uid: 2401
     components:
     - type: Transform
       pos: -27.5,13.5
       parent: 2
-  - uid: 2415
+  - uid: 2402
     components:
     - type: Transform
       pos: -51.5,17.5
       parent: 2
-  - uid: 2416
+  - uid: 2403
     components:
     - type: Transform
       pos: -52.5,17.5
       parent: 2
-  - uid: 2417
+  - uid: 2404
     components:
     - type: Transform
       pos: -53.5,16.5
       parent: 2
-  - uid: 2418
+  - uid: 2405
     components:
     - type: Transform
       pos: -54.5,15.5
       parent: 2
-  - uid: 2419
+  - uid: 2406
     components:
     - type: Transform
       pos: -54.5,14.5
       parent: 2
-  - uid: 2420
+  - uid: 2407
     components:
     - type: Transform
       pos: -51.5,-34.5
       parent: 2
-  - uid: 2421
+  - uid: 2408
     components:
     - type: Transform
       pos: -41.5,17.5
       parent: 2
-  - uid: 2422
+  - uid: 2409
     components:
     - type: Transform
       pos: -44.5,17.5
       parent: 2
-  - uid: 2519
+  - uid: 2410
     components:
     - type: Transform
       pos: -40.5,10.5
       parent: 2
-  - uid: 2522
+  - uid: 2411
     components:
     - type: Transform
       pos: -40.5,8.5
       parent: 2
-  - uid: 2555
+  - uid: 2412
     components:
     - type: Transform
       pos: -40.5,4.5
       parent: 2
-  - uid: 2560
+  - uid: 2413
     components:
     - type: Transform
       pos: -40.5,6.5
       parent: 2
-  - uid: 2563
+  - uid: 2414
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
-  - uid: 2736
+  - uid: 2415
     components:
     - type: Transform
       pos: -38.5,0.5
       parent: 2
-  - uid: 3142
+  - uid: 2416
     components:
     - type: Transform
       pos: -23.5,5.5
       parent: 2
-  - uid: 3698
+  - uid: 2417
     components:
     - type: Transform
       pos: -37.5,0.5
       parent: 2
 - proto: HandheldHealthAnalyzer
   entities:
-  - uid: 3583
+  - uid: 2418
     components:
     - type: Transform
-      pos: -38.529285,-9.6055155
+      pos: -43.673084,-2.4249458
       parent: 2
 - proto: HandHeldMassScanner
   entities:
-  - uid: 2423
+  - uid: 2419
     components:
     - type: Transform
-      pos: -16.802523,-7.2631845
+      pos: -15.46803,-10.428049
       parent: 2
-  - uid: 2424
+  - uid: 2420
     components:
     - type: Transform
-      pos: -16.550894,-7.360398
+      pos: -15.749281,-10.428049
       parent: 2
-  - uid: 2425
+  - uid: 2421
     components:
     - type: Transform
       pos: -43.302338,11.589426
       parent: 2
-  - uid: 2426
+  - uid: 2422
     components:
     - type: Transform
       pos: -22.587778,-6.411066
       parent: 2
 - proto: HolofanProjector
   entities:
-  - uid: 2427
+  - uid: 2423
     components:
     - type: Transform
       pos: -43.614838,11.448801
       parent: 2
 - proto: HolopadCargoBay
   entities:
-  - uid: 2428
+  - uid: 2424
     components:
     - type: Transform
       pos: -10.5,-9.5
       parent: 2
+- proto: HolopadCargoBayLongRange
+  entities:
+  - uid: 2425
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 2
 - proto: HolopadCargoMailroom
   entities:
-  - uid: 2429
+  - uid: 2426
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 2
 - proto: HolopadCargoSalvageBay
   entities:
-  - uid: 2430
+  - uid: 2427
     components:
     - type: Transform
       pos: -18.5,-9.5
       parent: 2
 - proto: HolopadCommandBridge
   entities:
-  - uid: 3717
+  - uid: 2428
     components:
     - type: Transform
       pos: -35.5,-26.5
       parent: 2
 - proto: HolopadCommandBridgeLongRange
   entities:
-  - uid: 3743
+  - uid: 2429
     components:
     - type: Transform
       pos: -37.5,-26.5
       parent: 2
 - proto: HolopadCommandCaptain
   entities:
-  - uid: 2433
+  - uid: 2430
     components:
     - type: Transform
       pos: -43.5,-28.5
       parent: 2
 - proto: HolopadCommandHop
   entities:
-  - uid: 2434
+  - uid: 2431
     components:
     - type: Transform
       pos: -31.5,-23.5
       parent: 2
 - proto: HolopadEngineeringFront
   entities:
-  - uid: 2435
+  - uid: 2432
     components:
     - type: Transform
       pos: -39.5,0.5
       parent: 2
 - proto: HolopadEngineeringMain
   entities:
-  - uid: 2436
+  - uid: 2433
     components:
     - type: Transform
       pos: -43.5,7.5
       parent: 2
 - proto: HolopadEngineeringTelecoms
   entities:
-  - uid: 2437
+  - uid: 2434
     components:
     - type: Transform
       pos: -42.5,-24.5
       parent: 2
 - proto: HolopadGeneralDisposals
   entities:
-  - uid: 2438
+  - uid: 2435
     components:
     - type: Transform
       pos: -29.5,-8.5
       parent: 2
 - proto: HolopadGeneralEvac
   entities:
-  - uid: 2439
+  - uid: 2436
     components:
     - type: Transform
       pos: -42.5,-17.5
       parent: 2
 - proto: HolopadMedicalChemistry
   entities:
-  - uid: 2440
+  - uid: 2437
     components:
     - type: Transform
       pos: -25.5,5.5
       parent: 2
 - proto: HolopadMedicalClinic
   entities:
-  - uid: 2441
+  - uid: 2438
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 2
 - proto: HolopadMedicalMorgue
   entities:
-  - uid: 2442
+  - uid: 2439
     components:
     - type: Transform
       pos: -36.5,5.5
       parent: 2
 - proto: HolopadMedicalSurgery
   entities:
-  - uid: 2443
+  - uid: 2440
     components:
     - type: Transform
       pos: -36.5,9.5
       parent: 2
 - proto: HolopadScienceFront
   entities:
-  - uid: 2444
+  - uid: 2441
     components:
     - type: Transform
       pos: -39.5,-7.5
       parent: 2
 - proto: HolopadSecurityBrig
   entities:
-  - uid: 2445
+  - uid: 2442
     components:
     - type: Transform
       pos: -29.5,-12.5
       parent: 2
 - proto: HolopadSecurityFront
   entities:
-  - uid: 2446
+  - uid: 2443
     components:
     - type: Transform
       pos: -32.5,-17.5
       parent: 2
 - proto: HolopadServiceBar
   entities:
-  - uid: 2447
+  - uid: 2444
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 2
 - proto: HolopadServiceBotany
   entities:
-  - uid: 2448
+  - uid: 2445
     components:
     - type: Transform
       pos: -19.5,6.5
       parent: 2
 - proto: HolopadServiceKitchen
   entities:
-  - uid: 2449
+  - uid: 2446
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 2
 - proto: HospitalCurtains
   entities:
-  - uid: 2450
+  - uid: 2447
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 2
-  - uid: 2451
+  - uid: 2448
     components:
     - type: Transform
       pos: -33.5,8.5
       parent: 2
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 2453
+  - uid: 2449
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-13.5
       parent: 2
-  - uid: 2454
+  - uid: 2450
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17635,76 +17678,76 @@ entities:
       parent: 2
 - proto: HydroponicsToolClippers
   entities:
-  - uid: 2455
+  - uid: 2451
     components:
     - type: Transform
       pos: -19.54595,5.569868
       parent: 2
 - proto: HydroponicsToolMiniHoe
   entities:
-  - uid: 2456
+  - uid: 2452
     components:
     - type: Transform
       pos: -19.493866,5.5594516
       parent: 2
 - proto: HydroponicsToolSpade
   entities:
-  - uid: 2457
+  - uid: 2453
     components:
     - type: Transform
       pos: -19.379284,5.5282016
       parent: 2
 - proto: hydroponicsTray
   entities:
-  - uid: 2458
+  - uid: 2454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,8.5
       parent: 2
-  - uid: 2459
+  - uid: 2455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,1.5
       parent: 2
-  - uid: 2460
+  - uid: 2456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,3.5
       parent: 2
-  - uid: 2461
+  - uid: 2457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,4.5
       parent: 2
-  - uid: 2462
+  - uid: 2458
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,5.5
       parent: 2
-  - uid: 2463
+  - uid: 2459
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,3.5
       parent: 2
-  - uid: 2464
+  - uid: 2460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,4.5
       parent: 2
-  - uid: 2465
+  - uid: 2461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,1.5
       parent: 2
-  - uid: 2466
+  - uid: 2462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17712,25 +17755,25 @@ entities:
       parent: 2
 - proto: IngotGold
   entities:
-  - uid: 1262
+  - uid: 2464
     components:
     - type: Transform
-      parent: 3716
+      parent: 2463
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: IngotSilver
   entities:
-  - uid: 1263
+  - uid: 2465
     components:
     - type: Transform
-      parent: 3716
+      parent: 2463
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: IngotSilver1
   entities:
-  - uid: 2467
+  - uid: 2466
     components:
     - type: Transform
       pos: -26.675043,-12.913063
@@ -17739,7 +17782,7 @@ entities:
       count: 2
 - proto: InsulsCabinetFilled
   entities:
-  - uid: 2562
+  - uid: 2467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17779,7 +17822,7 @@ entities:
       fixtures: {}
 - proto: IntercomMedical
   entities:
-  - uid: 3662
+  - uid: 2471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17789,7 +17832,7 @@ entities:
       fixtures: {}
 - proto: IntercomScience
   entities:
-  - uid: 1077
+  - uid: 2472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17799,7 +17842,7 @@ entities:
       fixtures: {}
 - proto: IntercomSecurity
   entities:
-  - uid: 2471
+  - uid: 2473
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17809,7 +17852,7 @@ entities:
       fixtures: {}
 - proto: IntercomService
   entities:
-  - uid: 3673
+  - uid: 2474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17819,7 +17862,7 @@ entities:
       fixtures: {}
 - proto: IntercomSupply
   entities:
-  - uid: 2586
+  - uid: 2475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17827,9 +17870,16 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: ItemBouquet
+  entities:
+  - uid: 1290
+    components:
+    - type: Transform
+      pos: -25.582962,10.902797
+      parent: 2
 - proto: JanitorialTrolley
   entities:
-  - uid: 166
+  - uid: 2476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17837,172 +17887,188 @@ entities:
       parent: 2
 - proto: JetpackMiniFilled
   entities:
-  - uid: 2473
+  - uid: 2477
     components:
     - type: Transform
       pos: -22.509653,-6.473566
       parent: 2
-- proto: Joint
-  entities:
-  - uid: 2474
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -41.538464,1.0941627
-      parent: 2
 - proto: Jukebox
   entities:
-  - uid: 2475
+  - uid: 2478
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
 - proto: JumperUnitCabinetFilled
   entities:
-  - uid: 3582
+  - uid: 2479
     components:
     - type: Transform
-      pos: -44.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-3.5
       parent: 2
 - proto: KitchenElectricGrill
   entities:
-  - uid: 2476
+  - uid: 2480
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 2
 - proto: KitchenKnife
   entities:
-  - uid: 2478
+  - uid: 2481
     components:
     - type: Transform
       pos: -17.433336,1.5791962
       parent: 2
 - proto: KitchenMicrowave
   entities:
-  - uid: 2479
+  - uid: 2482
     components:
     - type: Transform
       pos: -33.5,-14.5
       parent: 2
-  - uid: 2480
+  - uid: 2483
     components:
     - type: Transform
       pos: -14.5,5.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 2481
+  - uid: 2484
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
-  - uid: 2482
+  - uid: 2485
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
-- proto: LargeBeaker
+- proto: LampBanana
   entities:
-  - uid: 2432
+  - uid: 8
     components:
     - type: Transform
-      pos: -15.654884,5.7421966
+      pos: -45.489506,-13.083201
+      parent: 2
+    - type: HandheldLight
+      toggleActionEntity: 9
+    - type: ContainerContainer
+      containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9
+    - type: Physics
+      canCollide: True
+    - type: ActionsContainer
+- proto: LargeBeaker
+  entities:
+  - uid: 2486
+    components:
+    - type: Transform
+      pos: -16.331831,5.609236
+      parent: 2
+- proto: LesbianFlag
+  entities:
+  - uid: 2487
+    components:
+    - type: Transform
+      pos: -21.5,-7.5
       parent: 2
 - proto: Lighter
   entities:
-  - uid: 2484
+  - uid: 2488
     components:
     - type: Transform
       pos: -33.246765,-8.32643
       parent: 2
 - proto: LockerAdministrativeAssistantFilled
   entities:
-  - uid: 2485
+  - uid: 3735
     components:
     - type: Transform
-      pos: -40.5,-22.5
+      pos: -42.5,-22.5
       parent: 2
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 2486
+  - uid: 2490
     components:
     - type: Transform
       pos: -44.5,6.5
       parent: 2
 - proto: LockerBoozeFilled
   entities:
-  - uid: 2487
+  - uid: 2491
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
 - proto: LockerBotanistFilled
   entities:
-  - uid: 2488
+  - uid: 2492
     components:
     - type: Transform
       pos: -21.5,8.5
       parent: 2
 - proto: LockerBrigmedicFilled
   entities:
-  - uid: 2494
+  - uid: 2493
     components:
     - type: Transform
       pos: -31.5,-19.5
       parent: 2
 - proto: LockerCaptainFilledHardsuitSyndie
   entities:
-  - uid: 2489
+  - uid: 2494
     components:
     - type: Transform
       pos: -43.5,-27.5
       parent: 2
 - proto: LockerChemistryFilled
   entities:
-  - uid: 1217
+  - uid: 2495
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 2
 - proto: LockerChiefEngineerFilledHardsuit
   entities:
-  - uid: 2491
+  - uid: 2496
     components:
     - type: Transform
       pos: -44.5,4.5
       parent: 2
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 2492
+  - uid: 2497
     components:
     - type: Transform
       pos: -32.5,7.5
       parent: 2
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 2493
+  - uid: 2498
     components:
     - type: Transform
       pos: -44.5,5.5
       parent: 2
 - proto: LockerEvidence
   entities:
-  - uid: 1178
+  - uid: 2499
     components:
     - type: Transform
       pos: -30.5,-19.5
       parent: 2
-- proto: LockerFreezerBase
-  entities:
-  - uid: 2490
-    components:
-    - type: Transform
-      pos: -34.5,11.5
-      parent: 2
 - proto: LockerFreezerVaultFilled
   entities:
-  - uid: 3716
+  - uid: 2463
     components:
     - type: Transform
       pos: -30.5,-26.5
@@ -18021,253 +18087,285 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1263
-          - 1262
+          - 2465
+          - 2464
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: LockerHeadOfPersonnelFilledSyndie
   entities:
-  - uid: 2496
+  - uid: 2500
     components:
     - type: Transform
       pos: -31.5,-22.5
       parent: 2
 - proto: LockerHeadOfSecurityFilledHardsuit
   entities:
-  - uid: 2497
+  - uid: 2501
     components:
     - type: Transform
       pos: -28.5,-21.5
       parent: 2
 - proto: LockerMedicalFilled
   entities:
-  - uid: 2498
+  - uid: 2502
     components:
     - type: Transform
       pos: -32.5,8.5
       parent: 2
+- proto: LockerParamedicFilled
+  entities:
+  - uid: 2503
+    components:
+    - type: Transform
+      pos: -34.5,11.5
+      parent: 2
 - proto: LockerPsychologistFilled
   entities:
-  - uid: 1216
+  - uid: 2504
     components:
     - type: Transform
       pos: -32.5,9.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
-  - uid: 2499
+  - uid: 2505
     components:
     - type: Transform
       pos: -7.5,-10.5
       parent: 2
 - proto: LockerResearchDirectorFilledHardsuit
   entities:
-  - uid: 2500
+  - uid: 2506
     components:
     - type: Transform
       pos: -44.5,-7.5
       parent: 2
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 2501
+  - uid: 2507
     components:
     - type: Transform
       pos: -8.5,-10.5
       parent: 2
 - proto: LockerScienceFilled
   entities:
-  - uid: 2502
+  - uid: 2508
     components:
     - type: Transform
       pos: -44.5,-6.5
       parent: 2
 - proto: LockerSecurityFilled
   entities:
-  - uid: 2477
+  - uid: 2509
     components:
     - type: Transform
       pos: -33.5,-16.5
       parent: 2
-  - uid: 2789
+  - uid: 2510
     components:
     - type: Transform
       pos: -32.5,-16.5
       parent: 2
 - proto: LuxuryPen
   entities:
-  - uid: 1215
+  - uid: 2511
     components:
     - type: Transform
       pos: -36.143875,-25.511189
       parent: 2
 - proto: MachineAnomalyGenerator
   entities:
-  - uid: 2505
+  - uid: 2512
     components:
     - type: Transform
-      pos: -40.5,-4.5
+      pos: -40.5,-3.5
       parent: 2
 - proto: MachineAnomalyVessel
   entities:
-  - uid: 2506
+  - uid: 2513
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -39.5,-11.5
+      rot: 3.141592653589793 rad
+      pos: -41.5,-11.5
       parent: 2
 - proto: MachineAPE
   entities:
-  - uid: 2507
+  - uid: 3729
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -39.5,-10.5
-      parent: 2
-  - uid: 2508
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -40.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: -41.5,-4.5
       parent: 2
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 2509
+  - uid: 2515
     components:
     - type: Transform
       pos: -43.5,-11.5
       parent: 2
 - proto: MachineCentrifuge
   entities:
-  - uid: 2510
+  - uid: 2516
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
-- proto: MachineMaterialSilo
-  entities:
-  - uid: 2511
-    components:
-    - type: Transform
-      pos: -41.5,-11.5
-      parent: 2
-- proto: MaterialCardboard
-  entities:
-  - uid: 2513
-    components:
-    - type: Transform
-      pos: -20.405964,-14.529865
-      parent: 2
-- proto: MaterialCloth
-  entities:
-  - uid: 2514
-    components:
-    - type: Transform
-      pos: -31.447205,-21.40013
-      parent: 2
-- proto: MaterialCloth10
-  entities:
-  - uid: 2515
-    components:
-    - type: Transform
-      pos: -5.599204,3.8288617
-      parent: 2
-- proto: MaterialDurathread
-  entities:
-  - uid: 2516
-    components:
-    - type: Transform
-      pos: -31.738281,-21.22232
-      parent: 2
-- proto: MechEquipmentGrabberSmall
+- proto: MachineMaterialSiloFilled
   entities:
   - uid: 2517
     components:
     - type: Transform
-      pos: -2.5511339,-10.477908
+      pos: -41.5,-10.5
+      parent: 2
+- proto: MailCart
+  entities:
+  - uid: 2518
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 2
+- proto: MaterialCardboard
+  entities:
+  - uid: 1298
+    components:
+    - type: Transform
+      parent: 1295
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 1295
+- proto: MaterialCardboard10
+  entities:
+  - uid: 2519
+    components:
+    - type: Transform
+      pos: -20.481773,-14.387933
+      parent: 2
+- proto: MaterialCloth
+  entities:
+  - uid: 2520
+    components:
+    - type: Transform
+      pos: -31.447205,-21.40013
+      parent: 2
+  - uid: 2815
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
+- proto: MaterialCloth10
+  entities:
+  - uid: 1296
+    components:
+    - type: Transform
+      parent: 1295
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 1295
+- proto: MaterialDurathread
+  entities:
+  - uid: 2521
+    components:
+    - type: Transform
+      pos: -31.738281,-21.22232
+      parent: 2
+- proto: MaterialWoodPlank
+  entities:
+  - uid: 1299
+    components:
+    - type: Transform
+      parent: 1295
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 1295
+- proto: MechEquipmentGrabberSmall
+  entities:
+  - uid: 2522
+    components:
+    - type: Transform
+      pos: -43.585487,-2.4157019
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 2504
+  - uid: 2523
     components:
     - type: Transform
       pos: -30.5,6.5
       parent: 2
-  - uid: 2518
+  - uid: 2524
     components:
     - type: Transform
       pos: -30.5,4.5
       parent: 2
-  - uid: 2520
+  - uid: 2525
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 2523
+  - uid: 2526
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 2524
+  - uid: 2527
     components:
     - type: Transform
       pos: -28.33104,10.634712
       parent: 2
 - proto: MedkitBruteFilled
   entities:
-  - uid: 2525
+  - uid: 2528
     components:
     - type: Transform
       pos: -28.33104,11.431587
       parent: 2
 - proto: MedkitBurnFilled
   entities:
-  - uid: 2526
+  - uid: 2529
     components:
     - type: Transform
       pos: -28.33104,11.259712
       parent: 2
 - proto: MedkitCombatFilled
   entities:
-  - uid: 2527
+  - uid: 2530
     components:
     - type: Transform
       pos: -37.08776,-25.31421
       parent: 2
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 2528
+  - uid: 2531
     components:
     - type: Transform
       pos: -28.33104,11.056587
       parent: 2
 - proto: MedkitSiliconFilled
   entities:
-  - uid: 1080
+  - uid: 2532
     components:
     - type: Transform
-      pos: -38.497524,-9.271908
-      parent: 2
-  - uid: 3774
-    components:
-    - type: Transform
-      pos: -43.814953,11.527309
+      pos: -43.50121,-2.2372503
       parent: 2
 - proto: MedkitToxinFilled
   entities:
-  - uid: 2529
+  - uid: 2533
     components:
     - type: Transform
       pos: -28.33104,10.837837
       parent: 2
 - proto: MicroManipulatorStockPart
   entities:
-  - uid: 2530
+  - uid: 2534
     components:
     - type: Transform
       pos: -26.72412,-13.543716
@@ -18276,23 +18374,23 @@ entities:
       count: 2
 - proto: Morgue
   entities:
-  - uid: 2531
+  - uid: 2535
     components:
     - type: Transform
       pos: -34.5,6.5
       parent: 2
-  - uid: 2532
+  - uid: 2536
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 2
-  - uid: 2533
+  - uid: 2537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,4.5
       parent: 2
-  - uid: 2534
+  - uid: 2538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18300,50 +18398,55 @@ entities:
       parent: 2
 - proto: Multitool
   entities:
-  - uid: 2535
+  - uid: 2539
     components:
     - type: Transform
       pos: -26.784418,-11.522438
       parent: 2
 - proto: MysteryFigureBox
   entities:
-  - uid: 2536
+  - uid: 2540
     components:
     - type: Transform
       pos: -4.4968796,-2.2217891
       parent: 2
-  - uid: 2537
+  - uid: 2541
     components:
     - type: Transform
       pos: -4.6375046,-2.5030391
       parent: 2
 - proto: NitrogenCanister
   entities:
-  - uid: 2431
+  - uid: 2542
+    components:
+    - type: Transform
+      pos: -38.5,10.5
+      parent: 2
+  - uid: 2543
     components:
     - type: Transform
       pos: -20.5,-5.5
       parent: 2
-  - uid: 2538
+  - uid: 2544
     components:
     - type: Transform
       pos: -19.5,-9.5
       parent: 2
-  - uid: 2539
+  - uid: 2545
     components:
     - type: Transform
       pos: -51.5,8.5
       parent: 2
 - proto: NoticeBoardBridge
   entities:
-  - uid: 3773
+  - uid: 2546
     components:
     - type: Transform
       pos: -39.5,-21.5
       parent: 2
 - proto: NoticeBoardBrig
   entities:
-  - uid: 3768
+  - uid: 2547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18351,7 +18454,7 @@ entities:
       parent: 2
 - proto: NoticeBoardCargo
   entities:
-  - uid: 3770
+  - uid: 2548
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18359,21 +18462,21 @@ entities:
       parent: 2
 - proto: NoticeBoardEngineering
   entities:
-  - uid: 3771
+  - uid: 2549
     components:
     - type: Transform
       pos: -35.5,3.5
       parent: 2
 - proto: NoticeBoardGeneral
   entities:
-  - uid: 3764
+  - uid: 1313
     components:
     - type: Transform
-      pos: -40.5,-16.5
+      pos: -41.5,-16.5
       parent: 2
 - proto: NoticeBoardMedical
   entities:
-  - uid: 3769
+  - uid: 2551
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18381,14 +18484,15 @@ entities:
       parent: 2
 - proto: NoticeBoardScience
   entities:
-  - uid: 3766
+  - uid: 2552
     components:
     - type: Transform
-      pos: -43.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-2.5
       parent: 2
 - proto: NoticeBoardSecurity
   entities:
-  - uid: 3767
+  - uid: 2553
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18396,7 +18500,7 @@ entities:
       parent: 2
 - proto: NoticeBoardServiceBotany
   entities:
-  - uid: 1239
+  - uid: 2554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18404,7 +18508,7 @@ entities:
       parent: 2
 - proto: NoticeBoardServiceJanitor
   entities:
-  - uid: 3765
+  - uid: 2555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18412,122 +18516,129 @@ entities:
       parent: 2
 - proto: NoticeBoardServiceKitchenBar
   entities:
-  - uid: 2483
+  - uid: 3214
     components:
     - type: Transform
-      pos: -15.5,6.5
+      pos: -18.5,4.5
       parent: 2
 - proto: NoticeBoardServiceLibrary
   entities:
-  - uid: 3772
+  - uid: 2557
     components:
     - type: Transform
       pos: -32.5,-4.5
       parent: 2
 - proto: NoticeBoardServicePerformer
   entities:
-  - uid: 3763
+  - uid: 2558
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 2540
+  - uid: 2559
     components:
     - type: Transform
       pos: -34.5,8.5
       parent: 2
 - proto: OreProcessor
   entities:
-  - uid: 2541
+  - uid: 2560
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 2542
+  - uid: 2561
+    components:
+    - type: Transform
+      pos: -38.5,8.5
+      parent: 2
+  - uid: 2562
     components:
     - type: Transform
       pos: -19.5,-8.5
       parent: 2
-  - uid: 2543
+  - uid: 2563
     components:
     - type: Transform
       pos: -51.5,7.5
       parent: 2
-  - uid: 2544
+  - uid: 2564
     components:
     - type: Transform
       pos: -27.5,-23.5
       parent: 2
-- proto: OxygenTankFilled
-  entities:
-  - uid: 2546
-    components:
-    - type: Transform
-      parent: 2545
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: Paper
   entities:
-  - uid: 2547
+  - uid: 2566
     components:
     - type: Transform
-      pos: -8.612858,-6.4558353
-      parent: 2
-  - uid: 2548
-    components:
-    - type: Transform
-      pos: -8.503483,-6.3620853
-      parent: 2
-  - uid: 2549
-    components:
-    - type: Transform
-      pos: -31.568844,-5.4410157
-      parent: 2
-  - uid: 2550
-    components:
-    - type: Transform
-      pos: -41.350964,1.2295794
+      rot: 12.566370614359172 rad
+      pos: -41.363873,1.2008541
       parent: 2
     - type: Paper
       stampState: paper_stamp-signature
       stampedBy:
       - stampLargeIcon: null
-        stampedColor: '#009100FF'
-        stampedName: Shun The Unworthy
-      - stampLargeIcon: null
-        stampedColor: '#009100FF'
+        stampedColor: '#2F4F4FFF'
         stampedName: Odds-And-Ends
-      - stampLargeIcon: large_stamp-centcom
-        stampedColor: '#006600FF'
-        stampedName: stamp-component-stamped-name-centcom
-      content: "[color=#f39f27]░░▄▀░░ [head=2]Engineering Memo[/head]\r \n░▄█▄▄▀ [head=3]Subject:  Setup[/head]\r\n██▀░░░ [head=3]From:  Central Command[/head]\r\n        [/color]───────────────────────────────────────\r\n\r\nWelcome to the IMP-KDN-Banana Station! If you arent familiar, here's a checklist of things that you'll need to enable to keep the station functioning smoothly.\r\n\r\n- The radiation collectors in Frank (the crab)'s chamber. You can turn them on just by clicking on them.\r\n\r\n- The emitter and containment field in the shuttle bay will need to be enabled, in the same manner.\r\n\r\n- The solar panels on the northeast and southeast sides of the station near arrivals are only partially constructed., and will need to have glass applied to them to finish the construction. Please exercise caution near the east of the station, as the arrivals shuttle will not slow down if you get in its path.\r\n\r\nBest of luck!\r\n\r\n───────────────────────────────────────\nSincerely, CENTCOMM Engineering."
+      - stampLargeIcon: null
+        stampedColor: '#2F4F4FFF'
+        stampedName: Shun The Unworthy
+      - stampLargeIcon: large_stamp-syndcomm
+        stampedColor: '#664400FF'
+        stampedName: stamp-component-stamped-name-syndcomm
+      content: "[color=#f39f27]░░▄▀░░ [head=2]Engineering Memo[/head]\r \n░▄█▄▄▀ [head=3]Subject:  Setup[/head]\r\n██▀░░░ [head=3]From:  ███████████████████[/head]\r\n        [/color]───────────────────────────────────────\r\n\r\nWelcome to the IMP-KDN-Banana Station! If you aren't familiar, here's a checklist of things that you'll need to enable to keep the station functioning smoothly.\r\n\r\n- The radiation collectors in Frank (the crab)'s chamber. You can turn them on just by clicking on them.\r\n\r\n- T̷h̷e̵̴ ̶em̶i̴t̶t̴e̵r̴ ̶a̶n̶̷d ̶c̷o̶n̶tai̷n̶m̴e̵n̷̷t̴ ̴f̵i̴e̶l̶d̴ ̵in̶̴ ̷t̷h̵e̶ ̴s̷h̵u̷t̵tle̴ ̵ba̶y ̴wi̷l̷l̴ ̵n̶e̷ed̴ ̷to̶̴ ̶b̵e̴ ̶e̷n̶̶̶a̴b̷l̶e̶d̶ i̴n̷ ̷t̶h̷e̷ ̷s̴a̵m̷e̷ ̶m̶a̶n̶n̶̷e̴r̵.̵  [color=Red]Nevermind! Got blown up during acquisition! [font=\"Emoji\"]\U0001F60A[/font]\n[/color]\r\n- The solar panels on the northeast and southeast sides of the station near arrivals are only partially constructed, and will need to have glass applied to them to finish the construction. Please exercise caution near the east of the station, a̴s̵ ̵t̷h̶e̵ ̴a̷r̵r̴i̴v̷als̴ ̶̷s̷h̴u̵t̴t̷l̴e̷̴ ̶w̶i̷l̷l̶ ̴n̵o̴t̴ ̶̴sl̶o̴w̶ ̴d̶o̵w̴n̴ ̶if̴ ̶y̷o̴u̷̴ ̶g̵e̵t̴ ̶ ̷i̷n̴ ̵i̴t̶s̴ ̷pa̷t̷h̶. [color=Red]Blew up that shuttle, too! Nothing to worry about![/color]\r\n\r\nBest of luck!\r\n\r\n───────────────────────────────────────\n\n          [head=3]S̶i̵n̶c̵e̴r̵e̶l̵y̵,̶ C̶e̵̶n̶t̶C̶o̶̵m̶m̴ ̶̷E̶n̷g̶i̴n̶̷ee̴r̵i̶n̵g̴̶\n \n          [color=Red][font=\"Emoji\"]\U0001F496[/font][font=\"Emoji\"]\U0001F496[/font][font=\"Emoji\"]\U0001F496[/font], SyndComm Engineering.[/color][/head]"
+  - uid: 2567
+    components:
+    - type: Transform
+      pos: -8.369816,-6.390529
+      parent: 2
+  - uid: 2568
+    components:
+    - type: Transform
+      pos: -31.568844,-5.4410157
+      parent: 2
 - proto: PaperBin20
   entities:
-  - uid: 2551
+  - uid: 2569
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 2
-  - uid: 2552
+  - uid: 2570
     components:
     - type: Transform
       pos: -36.5,-25.5
       parent: 2
+- proto: PaperStickyNoteStack
+  entities:
+  - uid: 2571
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -45.617928,-13.450501
+      parent: 2
+- proto: ParcelWrap
+  entities:
+  - uid: 2572
+    components:
+    - type: Transform
+      pos: -2.4313653,-10.496313
+      parent: 2
 - proto: PartRodMetal
   entities:
-  - uid: 2553
+  - uid: 2573
     components:
     - type: Transform
       pos: -26.501015,-13.04204
       parent: 2
 - proto: Pen
   entities:
-  - uid: 2554
+  - uid: 2574
     components:
     - type: MetaData
       desc: Oho! A treat!
@@ -18537,28 +18648,36 @@ entities:
       parent: 2
 - proto: PhoneInstrument
   entities:
-  - uid: 2556
+  - uid: 2575
     components:
     - type: Transform
       pos: -37.671448,-25.286047
       parent: 2
+- proto: PigCube
+  entities:
+  - uid: 3743
+    components:
+    - type: Transform
+      parent: 3737
+    - type: Physics
+      canCollide: False
 - proto: PillDylovene
   entities:
-  - uid: 2557
+  - uid: 2576
     components:
     - type: Transform
       pos: -19.37526,5.788618
       parent: 2
 - proto: Pitcher
   entities:
-  - uid: 3703
+  - uid: 2577
     components:
     - type: Transform
       pos: -14.346833,4.8841467
       parent: 2
 - proto: PlasmaCanister
   entities:
-  - uid: 2558
+  - uid: 2578
     components:
     - type: Transform
       pos: -38.5,4.5
@@ -18567,47 +18686,52 @@ entities:
       releaseValve: True
     - type: Lock
       locked: False
-  - uid: 2559
+  - uid: 2579
     components:
     - type: Transform
       pos: -51.5,9.5
       parent: 2
 - proto: PlasmaWindoorSecureScienceLocked
   entities:
-  - uid: 2564
+  - uid: 2580
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -43.5,-3.5
+      pos: -42.5,-2.5
       parent: 2
 - proto: PlasmaWindoorSecureSecurityLocked
   entities:
-  - uid: 2565
+  - uid: 2581
     components:
     - type: Transform
       pos: -29.5,-20.5
       parent: 2
-  - uid: 2566
+  - uid: 2582
     components:
     - type: Transform
       pos: -28.5,-20.5
       parent: 2
 - proto: PlasmaWindowDirectional
   entities:
-  - uid: 2567
+  - uid: 2583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -41.5,-3.5
+      pos: -41.5,-2.5
       parent: 2
-  - uid: 2568
+  - uid: 2584
     components:
     - type: Transform
-      pos: -42.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: -43.5,-2.5
       parent: 2
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 2569
+  - uid: 2585
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 2586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18615,33 +18739,40 @@ entities:
       parent: 2
 - proto: PlushieArachind
   entities:
-  - uid: 2570
+  - uid: 2587
     components:
     - type: Transform
       pos: -50.303944,4.542165
       parent: 2
-  - uid: 2571
+  - uid: 2588
     components:
     - type: Transform
       pos: -24.41068,-0.43839788
       parent: 2
 - proto: PlushieCarp
   entities:
-  - uid: 3762
+  - uid: 2589
     components:
     - type: Transform
       pos: -42.55972,-27.557743
       parent: 2
+- proto: PlushieExperiment
+  entities:
+  - uid: 2590
+    components:
+    - type: Transform
+      pos: -30.408106,-16.464903
+      parent: 2
 - proto: PlushieLamp
   entities:
-  - uid: 2572
+  - uid: 2591
     components:
     - type: Transform
       pos: -32.631966,-5.1307135
       parent: 2
 - proto: PlushieLizardInversed
   entities:
-  - uid: 2573
+  - uid: 2592
     components:
     - type: Transform
       pos: -22.712833,7.8415327
@@ -18651,51 +18782,67 @@ entities:
     - type: Conveyed
 - proto: PlushieMoth
   entities:
-  - uid: 2574
+  - uid: 2593
     components:
     - type: Transform
       pos: -50.36846,3.5249386
       parent: 2
 - proto: PlushieSlime
   entities:
-  - uid: 2575
+  - uid: 2594
     components:
     - type: Transform
-      pos: -42.54184,-5.282342
+      pos: -40.33072,-4.2473607
       parent: 2
 - proto: PlushieVox
   entities:
-  - uid: 2576
+  - uid: 2595
     components:
     - type: Transform
       pos: -15.412783,-5.291333
       parent: 2
-- proto: PortableGeneratorSuperPacman
+- proto: PortableGeneratorSuperPacmanFilled
   entities:
-  - uid: 2577
+  - uid: 2596
     components:
     - type: Transform
       pos: -48.5,8.5
       parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 2578
+  - uid: 2597
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 2
 - proto: PosterBroken
   entities:
-  - uid: 3718
+  - uid: 2598
+    components:
+    - type: Transform
+      pos: -49.5,-21.5
+      parent: 2
+  - uid: 2599
+    components:
+    - type: Transform
+      pos: -41.5,-29.5
+      parent: 2
+  - uid: 2600
     components:
     - type: Transform
       pos: -51.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 2601
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -42.5,12.5
+      parent: 2
 - proto: PosterContrabandMissingGloves
   entities:
-  - uid: 2580
+  - uid: 2602
     components:
     - type: MetaData
       name: missing yellows
@@ -18706,7 +18853,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandSunkist
   entities:
-  - uid: 2581
+  - uid: 2603
     components:
     - type: Transform
       pos: -45.5,3.5
@@ -18715,7 +18862,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitJustAWeekAwaySyndie
   entities:
-  - uid: 2582
+  - uid: 2604
     components:
     - type: Transform
       pos: -27.5,7.5
@@ -18724,7 +18871,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitNoERPSyndie
   entities:
-  - uid: 2583
+  - uid: 2605
     components:
     - type: Transform
       pos: -34.5,-12.5
@@ -18733,7 +18880,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyMothEpi
   entities:
-  - uid: 2584
+  - uid: 2606
     components:
     - type: Transform
       pos: -33.5,0.5
@@ -18742,7 +18889,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyMothMeth
   entities:
-  - uid: 2585
+  - uid: 2607
     components:
     - type: Transform
       pos: -23.5,4.5
@@ -18751,7 +18898,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyMothSSD
   entities:
-  - uid: 3663
+  - uid: 2608
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18759,652 +18906,660 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: PosterLegitSyndicateLogo
+  entities:
+  - uid: 2609
+    components:
+    - type: Transform
+      pos: -49.5,-21.5
+      parent: 2
 - proto: PottedPlantRandom
   entities:
-  - uid: 2587
+  - uid: 2610
     components:
     - type: Transform
       pos: -50.5,-17.5
       parent: 2
 - proto: PottedPlantRD
   entities:
-  - uid: 2588
+  - uid: 2611
     components:
     - type: Transform
-      pos: -43.5,-3.5
+      pos: -40.5,-29.5
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 2589
+  - uid: 2612
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 2
-  - uid: 2590
+  - uid: 2613
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 2591
+  - uid: 2614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-6.5
       parent: 2
-  - uid: 2592
+  - uid: 2615
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,-5.5
       parent: 2
-  - uid: 2593
+  - uid: 2616
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 2594
+  - uid: 2617
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 2
-  - uid: 2595
+  - uid: 2618
     components:
     - type: Transform
       pos: -31.5,-12.5
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 2596
+  - uid: 2619
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -14.5,5.5
       parent: 2
-  - uid: 2597
+  - uid: 2620
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,1.5
       parent: 2
-  - uid: 2598
+  - uid: 2621
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-3.5
       parent: 2
-  - uid: 2599
-    components:
-    - type: Transform
-      pos: -17.5,-0.5
-      parent: 2
-  - uid: 2600
+  - uid: 2622
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-5.5
       parent: 2
-  - uid: 2601
+  - uid: 2623
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 2602
+  - uid: 2624
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 2
-  - uid: 2603
+  - uid: 2625
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 2604
+  - uid: 2626
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
-  - uid: 2605
+  - uid: 2627
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-10.5
       parent: 2
-  - uid: 2606
+  - uid: 2628
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-10.5
       parent: 2
-  - uid: 2607
+  - uid: 2629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 2
-  - uid: 2608
+  - uid: 2630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-10.5
       parent: 2
-  - uid: 2609
+  - uid: 2631
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-5.5
       parent: 2
-  - uid: 2610
+  - uid: 2632
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 2
-  - uid: 2611
+  - uid: 2633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-3.5
       parent: 2
-  - uid: 2612
+  - uid: 2634
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
-  - uid: 2613
+  - uid: 2635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-13.5
       parent: 2
-  - uid: 2614
+  - uid: 2636
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-5.5
       parent: 2
-  - uid: 2615
+  - uid: 2637
     components:
     - type: Transform
       pos: -19.5,-8.5
       parent: 2
-  - uid: 2616
+  - uid: 2638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 2617
+  - uid: 2639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-10.5
       parent: 2
-  - uid: 2618
+  - uid: 2640
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,-13.5
       parent: 2
-  - uid: 2619
+  - uid: 2641
     components:
     - type: Transform
       pos: -25.5,-8.5
       parent: 2
-  - uid: 2620
+  - uid: 2642
     components:
     - type: Transform
       pos: -21.5,-8.5
       parent: 2
-  - uid: 2621
+  - uid: 2643
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 2622
+  - uid: 2644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,8.5
       parent: 2
-  - uid: 2623
+  - uid: 2645
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,5.5
       parent: 2
-  - uid: 2624
+  - uid: 2646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,3.5
       parent: 2
-  - uid: 2625
+  - uid: 2647
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,0.5
       parent: 2
-  - uid: 2626
+  - uid: 2648
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,15.5
       parent: 2
-  - uid: 2627
+  - uid: 2649
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,-9.5
       parent: 2
-  - uid: 2628
+  - uid: 2650
     components:
     - type: Transform
       pos: -42.5,-13.5
       parent: 2
-  - uid: 2629
+  - uid: 2651
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-15.5
       parent: 2
-  - uid: 2630
+  - uid: 2652
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-11.5
       parent: 2
-  - uid: 2631
+  - uid: 2653
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,-8.5
       parent: 2
-  - uid: 2632
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -44.5,-3.5
-      parent: 2
-  - uid: 2633
+  - uid: 2654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-5.5
       parent: 2
-  - uid: 2634
+  - uid: 2655
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-0.5
       parent: 2
-  - uid: 2635
+  - uid: 2656
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,-0.5
       parent: 2
-  - uid: 2636
+  - uid: 2657
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,5.5
       parent: 2
-  - uid: 2637
+  - uid: 2658
     components:
     - type: Transform
       pos: -39.5,2.5
       parent: 2
-  - uid: 2638
+  - uid: 2659
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,2.5
       parent: 2
-  - uid: 2639
+  - uid: 2660
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,8.5
       parent: 2
-  - uid: 2640
+  - uid: 2661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,8.5
       parent: 2
-  - uid: 2641
+  - uid: 2662
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,8.5
       parent: 2
-  - uid: 2642
+  - uid: 2663
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-17.5
       parent: 2
-  - uid: 2643
+  - uid: 2664
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-16.5
       parent: 2
-  - uid: 2644
+  - uid: 2665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-20.5
       parent: 2
-  - uid: 2645
+  - uid: 2666
     components:
     - type: Transform
       pos: -33.5,-12.5
       parent: 2
-  - uid: 2646
+  - uid: 2667
     components:
     - type: Transform
       pos: -29.5,-12.5
       parent: 2
-  - uid: 2647
+  - uid: 2668
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-16.5
       parent: 2
-  - uid: 2648
+  - uid: 2669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-11.5
       parent: 2
-  - uid: 2649
+  - uid: 2670
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-6.5
       parent: 2
-  - uid: 2650
+  - uid: 2671
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-3.5
       parent: 2
-  - uid: 2651
+  - uid: 2672
     components:
     - type: Transform
       pos: -30.5,-0.5
       parent: 2
-  - uid: 2652
+  - uid: 2673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: 3.141592653589793 rad
       pos: -44.5,-11.5
       parent: 2
-  - uid: 2653
+  - uid: 2674
     components:
     - type: Transform
       pos: -40.5,-3.5
       parent: 2
-  - uid: 2654
+  - uid: 2675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,9.5
       parent: 2
-  - uid: 2655
+  - uid: 2676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,9.5
       parent: 2
-  - uid: 2656
-    components:
-    - type: Transform
-      pos: -40.5,-17.5
-      parent: 2
-  - uid: 2657
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -45.5,-20.5
-      parent: 2
-  - uid: 2658
-    components:
-    - type: Transform
-      pos: -50.5,-17.5
-      parent: 2
-  - uid: 2659
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-10.5
-      parent: 2
-  - uid: 2660
-    components:
-    - type: Transform
-      pos: -28.5,-5.5
-      parent: 2
-  - uid: 2661
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-9.5
-      parent: 2
-  - uid: 2662
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-6.5
-      parent: 2
-  - uid: 2663
-    components:
-    - type: Transform
-      pos: -18.5,-7.5
-      parent: 2
-  - uid: 2664
-    components:
-    - type: Transform
-      pos: -9.5,-7.5
-      parent: 2
-  - uid: 2665
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -26.5,6.5
-      parent: 2
-  - uid: 2666
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,1.5
-      parent: 2
-  - uid: 2667
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,6.5
-      parent: 2
-  - uid: 2668
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,11.5
-      parent: 2
-  - uid: 2669
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,8.5
-      parent: 2
-  - uid: 2670
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,8.5
-      parent: 2
-  - uid: 2671
-    components:
-    - type: Transform
-      pos: -35.5,11.5
-      parent: 2
-  - uid: 2672
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,-21.5
-      parent: 2
-  - uid: 2673
-    components:
-    - type: Transform
-      pos: -35.5,15.5
-      parent: 2
-  - uid: 2674
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,-24.5
-      parent: 2
-  - uid: 2675
-    components:
-    - type: Transform
-      pos: -33.5,-21.5
-      parent: 2
-  - uid: 2676
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,-29.5
-      parent: 2
   - uid: 2677
     components:
     - type: Transform
-      pos: -34.5,-26.5
+      pos: -40.5,-17.5
       parent: 2
   - uid: 2678
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -38.5,-29.5
+      pos: -45.5,-20.5
       parent: 2
   - uid: 2679
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -40.5,-26.5
+      pos: -50.5,-17.5
       parent: 2
   - uid: 2680
     components:
     - type: Transform
-      pos: -39.5,-22.5
+      rot: 1.5707963267948966 rad
+      pos: -29.5,-10.5
       parent: 2
   - uid: 2681
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -43.5,-25.5
+      pos: -28.5,-5.5
       parent: 2
   - uid: 2682
     components:
     - type: Transform
-      pos: -42.5,-22.5
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-9.5
       parent: 2
   - uid: 2683
     components:
     - type: Transform
-      pos: -15.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-6.5
       parent: 2
   - uid: 2684
     components:
     - type: Transform
-      pos: -18.5,-12.5
+      pos: -18.5,-7.5
       parent: 2
   - uid: 2685
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,13.5
+      pos: -9.5,-7.5
       parent: 2
   - uid: 2686
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -26.5,6.5
       parent: 2
   - uid: 2687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -46.5,-8.5
+      pos: -28.5,1.5
       parent: 2
   - uid: 2688
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: -28.5,6.5
       parent: 2
   - uid: 2689
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -46.5,15.5
+      rot: -1.5707963267948966 rad
+      pos: -28.5,11.5
       parent: 2
   - uid: 2690
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -32.5,8.5
       parent: 2
-- proto: PoweredlightBlack
-  entities:
   - uid: 2691
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -34.5,4.5
+      pos: -35.5,8.5
       parent: 2
   - uid: 2692
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -36.5,4.5
+      pos: -35.5,11.5
       parent: 2
   - uid: 2693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -35.5,4.5
+      pos: -29.5,-21.5
       parent: 2
   - uid: 2694
+    components:
+    - type: Transform
+      pos: -35.5,15.5
+      parent: 2
+  - uid: 2695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-24.5
+      parent: 2
+  - uid: 2696
+    components:
+    - type: Transform
+      pos: -33.5,-21.5
+      parent: 2
+  - uid: 2697
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-29.5
+      parent: 2
+  - uid: 2698
+    components:
+    - type: Transform
+      pos: -34.5,-26.5
+      parent: 2
+  - uid: 2699
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -38.5,-29.5
+      parent: 2
+  - uid: 2700
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -40.5,-26.5
+      parent: 2
+  - uid: 2701
+    components:
+    - type: Transform
+      pos: -39.5,-22.5
+      parent: 2
+  - uid: 2702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -43.5,-25.5
+      parent: 2
+  - uid: 2703
+    components:
+    - type: Transform
+      pos: -42.5,-22.5
+      parent: 2
+  - uid: 2704
+    components:
+    - type: Transform
+      pos: -15.5,-12.5
+      parent: 2
+  - uid: 2705
+    components:
+    - type: Transform
+      pos: -18.5,-12.5
+      parent: 2
+  - uid: 2706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -35.5,13.5
+      parent: 2
+  - uid: 2707
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,5.5
+      parent: 2
+  - uid: 2708
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -46.5,-8.5
+      parent: 2
+  - uid: 2709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 2710
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -46.5,15.5
+      parent: 2
+  - uid: 2711
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 2712
+    components:
+    - type: Transform
+      pos: -44.5,-2.5
+      parent: 2
+  - uid: 2713
+    components:
+    - type: Transform
+      pos: -18.5,-0.5
+      parent: 2
+- proto: PoweredlightBlack
+  entities:
+  - uid: 2714
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -34.5,4.5
+      parent: 2
+  - uid: 2715
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -36.5,4.5
+      parent: 2
+  - uid: 2716
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -35.5,4.5
+      parent: 2
+  - uid: 2717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,7.5
       parent: 2
-  - uid: 2695
+  - uid: 2718
     components:
     - type: Transform
       pos: -15.5,8.5
       parent: 2
+- proto: PoweredlightEmpty
+  entities:
+  - uid: 2719
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-15.5
+      parent: 2
 - proto: PoweredlightExterior
   entities:
-  - uid: 2696
+  - uid: 2720
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-26.5
       parent: 2
-- proto: PoweredlightSodium
-  entities:
-  - uid: 2697
-    components:
-    - type: Transform
-      pos: -45.5,-13.5
-      parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 2698
+  - uid: 2721
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19412,31 +19567,31 @@ entities:
       parent: 2
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 2872
+  - uid: 2722
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,4.5
       parent: 2
-  - uid: 3742
+  - uid: 2723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,1.5
       parent: 2
-  - uid: 3744
+  - uid: 2724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,6.5
       parent: 2
-  - uid: 3745
+  - uid: 2725
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,8.5
       parent: 2
-  - uid: 3746
+  - uid: 2726
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19444,43 +19599,54 @@ entities:
       parent: 2
 - proto: PresentRandom
   entities:
-  - uid: 2699
+  - uid: 2727
     components:
     - type: Transform
       pos: -25.02211,-0.46564555
       parent: 2
-  - uid: 2700
+  - uid: 2728
     components:
     - type: Transform
       pos: -24.67836,-0.82502055
       parent: 2
 - proto: Protolathe
   entities:
-  - uid: 2701
+  - uid: 2729
     components:
     - type: Transform
-      pos: -44.5,-5.5
+      pos: -40.5,-11.5
       parent: 2
+    - type: TechnologyDatabase
+      supportedDisciplines:
+      - Industrial
+      - Arsenal
+      - Experimental
+      - CivilianServices
 - proto: Rack
   entities:
-  - uid: 1138
+  - uid: 2730
+    components:
+    - type: Transform
+      pos: -29.5,-5.5
+      parent: 2
+  - uid: 2731
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -41.5,-9.5
+      parent: 2
+  - uid: 2732
     components:
     - type: Transform
       pos: -12.5,-10.5
       parent: 2
-  - uid: 2702
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -40.5,-11.5
-      parent: 2
-  - uid: 2703
+  - uid: 2733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,10.5
       parent: 2
-  - uid: 2704
+  - uid: 2734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19488,64 +19654,64 @@ entities:
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 2705
+  - uid: 2735
     components:
     - type: Transform
       pos: -46.5,5.5
       parent: 2
-  - uid: 2706
+  - uid: 2736
     components:
     - type: Transform
       pos: -47.5,5.5
       parent: 2
-  - uid: 2707
+  - uid: 2737
     components:
     - type: Transform
       pos: -48.5,5.5
       parent: 2
 - proto: Railing
   entities:
-  - uid: 2708
+  - uid: 2738
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-1.5
       parent: 2
-  - uid: 2709
+  - uid: 2739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-0.5
       parent: 2
-  - uid: 2710
+  - uid: 2740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-1.5
       parent: 2
-  - uid: 2711
+  - uid: 2741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-0.5
       parent: 2
-  - uid: 2712
+  - uid: 2742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-23.5
       parent: 2
-  - uid: 2713
+  - uid: 2743
     components:
     - type: Transform
       pos: -26.5,12.5
       parent: 2
-  - uid: 2714
+  - uid: 2744
     components:
     - type: Transform
       pos: -25.5,12.5
       parent: 2
-  - uid: 2715
+  - uid: 2745
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19553,14 +19719,14 @@ entities:
       parent: 2
 - proto: RailingCorner
   entities:
-  - uid: 2716
+  - uid: 2746
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 2717
+  - uid: 2747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19568,96 +19734,127 @@ entities:
       parent: 2
 - proto: RandomArtifactSpawner
   entities:
-  - uid: 2718
+  - uid: 2748
     components:
     - type: Transform
       pos: -43.5,-11.5
       parent: 2
+- proto: RandomCrystalSpawner
+  entities:
+  - uid: 3043
+    components:
+    - type: Transform
+      pos: -50.5,1.5
+      parent: 2
 - proto: RandomDrinkGlass
   entities:
-  - uid: 3753
+  - uid: 2749
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 2
 - proto: RandomFoodSingle
   entities:
-  - uid: 3704
+  - uid: 2750
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 2
-- proto: RandomMeat
-  entities:
-  - uid: 2719
-    components:
-    - type: Transform
-      pos: -14.587692,8.4760475
-      parent: 2
-  - uid: 2720
-    components:
-    - type: Transform
-      pos: -14.478317,8.2416725
-      parent: 2
 - proto: RandomNotebookSpawner
   entities:
-  - uid: 3668
+  - uid: 2753
     components:
     - type: Transform
       pos: -10.446872,0.50038767
       parent: 2
-  - uid: 3669
+  - uid: 2754
     components:
     - type: Transform
       pos: -18.477093,-5.425546
       parent: 2
-  - uid: 3670
+  - uid: 2755
     components:
     - type: Transform
       pos: -32.530125,-5.5352416
       parent: 2
-  - uid: 3671
+  - uid: 2756
     components:
     - type: Transform
       pos: -49.379654,-16.547926
       parent: 2
+- proto: RandomPacmanJrSpawner
+  entities:
+  - uid: 2757
+    components:
+    - type: Transform
+      pos: -29.5,-6.5
+      parent: 2
 - proto: RandomPosterContrabandSyndie
   entities:
-  - uid: 2561
+  - uid: 2758
     components:
     - type: Transform
       pos: -48.5,0.5
       parent: 2
 - proto: RandomVendingSnacks
   entities:
-  - uid: 2260
+  - uid: 2759
     components:
     - type: Transform
       pos: -48.5,-16.5
       parent: 2
-- proto: ReagentContainerSugar
+- proto: ReagentContainerFlour
   entities:
-  - uid: 3702
+  - uid: 2812
     components:
     - type: Transform
-      pos: -15.222349,5.6892242
+      parent: 2805
+    - type: Physics
+      canCollide: False
+  - uid: 2813
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
+- proto: ReagentContainerRice
+  entities:
+  - uid: 2816
+    components:
+    - type: Transform
+      parent: 2805
+    - type: Physics
+      canCollide: False
+- proto: ReagentContainerSugar
+  entities:
+  - uid: 2760
+    components:
+    - type: Transform
+      pos: -16.659956,5.703084
       parent: 2
 - proto: ReagentGrinderIndustrial
   entities:
-  - uid: 2721
+  - uid: 2761
     components:
     - type: Transform
       pos: -23.5,7.5
       parent: 2
+- proto: ReagentTinPowderedJuiceBanana
+  entities:
+  - uid: 3736
+    components:
+    - type: Transform
+      pos: -32.809788,-14.046549
+      parent: 2
 - proto: Recycler
   entities:
-  - uid: 2722
+  - uid: 2762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-7.5
       parent: 2
-  - uid: 2723
+  - uid: 2763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19665,53 +19862,51 @@ entities:
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 145
+  - uid: 2764
     components:
     - type: Transform
       pos: -40.5,10.5
       parent: 2
-  - uid: 151
+  - uid: 2765
     components:
     - type: Transform
       pos: -40.5,4.5
       parent: 2
-  - uid: 160
+  - uid: 2766
     components:
     - type: Transform
       pos: -40.5,6.5
       parent: 2
-  - uid: 163
+  - uid: 2767
     components:
     - type: Transform
       pos: -40.5,8.5
       parent: 2
-- proto: ReinforcedUraniumWindow
-  entities:
-  - uid: 2724
-    components:
-    - type: Transform
-      pos: -45.5,6.5
-      parent: 2
-  - uid: 2725
-    components:
-    - type: Transform
-      pos: -45.5,5.5
-      parent: 2
-  - uid: 2726
-    components:
-    - type: Transform
-      pos: -45.5,4.5
-      parent: 2
-- proto: ReinforcedWindow
-  entities:
-  - uid: 2727
+  - uid: 2768
     components:
     - type: Transform
       pos: -44.5,-9.5
       parent: 2
+- proto: ReinforcedUraniumWindow
+  entities:
+  - uid: 2769
+    components:
+    - type: Transform
+      pos: -45.5,6.5
+      parent: 2
+  - uid: 2770
+    components:
+    - type: Transform
+      pos: -45.5,5.5
+      parent: 2
+  - uid: 2771
+    components:
+    - type: Transform
+      pos: -45.5,4.5
+      parent: 2
 - proto: RemoteSignallerAdvanced
   entities:
-  - uid: 2728
+  - uid: 2772
     components:
     - type: MetaData
       name: shuttle bay door remote
@@ -19720,63 +19915,70 @@ entities:
       parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 2729
+  - uid: 2773
     components:
     - type: Transform
-      pos: -42.5,-3.5
+      pos: -42.5,-2.5
       parent: 2
 - proto: RollingPin
   entities:
-  - uid: 2730
+  - uid: 2774
     components:
     - type: Transform
       pos: -17.589586,1.6885712
       parent: 2
-- proto: RubberStampApproved
+- proto: RoseSeeds
   entities:
-  - uid: 2731
+  - uid: 3730
     components:
     - type: Transform
-      pos: -7.0741234,-7.1304073
+      pos: -18.426712,8.52532
+      parent: 2
+- proto: RubberStampApproved
+  entities:
+  - uid: 2775
+    components:
+    - type: Transform
+      pos: -7.0778103,-7.2203116
       parent: 2
 - proto: RubberStampDenied
   entities:
-  - uid: 2732
+  - uid: 2776
     components:
     - type: Transform
-      pos: -7.0741234,-7.3493094
+      pos: -7.0778103,-7.379475
       parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 2733
+  - uid: 2778
     components:
     - type: Transform
-      pos: -16.5,-7.5
+      pos: -18.5,-7.5
       parent: 2
 - proto: Screen
   entities:
-  - uid: 2734
+  - uid: 2779
     components:
     - type: Transform
       pos: -50.5,-16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2735
+  - uid: 2780
     components:
     - type: Transform
       pos: -39.5,-16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2737
+  - uid: 2781
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2738
+  - uid: 2782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19784,7 +19986,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2739
+  - uid: 2783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19792,23 +19994,27 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2740
-    components:
-    - type: Transform
-      pos: -18.5,4.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 3699
+  - uid: 2785
     components:
     - type: Transform
       pos: -38.5,-3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 2786
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -50.5,-21.5
+      parent: 2
+  - uid: 3523
+    components:
+    - type: Transform
+      pos: -16.5,6.5
+      parent: 2
 - proto: SecurityTechFab
   entities:
-  - uid: 2741
+  - uid: 2787
     components:
     - type: Transform
       pos: -29.5,-21.5
@@ -19821,19 +20027,19 @@ entities:
       - CivilianServices
 - proto: SeedExtractor
   entities:
-  - uid: 2742
+  - uid: 2788
     components:
     - type: Transform
       pos: -22.5,8.5
       parent: 2
 - proto: ShardCrystalGreen
   entities:
-  - uid: 2743
+  - uid: 2789
     components:
     - type: Transform
       pos: -46.25563,4.296426
       parent: 2
-  - uid: 2744
+  - uid: 2790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19841,37 +20047,35 @@ entities:
       parent: 2
 - proto: SheetGlass
   entities:
-  - uid: 1257
+  - uid: 1292
     components:
     - type: Transform
-      parent: 1256
+      parent: 1291
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 2745
+  - uid: 2791
     components:
     - type: Transform
       pos: -44.4165,10.807183
       parent: 2
-  - uid: 2746
-    components:
-    - type: Transform
-      pos: -40.469807,-11.4625
-      parent: 2
 - proto: SheetGlass10
   entities:
-  - uid: 2747
+  - uid: 1302
     components:
     - type: Transform
-      pos: -5.588787,3.6090302
-      parent: 2
-  - uid: 2748
+      parent: 1295
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 1295
+  - uid: 2792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.502018,-28.581347
       parent: 2
-  - uid: 2749
+  - uid: 2793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19879,114 +20083,107 @@ entities:
       parent: 2
 - proto: SheetPaper
   entities:
-  - uid: 2750
+  - uid: 1300
     components:
     - type: Transform
-      pos: -5.5638742,3.671122
-      parent: 2
-- proto: SheetPlasma
+      parent: 1295
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 1295
+- proto: SheetPlasma10
   entities:
-  - uid: 2751
+  - uid: 2794
     components:
     - type: Transform
-      pos: -40.48543,-11.446875
+      rot: 3.141592653589793 rad
+      pos: -41.326866,-9.348846
       parent: 2
 - proto: SheetPlasteel
   entities:
-  - uid: 2752
+  - uid: 2795
     components:
     - type: Transform
       pos: -44.338375,10.619683
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 1258
+  - uid: 1293
     components:
     - type: Transform
-      parent: 1256
+      parent: 1291
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 2753
-    components:
-    - type: Transform
-      pos: -40.501057,-11.4625
-      parent: 2
 - proto: SheetPlastic10
   entities:
-  - uid: 2754
+  - uid: 1297
     components:
     - type: Transform
-      pos: -5.692954,3.723693
-      parent: 2
-- proto: SheetSteel
-  entities:
-  - uid: 1259
-    components:
-    - type: Transform
-      parent: 1256
+      parent: 1295
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 2755
+      storage: 1295
+- proto: SheetSteel
+  entities:
+  - uid: 1294
+    components:
+    - type: Transform
+      parent: 1291
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 2796
     components:
     - type: Transform
       pos: -44.604,10.666558
       parent: 2
-  - uid: 2756
-    components:
-    - type: Transform
-      pos: -40.39168,-11.4
-      parent: 2
 - proto: SheetSteel1
   entities:
-  - uid: 2757
+  - uid: 2797
     components:
     - type: Transform
       pos: -45.5765,16.136856
       parent: 2
-  - uid: 2758
+  - uid: 2798
     components:
     - type: Transform
       pos: -43.685875,14.777481
       parent: 2
-  - uid: 2759
+  - uid: 2799
     components:
     - type: Transform
       pos: -40.404625,14.449356
       parent: 2
-  - uid: 2760
+  - uid: 2800
     components:
     - type: Transform
       pos: -38.639,16.168106
       parent: 2
-  - uid: 2761
+  - uid: 2801
     components:
     - type: Transform
       pos: -38.467125,13.418106
       parent: 2
-  - uid: 2762
+  - uid: 2802
     components:
     - type: Transform
       pos: -45.842125,13.918106
       parent: 2
 - proto: SheetSteel10
   entities:
-  - uid: 2763
+  - uid: 1301
     components:
     - type: Transform
-      pos: -5.79712,3.6924214
-      parent: 2
-- proto: SheetUranium
-  entities:
-  - uid: 1254
-    components:
-    - type: Transform
-      pos: -48.38951,8.523367
-      parent: 2
+      parent: 1295
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 1295
 - proto: ShelfBar
   entities:
-  - uid: 3672
+  - uid: 2804
     components:
     - type: Transform
       pos: -7.5,4.5
@@ -19995,16 +20192,106 @@ entities:
       fixtures: {}
 - proto: ShelfKitchen
   entities:
-  - uid: 2764
+  - uid: 2805
     components:
     - type: Transform
       pos: -17.5,4.5
       parent: 2
+    - type: Storage
+      storedItems:
+        2806:
+          position: 0,0
+          _rotation: South
+        2807:
+          position: 2,0
+          _rotation: South
+        2808:
+          position: 2,1
+          _rotation: South
+        2809:
+          position: 0,1
+          _rotation: South
+        2810:
+          position: 4,1
+          _rotation: South
+        2811:
+          position: 5,1
+          _rotation: South
+        2812:
+          position: 0,3
+          _rotation: South
+        2813:
+          position: 1,3
+          _rotation: South
+        2814:
+          position: 5,3
+          _rotation: South
+        2815:
+          position: 3,3
+          _rotation: South
+        2816:
+          position: 2,3
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 2806
+          - 2807
+          - 2809
+          - 2808
+          - 2810
+          - 2811
+          - 2812
+          - 2813
+          - 2814
+          - 2815
+          - 2816
     - type: Fixtures
       fixtures: {}
+  - uid: 3737
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,7.5
+      parent: 2
+    - type: Storage
+      storedItems:
+        3738:
+          position: 0,0
+          _rotation: South
+        3739:
+          position: 2,0
+          _rotation: South
+        3740:
+          position: 5,0
+          _rotation: South
+        3741:
+          position: 4,1
+          _rotation: South
+        3742:
+          position: 5,1
+          _rotation: South
+        3743:
+          position: 4,0
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 3738
+          - 3739
+          - 3740
+          - 3742
+          - 3741
+          - 3743
 - proto: ShotGunCabinetFilled
   entities:
-  - uid: 2765
+  - uid: 2817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20014,374 +20301,375 @@ entities:
       fixtures: {}
 - proto: ShuttleWindow
   entities:
-  - uid: 1490
+  - uid: 2818
     components:
     - type: Transform
       pos: -23.5,5.5
       parent: 2
-  - uid: 2170
+  - uid: 2819
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
-  - uid: 2182
+  - uid: 2820
     components:
     - type: Transform
       pos: -37.5,0.5
       parent: 2
-  - uid: 2217
+  - uid: 2821
     components:
     - type: Transform
       pos: -38.5,0.5
       parent: 2
-  - uid: 2766
+  - uid: 2822
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 2767
+  - uid: 2823
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 2768
+  - uid: 2824
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 2769
+  - uid: 2825
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 2770
+  - uid: 2826
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 2771
+  - uid: 2827
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
-  - uid: 2772
+  - uid: 2828
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 2
-  - uid: 2773
+  - uid: 2829
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
-  - uid: 2774
+  - uid: 2830
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 2
-  - uid: 2775
+  - uid: 2831
     components:
     - type: Transform
       pos: -10.5,-11.5
       parent: 2
-  - uid: 2776
+  - uid: 2832
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 2
-  - uid: 2777
+  - uid: 2833
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 2
-  - uid: 2778
+  - uid: 2834
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
-  - uid: 2779
+  - uid: 2835
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 2
-  - uid: 2782
+  - uid: 2836
     components:
     - type: Transform
       pos: -20.5,0.5
       parent: 2
-  - uid: 2783
+  - uid: 2837
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
-  - uid: 2784
+  - uid: 2838
     components:
     - type: Transform
       pos: -18.5,9.5
       parent: 2
-  - uid: 2785
+  - uid: 2839
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 2
-  - uid: 2786
+  - uid: 2840
     components:
     - type: Transform
       pos: -20.5,9.5
       parent: 2
-  - uid: 2787
+  - uid: 2841
     components:
     - type: Transform
       pos: -21.5,9.5
       parent: 2
-  - uid: 2788
+  - uid: 2842
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 2
-  - uid: 2790
+  - uid: 2843
     components:
     - type: Transform
       pos: -25.5,0.5
       parent: 2
-  - uid: 2791
+  - uid: 2844
     components:
     - type: Transform
       pos: -26.5,0.5
       parent: 2
-  - uid: 2792
+  - uid: 2845
     components:
     - type: Transform
       pos: -28.5,12.5
       parent: 2
-  - uid: 2793
+  - uid: 2846
     components:
     - type: Transform
       pos: -29.5,12.5
       parent: 2
-  - uid: 2794
+  - uid: 2847
     components:
     - type: Transform
       pos: -30.5,12.5
       parent: 2
-  - uid: 2795
+  - uid: 2848
     components:
     - type: Transform
       pos: -31.5,12.5
       parent: 2
-  - uid: 2796
+  - uid: 2849
     components:
     - type: Transform
       pos: -32.5,12.5
       parent: 2
-  - uid: 2797
+  - uid: 2850
     components:
     - type: Transform
       pos: -28.5,0.5
       parent: 2
-  - uid: 2798
+  - uid: 2851
     components:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
-  - uid: 2799
+  - uid: 2852
     components:
     - type: Transform
       pos: -33.5,8.5
       parent: 2
-  - uid: 2800
+  - uid: 2853
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 2
-  - uid: 2801
-    components:
-    - type: Transform
-      pos: -34.5,-5.5
-      parent: 2
-  - uid: 2802
+  - uid: 2855
     components:
     - type: Transform
       pos: -34.5,-8.5
       parent: 2
-  - uid: 2803
+  - uid: 2856
     components:
     - type: Transform
       pos: -34.5,-10.5
       parent: 2
-  - uid: 2804
+  - uid: 2857
     components:
     - type: Transform
       pos: -34.5,-13.5
       parent: 2
-  - uid: 2805
+  - uid: 2858
     components:
     - type: Transform
       pos: -34.5,-14.5
       parent: 2
-  - uid: 2806
+  - uid: 2859
     components:
     - type: Transform
       pos: -32.5,-15.5
       parent: 2
-  - uid: 2807
+  - uid: 2860
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 2808
+  - uid: 2861
     components:
     - type: Transform
       pos: -27.5,-19.5
       parent: 2
-  - uid: 2809
+  - uid: 2862
     components:
     - type: Transform
       pos: -34.5,-18.5
       parent: 2
-  - uid: 2810
+  - uid: 2863
     components:
     - type: Transform
       pos: -34.5,-19.5
       parent: 2
-  - uid: 2811
+  - uid: 2864
     components:
     - type: Transform
       pos: -51.5,10.5
       parent: 2
-  - uid: 2814
+  - uid: 2865
     components:
     - type: Transform
       pos: -45.5,-4.5
       parent: 2
-  - uid: 2815
+  - uid: 2866
     components:
     - type: Transform
       pos: -45.5,-5.5
       parent: 2
-  - uid: 2816
+  - uid: 2867
     components:
     - type: Transform
       pos: -46.5,-14.5
       parent: 2
-  - uid: 2817
+  - uid: 2868
     components:
     - type: Transform
       pos: -51.5,-19.5
       parent: 2
-  - uid: 2818
+  - uid: 2869
     components:
     - type: Transform
       pos: -38.5,17.5
       parent: 2
-  - uid: 2819
+  - uid: 2870
     components:
     - type: Transform
       pos: -27.5,-18.5
       parent: 2
-  - uid: 2820
+  - uid: 2871
     components:
     - type: Transform
       pos: -31.5,-25.5
       parent: 2
-  - uid: 2821
+  - uid: 2872
     components:
     - type: Transform
       pos: -29.5,-28.5
       parent: 2
-  - uid: 2822
+  - uid: 2873
     components:
     - type: Transform
       pos: -29.5,-27.5
       parent: 2
-  - uid: 2823
+  - uid: 2874
     components:
     - type: Transform
       pos: -31.5,-30.5
       parent: 2
-  - uid: 2824
+  - uid: 2875
     components:
     - type: Transform
       pos: -32.5,-30.5
       parent: 2
-  - uid: 2825
+  - uid: 2876
     components:
     - type: Transform
       pos: -33.5,-30.5
       parent: 2
-  - uid: 2826
+  - uid: 2877
     components:
     - type: Transform
       pos: -34.5,-30.5
       parent: 2
-  - uid: 2827
+  - uid: 2878
     components:
     - type: Transform
       pos: -35.5,-30.5
       parent: 2
-  - uid: 2828
+  - uid: 2879
     components:
     - type: Transform
       pos: -36.5,-30.5
       parent: 2
-  - uid: 2829
+  - uid: 2880
     components:
     - type: Transform
       pos: -37.5,-30.5
       parent: 2
-  - uid: 2830
+  - uid: 2881
     components:
     - type: Transform
       pos: -44.5,-28.5
       parent: 2
-  - uid: 2831
+  - uid: 2882
     components:
     - type: Transform
       pos: -35.5,-24.5
       parent: 2
-  - uid: 2832
+  - uid: 2883
     components:
     - type: Transform
       pos: -36.5,-24.5
       parent: 2
-  - uid: 2833
+  - uid: 2884
     components:
     - type: Transform
       pos: -37.5,-24.5
       parent: 2
-  - uid: 2834
+  - uid: 2885
     components:
     - type: Transform
       pos: -43.5,17.5
       parent: 2
-  - uid: 2835
+  - uid: 2886
     components:
     - type: Transform
       pos: -39.5,17.5
       parent: 2
-  - uid: 2836
+  - uid: 2887
     components:
     - type: Transform
       pos: -40.5,17.5
       parent: 2
-  - uid: 2837
+  - uid: 2888
     components:
     - type: Transform
       pos: -45.5,17.5
       parent: 2
-  - uid: 2838
+  - uid: 2889
     components:
     - type: Transform
       pos: -27.5,-17.5
       parent: 2
-  - uid: 2839
+  - uid: 2890
     components:
     - type: Transform
       pos: -46.5,17.5
       parent: 2
+  - uid: 2891
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -46.5,-13.5
+      parent: 2
 - proto: SignalButtonDirectional
   entities:
-  - uid: 2840
+  - uid: 2892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20389,32 +20677,56 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        79:
+        85:
         - - Pressed
           - Open
-        78:
+        84:
         - - Pressed
           - Open
     - type: Fixtures
       fixtures: {}
-  - uid: 2841
+  - uid: 2893
     components:
+    - type: MetaData
+      name: light switch
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        2646:
+        2667:
         - - Pressed
           - Toggle
-        2645:
+        2666:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
+  - uid: 3731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.5,-9.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        196:
+        - - Pressed
+          - Toggle
+  - uid: 3734
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-11.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        196:
+        - - Pressed
+          - Toggle
 - proto: SignalSwitch
   entities:
-  - uid: 2842
+  - uid: 2894
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20422,24 +20734,19 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        2722:
+        2762:
         - - On
           - Reverse
         - - Off
           - Off
-        1247:
-        - - On
-          - Reverse
+        1287:
         - - Off
           - Off
-        1251:
         - - On
           - Reverse
-        - - Off
-          - Off
     - type: Fixtures
       fixtures: {}
-  - uid: 2843
+  - uid: 2895
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20447,7 +20754,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        2721:
+        2761:
         - - On
           - Forward
         - - Off
@@ -20456,7 +20763,7 @@ entities:
       fixtures: {}
 - proto: SignAtmos
   entities:
-  - uid: 2844
+  - uid: 2896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20464,7 +20771,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2845
+  - uid: 2897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20474,7 +20781,7 @@ entities:
       fixtures: {}
 - proto: SignBar
   entities:
-  - uid: 2846
+  - uid: 2898
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20484,7 +20791,7 @@ entities:
       fixtures: {}
 - proto: SignBridgeSyndie
   entities:
-  - uid: 2847
+  - uid: 2899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20492,9 +20799,17 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: SignCans
+  entities:
+  - uid: 2900
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -49.5,8.5
+      parent: 2
 - proto: SignCargo
   entities:
-  - uid: 2848
+  - uid: 2901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20504,7 +20819,7 @@ entities:
       fixtures: {}
 - proto: SignCargoDock
   entities:
-  - uid: 2849
+  - uid: 2902
     components:
     - type: Transform
       pos: -10.5,-11.5
@@ -20513,17 +20828,15 @@ entities:
       fixtures: {}
 - proto: SignChapel
   entities:
-  - uid: 2850
+  - uid: 2903
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -34.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: -34.5,-11.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: SignChem
   entities:
-  - uid: 2851
+  - uid: 2904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20533,7 +20846,7 @@ entities:
       fixtures: {}
 - proto: SignDirectionalEvac
   entities:
-  - uid: 2852
+  - uid: 2905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20541,14 +20854,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2853
+  - uid: 2906
     components:
     - type: Transform
       pos: -34.5,-4.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2854
+  - uid: 2907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20558,26 +20871,14 @@ entities:
       fixtures: {}
 - proto: SignDisposalSpace
   entities:
-  - uid: 2855
+  - uid: 2908
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-4.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
-- proto: SignDoors
-  entities:
-  - uid: 2856
-    components:
-    - type: Transform
-      pos: -22.5,-5.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: SignEngine
   entities:
-  - uid: 2857
+  - uid: 2909
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20587,7 +20888,7 @@ entities:
       fixtures: {}
 - proto: SignEngineering
   entities:
-  - uid: 2858
+  - uid: 2910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20597,7 +20898,7 @@ entities:
       fixtures: {}
 - proto: SignEVA
   entities:
-  - uid: 2859
+  - uid: 2911
     components:
     - type: Transform
       pos: -24.5,-5.5
@@ -20606,7 +20907,7 @@ entities:
       fixtures: {}
 - proto: SignGravity
   entities:
-  - uid: 2860
+  - uid: 2912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20616,7 +20917,7 @@ entities:
       fixtures: {}
 - proto: SignHeadSyndie
   entities:
-  - uid: 2861
+  - uid: 2913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20626,7 +20927,7 @@ entities:
       fixtures: {}
 - proto: SignHydro1
   entities:
-  - uid: 2862
+  - uid: 2914
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20636,7 +20937,7 @@ entities:
       fixtures: {}
 - proto: SignJanitor
   entities:
-  - uid: 2863
+  - uid: 2915
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20646,7 +20947,7 @@ entities:
       fixtures: {}
 - proto: SignKitchen
   entities:
-  - uid: 2864
+  - uid: 2916
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20654,9 +20955,16 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: SignLibrary
+  entities:
+  - uid: 3185
+    components:
+    - type: Transform
+      pos: -34.5,-5.5
+      parent: 2
 - proto: SignMedical
   entities:
-  - uid: 2865
+  - uid: 2917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20666,7 +20974,7 @@ entities:
       fixtures: {}
 - proto: SignMorgue
   entities:
-  - uid: 2866
+  - uid: 2918
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20676,7 +20984,7 @@ entities:
       fixtures: {}
 - proto: SignSalvage
   entities:
-  - uid: 2867
+  - uid: 2919
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20686,7 +20994,7 @@ entities:
       fixtures: {}
 - proto: SignScience
   entities:
-  - uid: 2868
+  - uid: 2920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20696,7 +21004,7 @@ entities:
       fixtures: {}
 - proto: SignSecurity
   entities:
-  - uid: 2869
+  - uid: 2921
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20706,7 +21014,7 @@ entities:
       fixtures: {}
 - proto: SignShipDock
   entities:
-  - uid: 2870
+  - uid: 2922
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20716,7 +21024,7 @@ entities:
       fixtures: {}
 - proto: SignSurgery
   entities:
-  - uid: 2871
+  - uid: 2923
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20726,14 +21034,15 @@ entities:
       fixtures: {}
 - proto: Sink
   entities:
-  - uid: 2873
+  - uid: 2924
     components:
     - type: Transform
-      pos: -44.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -44.5,-14.5
       parent: 2
 - proto: SinkStemlessWater
   entities:
-  - uid: 2874
+  - uid: 2925
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20741,24 +21050,24 @@ entities:
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 2875
+  - uid: 2926
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 2
-  - uid: 2876
+  - uid: 2927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-15.5
       parent: 2
-  - uid: 2877
+  - uid: 2928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,1.5
       parent: 2
-  - uid: 2878
+  - uid: 2929
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20766,345 +21075,349 @@ entities:
       parent: 2
 - proto: SmartFridge
   entities:
-  - uid: 2879
+  - uid: 2930
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
-  - uid: 2880
+  - uid: 2931
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 2
-  - uid: 2881
+  - uid: 2932
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 2
-  - uid: 2882
+  - uid: 2933
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 2
 - proto: SMESAdvanced
   entities:
-  - uid: 2883
+  - uid: 2934
     components:
+    - type: MetaData
+      name: SMES 1
     - type: Transform
       pos: -44.5,2.5
       parent: 2
-  - uid: 2884
+  - uid: 2935
     components:
+    - type: MetaData
+      name: SMES 2
     - type: Transform
       pos: -44.5,1.5
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 2885
+  - uid: 2936
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 2
 - proto: SolarAssembly
   entities:
-  - uid: 2886
+  - uid: 2937
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2887
+  - uid: 2938
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 2
-  - uid: 2888
+  - uid: 2939
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 2889
+  - uid: 2940
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 2890
+  - uid: 2941
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 2
-  - uid: 2891
+  - uid: 2942
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 2
-  - uid: 2892
+  - uid: 2943
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 2
-  - uid: 2893
+  - uid: 2944
     components:
     - type: Transform
       pos: -46.5,-25.5
       parent: 2
-  - uid: 2894
+  - uid: 2945
     components:
     - type: Transform
       pos: -50.5,-30.5
       parent: 2
-  - uid: 2895
+  - uid: 2946
     components:
     - type: Transform
       pos: -48.5,-30.5
       parent: 2
-  - uid: 2896
+  - uid: 2947
     components:
     - type: Transform
       pos: -48.5,-32.5
       parent: 2
-  - uid: 2897
+  - uid: 2948
     components:
     - type: Transform
       pos: -48.5,-24.5
       parent: 2
-  - uid: 2898
+  - uid: 2949
     components:
     - type: Transform
       pos: -46.5,-32.5
       parent: 2
-  - uid: 2899
+  - uid: 2950
     components:
     - type: Transform
       pos: -50.5,-25.5
       parent: 2
-  - uid: 2900
+  - uid: 2951
     components:
     - type: Transform
       pos: -50.5,-27.5
       parent: 2
-  - uid: 2901
+  - uid: 2952
     components:
     - type: Transform
       pos: -46.5,-29.5
       parent: 2
-  - uid: 2902
+  - uid: 2953
     components:
     - type: Transform
       pos: -48.5,-26.5
       parent: 2
 - proto: SolarPanel
   entities:
-  - uid: 2903
+  - uid: 2954
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
-  - uid: 2904
+  - uid: 2955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,7.5
       parent: 2
-  - uid: 2905
+  - uid: 2956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,8.5
       parent: 2
-  - uid: 2906
+  - uid: 2957
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,9.5
       parent: 2
-  - uid: 2907
+  - uid: 2958
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,9.5
       parent: 2
-  - uid: 2908
+  - uid: 2959
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,7.5
       parent: 2
-  - uid: 2909
+  - uid: 2960
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
-  - uid: 2910
+  - uid: 2961
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,8.5
       parent: 2
-  - uid: 2911
+  - uid: 2962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,7.5
       parent: 2
-  - uid: 2912
+  - uid: 2963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 2
-  - uid: 2913
+  - uid: 2964
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,9.5
       parent: 2
-  - uid: 2914
+  - uid: 2965
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,6.5
       parent: 2
-  - uid: 2915
+  - uid: 2966
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 2
-  - uid: 2916
+  - uid: 2967
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,8.5
       parent: 2
-  - uid: 2917
+  - uid: 2968
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 2
-  - uid: 2918
+  - uid: 2969
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 2
-  - uid: 2919
+  - uid: 2970
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 2
-  - uid: 2920
+  - uid: 2971
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-23.5
       parent: 2
-  - uid: 2921
+  - uid: 2972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-24.5
       parent: 2
-  - uid: 2922
+  - uid: 2973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-26.5
       parent: 2
-  - uid: 2923
+  - uid: 2974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-27.5
       parent: 2
-  - uid: 2924
+  - uid: 2975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-28.5
       parent: 2
-  - uid: 2925
+  - uid: 2976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-30.5
       parent: 2
-  - uid: 2926
+  - uid: 2977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-31.5
       parent: 2
-  - uid: 2927
+  - uid: 2978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-31.5
       parent: 2
-  - uid: 2928
+  - uid: 2979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-29.5
       parent: 2
-  - uid: 2929
+  - uid: 2980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-28.5
       parent: 2
-  - uid: 2930
+  - uid: 2981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-25.5
       parent: 2
-  - uid: 2931
+  - uid: 2982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-23.5
       parent: 2
-  - uid: 2932
+  - uid: 2983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-23.5
       parent: 2
-  - uid: 2933
+  - uid: 2984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-24.5
       parent: 2
-  - uid: 2934
+  - uid: 2985
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-26.5
       parent: 2
-  - uid: 2935
+  - uid: 2986
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-28.5
       parent: 2
-  - uid: 2936
+  - uid: 2987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-29.5
       parent: 2
-  - uid: 2937
+  - uid: 2988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-31.5
       parent: 2
-  - uid: 2938
+  - uid: 2989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21112,474 +21425,493 @@ entities:
       parent: 2
 - proto: SolarTracker
   entities:
-  - uid: 2939
+  - uid: 2990
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 2
-  - uid: 2940
+  - uid: 2991
     components:
     - type: Transform
       pos: -48.5,-27.5
       parent: 2
 - proto: SpaceHeaterAnchored
   entities:
-  - uid: 1150
+  - uid: 2992
     components:
     - type: Transform
       pos: -28.5,1.5
       parent: 2
 - proto: SpaceVillainArcadeFilled
   entities:
-  - uid: 1214
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 2
-  - uid: 2941
+  - uid: 2993
     components:
     - type: Transform
       pos: -33.5,-12.5
       parent: 2
-  - uid: 2942
-    components:
-    - type: Transform
-      pos: -32.5,-12.5
-      parent: 2
-- proto: SpawnMechRipley
-  entities:
-  - uid: 2943
-    components:
-    - type: Transform
-      pos: -2.5,-9.5
-      parent: 2
-- proto: SpawnMobCat
-  entities:
-  - uid: 2944
-    components:
-    - type: Transform
-      pos: -31.5,8.5
-      parent: 2
 - proto: SpawnMobCorgi
   entities:
-  - uid: 2945
+  - uid: 2995
     components:
     - type: Transform
       pos: -31.5,-24.5
       parent: 2
-- proto: SpawnMobCrabAtmos
+- proto: SpawnMobEngineeringPet
   entities:
-  - uid: 2946
+  - uid: 2854
     components:
     - type: Transform
-      pos: -42.5,8.5
+      pos: -43.5,8.5
+      parent: 2
+- proto: SpawnMobFireBot
+  entities:
+  - uid: 3732
+    components:
+    - type: Transform
+      pos: -21.5,6.5
+      parent: 2
+- proto: SpawnMobFoxRenault
+  entities:
+  - uid: 2997
+    components:
+    - type: Transform
+      pos: -43.5,-28.5
+      parent: 2
+- proto: SpawnMobMedicalPet
+  entities:
+  - uid: 2994
+    components:
+    - type: Transform
+      pos: -31.5,8.5
       parent: 2
 - proto: SpawnMobMonkeyPunpun
   entities:
-  - uid: 2947
+  - uid: 2998
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 2
 - proto: SpawnMobShiva
   entities:
-  - uid: 2948
+  - uid: 2999
     components:
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
 - proto: SpawnMobSlothPaperwork
   entities:
-  - uid: 3693
+  - uid: 3000
     components:
     - type: Transform
       pos: -31.5,-6.5
       parent: 2
 - proto: SpawnMobSmile
   entities:
-  - uid: 2949
+  - uid: 3001
     components:
     - type: Transform
       pos: -41.5,-6.5
       parent: 2
 - proto: SpawnPointAdminAssistant
   entities:
-  - uid: 2950
+  - uid: 2489
     components:
     - type: Transform
-      pos: -42.5,-23.5
+      pos: -42.5,-24.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 2951
+  - uid: 3002
     components:
     - type: Transform
       pos: -42.5,1.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 2952
+  - uid: 3003
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
 - proto: SpawnPointBorg
   entities:
-  - uid: 2953
+  - uid: 3004
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 2954
+  - uid: 3005
     components:
     - type: Transform
       pos: -20.5,6.5
       parent: 2
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 2495
+  - uid: 3006
     components:
     - type: Transform
       pos: -32.5,-18.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 2955
+  - uid: 3007
     components:
     - type: Transform
       pos: -42.5,-28.5
       parent: 2
 - proto: SpawnPointCargoAssistant
   entities:
-  - uid: 2956
+  - uid: 3008
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 2
-  - uid: 2957
+  - uid: 3009
     components:
     - type: Transform
       pos: -11.5,-9.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 2958
+  - uid: 3010
     components:
     - type: Transform
-      pos: -8.5,-9.5
+      pos: -7.5,-9.5
       parent: 2
 - proto: SpawnPointChaplain
   entities:
-  - uid: 2959
+  - uid: 3011
     components:
     - type: Transform
       pos: -32.5,-9.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 2960
+  - uid: 3012
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 2961
+  - uid: 3013
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 2962
+  - uid: 3014
     components:
     - type: Transform
       pos: -37.5,-27.5
       parent: 2
 - proto: SpawnPointChiefMedicalOfficer
   entities:
-  - uid: 2963
+  - uid: 3015
     components:
     - type: Transform
       pos: -36.5,-27.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 2964
+  - uid: 3016
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
 - proto: SpawnPointCourier
   entities:
-  - uid: 2965
+  - uid: 3017
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 2966
+  - uid: 3018
     components:
     - type: Transform
       pos: -33.5,-22.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 2967
+  - uid: 3019
     components:
     - type: Transform
       pos: -34.5,-27.5
       parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 2968
+  - uid: 3020
     components:
     - type: Transform
       pos: -40.5,-14.5
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 3631
+  - uid: 3021
     components:
     - type: Transform
       pos: -46.5,-20.5
       parent: 2
-  - uid: 3660
+  - uid: 3022
     components:
     - type: Transform
       pos: -48.5,-20.5
       parent: 2
-  - uid: 3686
+  - uid: 3023
     components:
     - type: Transform
       pos: -41.5,-20.5
       parent: 2
-  - uid: 3687
+  - uid: 3024
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 3688
+  - uid: 3025
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
+- proto: SpawnPointLawyer
+  entities:
+  - uid: 3744
+    components:
+    - type: Transform
+      pos: -33.5,-6.5
+      parent: 2
 - proto: SpawnPointLibrarian
   entities:
-  - uid: 1481
+  - uid: 3026
     components:
     - type: Transform
       pos: -32.5,-6.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 2969
+  - uid: 3027
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 2970
+  - uid: 3028
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 2971
+  - uid: 3029
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 2972
+  - uid: 3030
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
-  - uid: 2973
+  - uid: 3031
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
+- proto: SpawnPointParamedic
+  entities:
+  - uid: 3193
+    components:
+    - type: Transform
+      pos: -29.5,7.5
+      parent: 2
 - proto: SpawnPointPassenger
   entities:
-  - uid: 2974
+  - uid: 3032
     components:
     - type: Transform
       pos: -42.5,-20.5
       parent: 2
-  - uid: 2975
+  - uid: 3033
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 2976
+  - uid: 3034
     components:
     - type: Transform
       pos: -26.5,-0.5
       parent: 2
-  - uid: 2977
+  - uid: 3035
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 2
-  - uid: 2978
+  - uid: 3036
     components:
     - type: Transform
       pos: -47.5,-20.5
       parent: 2
 - proto: SpawnPointPrisoner
   entities:
-  - uid: 185
+  - uid: 3037
     components:
     - type: Transform
       pos: -30.5,-13.5
       parent: 2
 - proto: SpawnPointPsychologist
   entities:
-  - uid: 3127
+  - uid: 3038
     components:
     - type: Transform
       pos: -29.5,10.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 2979
+  - uid: 3039
     components:
     - type: Transform
       pos: -32.5,-27.5
       parent: 2
 - proto: SpawnPointReporter
   entities:
-  - uid: 2980
+  - uid: 3040
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 2981
+  - uid: 3041
     components:
     - type: Transform
       pos: -42.5,-6.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 2982
+  - uid: 3042
     components:
     - type: Transform
       pos: -35.5,-27.5
       parent: 2
 - proto: SpawnPointRoboticist
   entities:
-  - uid: 2983
+  - uid: 2565
     components:
     - type: Transform
-      pos: -41.5,-7.5
+      pos: -43.5,-3.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 2984
+  - uid: 3044
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 2985
+  - uid: 3045
     components:
     - type: Transform
       pos: -43.5,-6.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 2986
+  - uid: 3046
     components:
     - type: Transform
       pos: -30.5,-18.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 2987
+  - uid: 3047
     components:
     - type: Transform
       pos: -31.5,-18.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 2988
+  - uid: 3048
     components:
     - type: Transform
       pos: -42.5,0.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 2989
+  - uid: 3049
     components:
     - type: Transform
       pos: -40.5,1.5
       parent: 2
 - proto: SpiderWeb
   entities:
-  - uid: 2990
+  - uid: 3050
     components:
     - type: Transform
       pos: -50.5,3.5
       parent: 2
 - proto: StairStageWood
   entities:
-  - uid: 2991
+  - uid: 3051
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 2992
+  - uid: 3052
     components:
     - type: Transform
       pos: -32.5,6.5
       parent: 2
+- proto: StationAiFixerComputer
+  entities:
+  - uid: 3053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -39.5,-29.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - ResearchDirector
 - proto: StationAnchor
   entities:
-  - uid: 2993
+  - uid: 3054
     components:
     - type: Transform
       pos: -35.5,14.5
       parent: 2
 - proto: StationMap
   entities:
-  - uid: 2994
+  - uid: 3055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -34.5,-11.5
+      rot: 3.141592653589793 rad
+      pos: -41.5,-21.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 2995
+  - uid: 3056
     components:
     - type: Transform
-      pos: -41.5,-16.5
+      rot: 1.5707963267948966 rad
+      pos: -38.5,-12.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 2996
+  - uid: 3057
     components:
     - type: Transform
       pos: -34.5,0.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2997
+  - uid: 3058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21589,190 +21921,221 @@ entities:
       fixtures: {}
 - proto: SteelBench
   entities:
-  - uid: 2998
+  - uid: 3059
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -41.5,-20.5
       parent: 2
-  - uid: 2999
+  - uid: 3060
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -42.5,-20.5
       parent: 2
-  - uid: 3000
+  - uid: 3061
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -43.5,-20.5
+      parent: 2
+  - uid: 3062
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -46.5,-20.5
       parent: 2
-  - uid: 3001
+  - uid: 3063
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -47.5,-20.5
       parent: 2
-  - uid: 3002
-    components:
-    - type: Transform
-      pos: -48.5,-20.5
-      parent: 2
-  - uid: 3003
+  - uid: 3064
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-10.5
       parent: 2
-  - uid: 3004
+  - uid: 3065
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-10.5
       parent: 2
-  - uid: 3005
+  - uid: 3066
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-10.5
       parent: 2
+  - uid: 3067
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -48.5,-20.5
+      parent: 2
 - proto: StoolBar
   entities:
-  - uid: 3006
+  - uid: 3068
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,-0.5
+      parent: 2
+  - uid: 3069
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-0.5
       parent: 2
-  - uid: 3007
+  - uid: 3070
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-0.5
       parent: 2
-  - uid: 3008
+  - uid: 3071
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-0.5
       parent: 2
-  - uid: 3009
+  - uid: 3072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-0.5
       parent: 2
-  - uid: 3010
+  - uid: 3073
     components:
     - type: Transform
-      pos: -9.5,1.5
+      rot: 3.141592653589793 rad
+      pos: -15.5,-0.5
       parent: 2
-  - uid: 3011
+- proto: StorageCanister
+  entities:
+  - uid: 2777
     components:
     - type: Transform
-      pos: -10.5,1.5
+      pos: -45.5,16.5
       parent: 2
 - proto: SubstationWallBasic
   entities:
-  - uid: 3012
+  - uid: 3074
     components:
+    - type: MetaData
+      name: Evac wallmount substation
     - type: Transform
       pos: -43.5,-16.5
       parent: 2
-  - uid: 3013
+  - uid: 3075
     components:
     - type: Transform
       pos: -39.5,-12.5
       parent: 2
-  - uid: 3014
+  - uid: 3076
     components:
+    - type: MetaData
+      name: Security wallmount substation
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-20.5
       parent: 2
-  - uid: 3015
+  - uid: 3077
     components:
+    - type: MetaData
+      name: Bridge wallmount substation
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-24.5
       parent: 2
-  - uid: 3016
+  - uid: 3078
     components:
+    - type: MetaData
+      name: Medical wallmount substation
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,3.5
       parent: 2
-  - uid: 3017
+  - uid: 3079
     components:
+    - type: MetaData
+      name: Engineering wallmount substation
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,-1.5
       parent: 2
-  - uid: 3018
+  - uid: 3080
     components:
+    - type: MetaData
+      name: Botany & Kitchen wallmount substation
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,0.5
       parent: 2
-  - uid: 3019
+  - uid: 3081
     components:
+    - type: MetaData
+      name: Bar wallmount substation
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 2
-  - uid: 3020
+  - uid: 3082
     components:
+    - type: MetaData
+      name: Logistics wallmount substation
     - type: Transform
       pos: -17.5,-6.5
       parent: 2
-  - uid: 3021
+  - uid: 3083
     components:
+    - type: MetaData
+      name: EVA wallmount substation
     - type: Transform
       pos: -28.5,-4.5
       parent: 2
-  - uid: 3022
+  - uid: 3084
     components:
+    - type: MetaData
+      name: Chapel & Library wallmount substation
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-7.5
       parent: 2
-- proto: SuitStorageBase
+- proto: SuitStorageEVA
   entities:
-  - uid: 2545
+  - uid: 2238
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 2546
-- proto: SuitStorageEVA
-  entities:
-  - uid: 3023
+  - uid: 3085
     components:
     - type: Transform
       pos: -24.5,-6.5
       parent: 2
-  - uid: 3024
+  - uid: 3086
     components:
     - type: Transform
       pos: -24.5,-7.5
       parent: 2
 - proto: SuitStorageSec
   entities:
-  - uid: 3025
+  - uid: 3087
     components:
     - type: Transform
       pos: -33.5,-19.5
       parent: 2
-  - uid: 3026
+  - uid: 3088
     components:
     - type: Transform
       pos: -32.5,-19.5
       parent: 2
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 3027
+  - uid: 3089
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21783,7 +22146,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Botany
-  - uid: 3028
+  - uid: 3090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21794,7 +22157,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Shuttle Bay
-  - uid: 3029
+  - uid: 3091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21805,7 +22168,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Evac
-  - uid: 3030
+  - uid: 3092
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21816,7 +22179,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Science
-  - uid: 3031
+  - uid: 3093
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21827,7 +22190,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Engineering
-  - uid: 3032
+  - uid: 3094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21838,7 +22201,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Medical
-  - uid: 3033
+  - uid: 3095
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21849,7 +22212,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Chemistry
-  - uid: 3034
+  - uid: 3096
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21860,7 +22223,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Kitchen
-  - uid: 3035
+  - uid: 3097
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21871,7 +22234,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Bar
-  - uid: 3036
+  - uid: 3098
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21882,7 +22245,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Arrivals
-  - uid: 3037
+  - uid: 3099
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21893,7 +22256,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Cargo
-  - uid: 3038
+  - uid: 3100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21906,26 +22269,26 @@ entities:
       id: Salvage
 - proto: SurveillanceCameraRouterGeneral
   entities:
-  - uid: 3039
+  - uid: 3101
     components:
     - type: Transform
       pos: -43.5,-23.5
       parent: 2
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 3040
+  - uid: 3102
     components:
     - type: Transform
       pos: -43.5,-24.5
       parent: 2
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 1226
+  - uid: 3103
     components:
     - type: Transform
       pos: -33.5,-24.5
       parent: 2
-  - uid: 3041
+  - uid: 3104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21936,7 +22299,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security
-  - uid: 3042
+  - uid: 3105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21947,7 +22310,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Brig
-  - uid: 3043
+  - uid: 3106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21958,7 +22321,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Bridge
-  - uid: 3045
+  - uid: 3107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21971,14 +22334,14 @@ entities:
       id: Server Room
 - proto: SurveillanceCameraWirelessRouterEntertainment
   entities:
-  - uid: 3046
+  - uid: 3108
     components:
     - type: Transform
       pos: -43.5,-22.5
       parent: 2
 - proto: SurveillanceWirelessCameraAnchoredEntertainment
   entities:
-  - uid: 3047
+  - uid: 3109
     components:
     - type: Transform
       pos: -47.5,8.5
@@ -21990,7 +22353,7 @@ entities:
       id: Frankwatch
 - proto: SyndieFlag
   entities:
-  - uid: 3664
+  - uid: 3110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21998,21 +22361,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 3665
+  - uid: 3111
     components:
     - type: Transform
       pos: -38.5,-24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 3666
+  - uid: 3112
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 3667
+  - uid: 3113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22022,215 +22385,245 @@ entities:
       fixtures: {}
 - proto: Table
   entities:
-  - uid: 3048
+  - uid: 3114
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 3115
+    components:
+    - type: Transform
+      pos: -43.5,-2.5
+      parent: 2
+  - uid: 3116
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 2
-  - uid: 3049
+  - uid: 3117
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
-  - uid: 3050
+  - uid: 3118
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 2
-  - uid: 3051
+  - uid: 3119
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 2
-  - uid: 3052
+  - uid: 3120
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 2
-  - uid: 3053
-    components:
-    - type: Transform
-      pos: -5.5,3.5
-      parent: 2
-  - uid: 3054
+  - uid: 3121
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
-  - uid: 3055
+  - uid: 3122
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 2
-  - uid: 3056
+  - uid: 3123
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 2
-  - uid: 3057
+  - uid: 3124
     components:
     - type: Transform
       pos: -14.5,5.5
       parent: 2
-  - uid: 3058
+  - uid: 3125
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
-  - uid: 3059
+  - uid: 3126
     components:
     - type: Transform
       pos: -24.5,4.5
       parent: 2
-  - uid: 3060
+  - uid: 3127
     components:
     - type: Transform
       pos: -19.5,5.5
       parent: 2
-  - uid: 3061
+  - uid: 3128
     components:
     - type: Transform
       pos: -23.5,2.5
       parent: 2
-  - uid: 3062
+  - uid: 3129
     components:
     - type: Transform
       pos: -26.5,-13.5
       parent: 2
-  - uid: 3063
+  - uid: 3130
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
-  - uid: 3064
+  - uid: 3131
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
-  - uid: 3065
+  - uid: 3132
     components:
     - type: Transform
       pos: -27.5,5.5
       parent: 2
-  - uid: 3066
+  - uid: 3133
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 2
-  - uid: 3067
+  - uid: 3134
     components:
     - type: Transform
       pos: -26.5,-12.5
       parent: 2
-  - uid: 3068
+  - uid: 3135
     components:
     - type: Transform
       pos: -26.5,-11.5
       parent: 2
-  - uid: 3069
+  - uid: 3136
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 2
-  - uid: 3070
+  - uid: 3137
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 2
-  - uid: 3071
+  - uid: 3138
     components:
     - type: Transform
       pos: -28.5,11.5
       parent: 2
-  - uid: 3072
+  - uid: 3139
     components:
     - type: Transform
       pos: -28.5,10.5
       parent: 2
-  - uid: 3073
+  - uid: 3140
     components:
     - type: Transform
       pos: -32.5,-14.5
       parent: 2
-  - uid: 3074
+  - uid: 3141
     components:
     - type: Transform
       pos: -33.5,-14.5
       parent: 2
-  - uid: 3075
+  - uid: 3142
     components:
     - type: Transform
       pos: -36.5,6.5
       parent: 2
-  - uid: 3076
+  - uid: 3143
     components:
     - type: Transform
       pos: -43.5,11.5
       parent: 2
-  - uid: 3077
+  - uid: 3144
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 2
-  - uid: 3078
+  - uid: 3145
     components:
     - type: Transform
       pos: -49.5,-16.5
       parent: 2
-  - uid: 3079
+  - uid: 3146
     components:
     - type: Transform
       pos: -34.5,-22.5
       parent: 2
-  - uid: 3080
+  - uid: 3147
     components:
     - type: Transform
       pos: -34.5,-23.5
       parent: 2
-  - uid: 3081
+  - uid: 3148
     components:
     - type: Transform
       pos: -37.5,-25.5
       parent: 2
-  - uid: 3082
+  - uid: 3149
     components:
     - type: Transform
       pos: -35.5,-25.5
       parent: 2
-  - uid: 3083
+  - uid: 3150
     components:
     - type: Transform
       pos: -36.5,-25.5
       parent: 2
-  - uid: 3084
+  - uid: 3151
     components:
     - type: Transform
       pos: -31.5,-21.5
       parent: 2
-  - uid: 3085
+  - uid: 3152
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
-  - uid: 3086
+  - uid: 3153
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 2
-  - uid: 3700
+  - uid: 3154
     components:
     - type: Transform
-      pos: -15.5,5.5
+      pos: -16.5,4.5
+      parent: 2
+  - uid: 3155
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-10.5
+      parent: 2
+  - uid: 3156
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -40.5,-29.5
+      parent: 2
+  - uid: 3206
+    components:
+    - type: Transform
+      pos: -16.5,5.5
+      parent: 2
+- proto: TableCard
+  entities:
+  - uid: 3157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -45.5,-13.5
       parent: 2
 - proto: TableFancyRed
   entities:
-  - uid: 3087
+  - uid: 3158
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 2
-  - uid: 3088
+  - uid: 3159
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22238,13 +22631,13 @@ entities:
       parent: 2
 - proto: TableFancyWhite
   entities:
-  - uid: 3089
+  - uid: 3160
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-5.5
       parent: 2
-  - uid: 3090
+  - uid: 3161
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22252,62 +22645,68 @@ entities:
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 3091
+  - uid: 3162
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
-  - uid: 3092
+  - uid: 3163
     components:
     - type: Transform
       pos: -15.5,0.5
       parent: 2
+  - uid: 3164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,-0.5
+      parent: 2
 - proto: TableWood
   entities:
-  - uid: 3093
+  - uid: 3165
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 3094
+  - uid: 3166
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 3095
+  - uid: 3167
     components:
     - type: Transform
       pos: -32.5,-5.5
       parent: 2
-  - uid: 3096
+  - uid: 3168
     components:
     - type: Transform
       pos: -31.5,-5.5
       parent: 2
-  - uid: 3097
+  - uid: 3169
     components:
     - type: Transform
       pos: -33.5,-8.5
       parent: 2
-  - uid: 3098
+  - uid: 3170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,1.5
       parent: 2
-  - uid: 3099
+  - uid: 3171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,0.5
       parent: 2
-  - uid: 3100
+  - uid: 3172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,-20.5
       parent: 2
-  - uid: 3101
+  - uid: 3173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22315,154 +22714,142 @@ entities:
       parent: 2
 - proto: TableWoodReinforced
   entities:
-  - uid: 3102
+  - uid: 3174
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 2
-  - uid: 3103
+  - uid: 3175
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 2
-  - uid: 3104
+  - uid: 3176
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 2
-  - uid: 3105
+  - uid: 3177
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 2
-  - uid: 3106
+  - uid: 3178
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
 - proto: TelecomServerFilled
   entities:
-  - uid: 3107
+  - uid: 3179
     components:
     - type: Transform
       pos: -43.5,-25.5
       parent: 2
 - proto: ThrusterFlatpack
   entities:
-  - uid: 3108
+  - uid: 3180
     components:
     - type: Transform
       pos: -26.393793,-11.803688
       parent: 2
-  - uid: 3109
+  - uid: 3181
     components:
     - type: Transform
       pos: -26.628168,-12.084938
       parent: 2
-  - uid: 3110
+  - uid: 3182
     components:
     - type: Transform
       pos: -26.393793,-12.334938
       parent: 2
 - proto: ToolboxArtisticFilled
   entities:
-  - uid: 3111
+  - uid: 3183
     components:
     - type: Transform
-      pos: -29.513348,-7.462534
+      pos: -29.401129,-5.4334598
+      parent: 2
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 3184
+    components:
+    - type: Transform
+      pos: -43.652096,11.770135
       parent: 2
 - proto: ToolboxMechanicalFilledAllTools
   entities:
-  - uid: 3112
+  - uid: 3186
     components:
     - type: Transform
-      pos: -29.513348,-7.150034
+      pos: -29.573004,-5.2926884
       parent: 2
 - proto: ToyAmongPequeno
   entities:
-  - uid: 2452
+  - uid: 3187
     components:
     - type: Transform
       pos: -8.337955,0.8512052
       parent: 2
-  - uid: 3113
+  - uid: 3188
     components:
     - type: Transform
       pos: -46.97438,4.2337456
       parent: 2
-  - uid: 3114
-    components:
-    - type: Transform
-      pos: -30.221962,-16.617868
-      parent: 2
 - proto: ToyFigurineQuartermaster
   entities:
-  - uid: 2261
+  - uid: 3189
     components:
     - type: Transform
       pos: -12.608709,-10.234196
       parent: 2
 - proto: TreasureCoinGold
   entities:
-  - uid: 3605
+  - uid: 3190
     components:
     - type: Transform
       pos: -18.437244,-12.429417
       parent: 2
 - proto: TreasureCoinSilver
   entities:
-  - uid: 1253
+  - uid: 3191
     components:
     - type: Transform
       pos: -18.56741,-12.561357
       parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 3115
+  - uid: 3192
     components:
     - type: Transform
       pos: -28.5,-7.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1249:
+        1285:
         - - Left
           - Reverse
         - - Right
           - Forward
         - - Middle
           - Off
-        1250:
+        1286:
         - - Left
           - Reverse
         - - Right
           - Forward
         - - Middle
           - Off
-        2723:
+        2763:
         - - Left
           - Forward
         - - Right
           - Reverse
         - - Middle
           - Off
-  - uid: 3116
-    components:
-    - type: Transform
-      pos: -43.5,-8.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        181:
-        - - Left
-          - Open
-        - - Right
-          - Open
-        - - Middle
-          - Close
 - proto: UniformPrinter
   entities:
-  - uid: 3117
+  - uid: 3194
     components:
     - type: Transform
       pos: -33.5,-24.5
@@ -22475,20 +22862,20 @@ entities:
       - CivilianServices
 - proto: UraniumCrabSpawnerFrank
   entities:
-  - uid: 3118
+  - uid: 3195
     components:
     - type: Transform
       pos: -47.5,4.5
       parent: 2
 - proto: UraniumOre1
   entities:
-  - uid: 3119
+  - uid: 3196
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.396255,4.249551
       parent: 2
-  - uid: 3120
+  - uid: 3197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22496,302 +22883,334 @@ entities:
       parent: 2
 - proto: UraniumWindoorSecureEngineeringLocked
   entities:
-  - uid: 3121
+  - uid: 3198
     components:
     - type: Transform
       pos: -46.5,6.5
       parent: 2
-  - uid: 3122
+  - uid: 3199
     components:
     - type: Transform
       pos: -47.5,6.5
       parent: 2
-  - uid: 3123
+  - uid: 3200
     components:
     - type: Transform
       pos: -48.5,6.5
       parent: 2
+- proto: UtilityKnife
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      parent: 3
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 3
 - proto: VendingMachineAtmosDrobe
   entities:
-  - uid: 3124
+  - uid: 3201
     components:
     - type: Transform
       pos: -39.5,16.5
       parent: 2
 - proto: VendingMachineBooze
   entities:
-  - uid: 3125
+  - uid: 3202
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
 - proto: VendingMachineCargoDrobe
   entities:
-  - uid: 3126
+  - uid: 3203
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
 - proto: VendingMachineCart
   entities:
-  - uid: 3044
+  - uid: 3204
     components:
     - type: Transform
       pos: -32.5,-21.5
       parent: 2
 - proto: VendingMachineChapel
   entities:
-  - uid: 3128
+  - uid: 3205
     components:
     - type: Transform
       pos: -31.5,-8.5
       parent: 2
-- proto: VendingMachineChefvend
+- proto: VendingMachineChefDrobe
   entities:
-  - uid: 3129
+  - uid: 1604
     components:
     - type: Transform
-      pos: -14.5,7.5
+      pos: -14.5,8.5
+      parent: 2
+- proto: VendingMachineChefvend
+  entities:
+  - uid: 2784
+    components:
+    - type: Transform
+      pos: -14.5,3.5
       parent: 2
 - proto: VendingMachineChemDrobe
   entities:
-  - uid: 3130
+  - uid: 3207
     components:
     - type: Transform
       pos: -35.5,11.5
       parent: 2
 - proto: VendingMachineChemicals
   entities:
-  - uid: 3131
+  - uid: 3208
     components:
     - type: Transform
       pos: -26.5,1.5
       parent: 2
 - proto: VendingMachineCigs
   entities:
-  - uid: 3132
+  - uid: 3209
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 2
 - proto: VendingMachineClothing
   entities:
-  - uid: 3133
+  - uid: 3210
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
 - proto: VendingMachineCoffee
   entities:
-  - uid: 3134
+  - uid: 3211
     components:
     - type: Transform
       pos: -46.5,-17.5
       parent: 2
+- proto: VendingMachineCondiments
+  entities:
+  - uid: 3212
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,-0.5
+      parent: 2
 - proto: VendingMachineCourierDrobe
   entities:
-  - uid: 3135
+  - uid: 3213
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 2
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 3136
+  - uid: 1224
     components:
     - type: Transform
-      pos: -14.5,3.5
+      pos: -15.5,8.5
       parent: 2
 - proto: VendingMachineDonut
   entities:
-  - uid: 3137
+  - uid: 3215
     components:
     - type: Transform
-      pos: -17.5,-0.5
+      pos: -20.5,-0.5
       parent: 2
 - proto: VendingMachineEngiDrobe
   entities:
-  - uid: 3138
+  - uid: 3216
     components:
     - type: Transform
       pos: -44.5,-0.5
       parent: 2
 - proto: VendingMachineEngivend
   entities:
-  - uid: 3139
+  - uid: 3217
     components:
     - type: Transform
       pos: -34.5,1.5
       parent: 2
 - proto: VendingMachineGames
   entities:
-  - uid: 3140
+  - uid: 3218
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
 - proto: VendingMachineHydrobe
   entities:
-  - uid: 3141
+  - uid: 3219
     components:
     - type: Transform
       pos: -18.5,5.5
       parent: 2
 - proto: VendingMachineJaniDrobe
   entities:
-  - uid: 2812
+  - uid: 3220
     components:
     - type: Transform
       pos: -42.5,-13.5
       parent: 2
 - proto: VendingMachineMedical
   entities:
-  - uid: 3143
+  - uid: 3221
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 3144
+  - uid: 3222
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 2
 - proto: VendingMachineMNKDrobe
   entities:
-  - uid: 3661
+  - uid: 3223
     components:
     - type: Transform
       pos: -47.5,-16.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
-  - uid: 3145
+  - uid: 3224
     components:
     - type: Transform
       pos: -19.5,8.5
       parent: 2
 - proto: VendingMachinePride
   entities:
-  - uid: 3146
+  - uid: 3225
     components:
     - type: Transform
       pos: -40.5,-17.5
       parent: 2
 - proto: VendingMachineRestockChemVend
   entities:
-  - uid: 3147
+  - uid: 3226
     components:
     - type: Transform
       pos: -28.361357,11.747647
       parent: 2
 - proto: VendingMachineRestockMedical
   entities:
-  - uid: 3148
+  - uid: 3227
     components:
     - type: Transform
       pos: -28.658232,11.903897
       parent: 2
+- proto: VendingMachineRobotics
+  entities:
+  - uid: 2514
+    components:
+    - type: Transform
+      pos: -44.5,-5.5
+      parent: 2
 - proto: VendingMachineSalvage
   entities:
-  - uid: 3149
+  - uid: 3228
     components:
     - type: Transform
       pos: -13.5,-10.5
       parent: 2
 - proto: VendingMachineSec
   entities:
-  - uid: 3150
+  - uid: 3229
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
 - proto: VendingMachineSecDrobe
   entities:
-  - uid: 3151
+  - uid: 3230
     components:
     - type: Transform
       pos: -28.5,-19.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:
-  - uid: 3152
+  - uid: 3231
     components:
     - type: Transform
       pos: -20.5,8.5
       parent: 2
 - proto: VendingMachineTankDispenserEngineering
   entities:
-  - uid: 3153
+  - uid: 3232
     components:
     - type: Transform
       pos: -50.5,6.5
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 3154
+  - uid: 3233
     components:
     - type: Transform
       pos: -19.5,-10.5
       parent: 2
-  - uid: 3155
+  - uid: 3234
     components:
     - type: Transform
       pos: -22.5,-7.5
       parent: 2
 - proto: VendingMachineTheater
   entities:
-  - uid: 3156
+  - uid: 3235
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
 - proto: VendingMachineWinter
   entities:
-  - uid: 3157
+  - uid: 3236
     components:
     - type: Transform
       pos: -39.5,-17.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 3158
+  - uid: 3237
     components:
     - type: Transform
       pos: -26.5,-7.5
       parent: 2
-  - uid: 3159
+  - uid: 3238
     components:
     - type: Transform
       pos: -34.5,2.5
       parent: 2
 - proto: ViolinInstrument
   entities:
-  - uid: 3160
+  - uid: 3239
     components:
     - type: Transform
       pos: -13.524579,-0.45186973
       parent: 2
 - proto: WallpaperFish
   entities:
-  - uid: 3757
+  - uid: 3240
     components:
     - type: Transform
       pos: -42.5,-26.5
       parent: 2
-  - uid: 3758
+  - uid: 3241
     components:
     - type: Transform
       pos: -43.5,-26.5
       parent: 2
-  - uid: 3760
+  - uid: 3242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-27.5
       parent: 2
-  - uid: 3761
+  - uid: 3243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22799,12 +23218,12 @@ entities:
       parent: 2
 - proto: WallpaperFishCorner
   entities:
-  - uid: 3754
+  - uid: 3244
     components:
     - type: Transform
       pos: -41.5,-26.5
       parent: 2
-  - uid: 3759
+  - uid: 3245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22812,2090 +23231,2061 @@ entities:
       parent: 2
 - proto: WallpaperStarsBig
   entities:
-  - uid: 3161
+  - uid: 3246
     components:
     - type: Transform
       pos: -33.5,-11.5
       parent: 2
 - proto: WallpaperStarsMoon
   entities:
-  - uid: 3162
+  - uid: 3247
     components:
     - type: Transform
       pos: -32.5,-11.5
       parent: 2
 - proto: WallpaperStarsSmall
   entities:
-  - uid: 3163
+  - uid: 3248
     components:
     - type: Transform
       pos: -31.5,-11.5
       parent: 2
 - proto: WallShuttle
   entities:
-  - uid: 3164
+  - uid: 71
     components:
     - type: Transform
-      pos: 0.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -16.5,6.5
       parent: 2
-  - uid: 3165
+  - uid: 1312
     components:
     - type: Transform
-      pos: 0.5,-7.5
-      parent: 2
-  - uid: 3166
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 2
-  - uid: 3167
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
-      parent: 2
-  - uid: 3168
-    components:
-    - type: Transform
-      pos: -1.5,-8.5
-      parent: 2
-  - uid: 3169
-    components:
-    - type: Transform
-      pos: -1.5,-9.5
-      parent: 2
-  - uid: 3170
-    components:
-    - type: Transform
-      pos: -1.5,-10.5
-      parent: 2
-  - uid: 3171
-    components:
-    - type: Transform
-      pos: -1.5,-11.5
-      parent: 2
-  - uid: 3172
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 2
-  - uid: 3173
-    components:
-    - type: Transform
-      pos: -5.5,-10.5
-      parent: 2
-  - uid: 3174
-    components:
-    - type: Transform
-      pos: -5.5,-9.5
-      parent: 2
-  - uid: 3175
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 2
-  - uid: 3176
-    components:
-    - type: Transform
-      pos: -14.5,-10.5
-      parent: 2
-  - uid: 3177
-    components:
-    - type: Transform
-      pos: -14.5,-11.5
-      parent: 2
-  - uid: 3178
-    components:
-    - type: Transform
-      pos: -15.5,-11.5
-      parent: 2
-  - uid: 3179
-    components:
-    - type: Transform
-      pos: -18.5,-11.5
-      parent: 2
-  - uid: 3180
-    components:
-    - type: Transform
-      pos: -19.5,-11.5
-      parent: 2
-  - uid: 3181
-    components:
-    - type: Transform
-      pos: -19.5,-12.5
-      parent: 2
-  - uid: 3182
-    components:
-    - type: Transform
-      pos: -19.5,-13.5
-      parent: 2
-  - uid: 3183
-    components:
-    - type: Transform
-      pos: -19.5,-14.5
-      parent: 2
-  - uid: 3184
-    components:
-    - type: Transform
-      pos: -27.5,-7.5
-      parent: 2
-  - uid: 3185
-    components:
-    - type: Transform
-      pos: -27.5,-8.5
-      parent: 2
-  - uid: 3186
-    components:
-    - type: Transform
-      pos: -27.5,-9.5
-      parent: 2
-  - uid: 3187
-    components:
-    - type: Transform
-      pos: -27.5,-10.5
-      parent: 2
-  - uid: 3188
-    components:
-    - type: Transform
-      pos: -27.5,-11.5
-      parent: 2
-  - uid: 3189
-    components:
-    - type: Transform
-      pos: -27.5,-12.5
-      parent: 2
-  - uid: 3190
-    components:
-    - type: Transform
-      pos: -27.5,-13.5
-      parent: 2
-  - uid: 3191
-    components:
-    - type: Transform
-      pos: -27.5,-14.5
-      parent: 2
-  - uid: 3192
-    components:
-    - type: Transform
-      pos: -6.5,-11.5
-      parent: 2
-  - uid: 3193
-    components:
-    - type: Transform
-      pos: -7.5,-11.5
-      parent: 2
-  - uid: 3194
-    components:
-    - type: Transform
-      pos: -8.5,-11.5
-      parent: 2
-  - uid: 3195
-    components:
-    - type: Transform
-      pos: -12.5,-11.5
-      parent: 2
-  - uid: 3196
-    components:
-    - type: Transform
-      pos: -13.5,-11.5
-      parent: 2
-  - uid: 3197
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 2
-  - uid: 3198
-    components:
-    - type: Transform
-      pos: -1.5,2.5
-      parent: 2
-  - uid: 3199
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 2
-  - uid: 3200
-    components:
-    - type: Transform
-      pos: -3.5,4.5
-      parent: 2
-  - uid: 3201
-    components:
-    - type: Transform
-      pos: -4.5,4.5
-      parent: 2
-  - uid: 3202
-    components:
-    - type: Transform
-      pos: -5.5,4.5
-      parent: 2
-  - uid: 3203
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 2
-  - uid: 3204
-    components:
-    - type: Transform
-      pos: -7.5,4.5
-      parent: 2
-  - uid: 3205
-    components:
-    - type: Transform
-      pos: -11.5,4.5
-      parent: 2
-  - uid: 3206
-    components:
-    - type: Transform
-      pos: -12.5,4.5
-      parent: 2
-  - uid: 3207
-    components:
-    - type: Transform
-      pos: -13.5,4.5
-      parent: 2
-  - uid: 3208
-    components:
-    - type: Transform
-      pos: -17.5,9.5
-      parent: 2
-  - uid: 3209
-    components:
-    - type: Transform
-      pos: -17.5,8.5
-      parent: 2
-  - uid: 3210
-    components:
-    - type: Transform
-      pos: -24.5,9.5
-      parent: 2
-  - uid: 3211
-    components:
-    - type: Transform
-      pos: -23.5,9.5
-      parent: 2
-  - uid: 3212
-    components:
-    - type: Transform
-      pos: -25.5,9.5
-      parent: 2
-  - uid: 3213
-    components:
-    - type: Transform
-      pos: -26.5,9.5
-      parent: 2
-  - uid: 3214
-    components:
-    - type: Transform
-      pos: -27.5,9.5
-      parent: 2
-  - uid: 3215
-    components:
-    - type: Transform
-      pos: -27.5,10.5
-      parent: 2
-  - uid: 3216
-    components:
-    - type: Transform
-      pos: -27.5,12.5
-      parent: 2
-  - uid: 3217
-    components:
-    - type: Transform
-      pos: -33.5,14.5
-      parent: 2
-  - uid: 3218
-    components:
-    - type: Transform
-      pos: -23.5,8.5
-      parent: 2
-  - uid: 3219
-    components:
-    - type: Transform
-      pos: -24.5,8.5
-      parent: 2
-  - uid: 3220
-    components:
-    - type: Transform
-      pos: -25.5,8.5
-      parent: 2
-  - uid: 3221
-    components:
-    - type: Transform
-      pos: -26.5,8.5
-      parent: 2
-  - uid: 3222
-    components:
-    - type: Transform
-      pos: -27.5,8.5
-      parent: 2
-  - uid: 3223
-    components:
-    - type: Transform
-      pos: -20.5,-15.5
-      parent: 2
-  - uid: 3224
-    components:
-    - type: Transform
-      pos: -26.5,-15.5
-      parent: 2
-  - uid: 3225
-    components:
-    - type: Transform
-      pos: -42.5,-10.5
-      parent: 2
-  - uid: 3226
-    components:
-    - type: Transform
-      pos: -33.5,12.5
-      parent: 2
-  - uid: 3227
-    components:
-    - type: Transform
-      pos: -33.5,11.5
-      parent: 2
-  - uid: 3228
-    components:
-    - type: Transform
-      pos: -42.5,-9.5
-      parent: 2
-  - uid: 3229
-    components:
-    - type: Transform
-      pos: -27.5,-15.5
-      parent: 2
-  - uid: 3230
-    components:
-    - type: Transform
-      pos: -34.5,12.5
-      parent: 2
-  - uid: 3231
-    components:
-    - type: Transform
-      pos: -27.5,-16.5
-      parent: 2
-  - uid: 3232
-    components:
-    - type: Transform
-      pos: -27.5,-20.5
-      parent: 2
-  - uid: 3233
-    components:
-    - type: Transform
-      pos: -27.5,-21.5
-      parent: 2
-  - uid: 3234
-    components:
-    - type: Transform
-      pos: -27.5,-22.5
-      parent: 2
-  - uid: 3235
-    components:
-    - type: Transform
-      pos: -28.5,-22.5
-      parent: 2
-  - uid: 3236
-    components:
-    - type: Transform
-      pos: -29.5,-22.5
-      parent: 2
-  - uid: 3237
-    components:
-    - type: Transform
-      pos: -30.5,-22.5
-      parent: 2
-  - uid: 3238
-    components:
-    - type: Transform
-      pos: -30.5,-21.5
-      parent: 2
-  - uid: 3239
-    components:
-    - type: Transform
-      pos: -30.5,-20.5
-      parent: 2
-  - uid: 3240
-    components:
-    - type: Transform
-      pos: -33.5,-20.5
-      parent: 2
-  - uid: 3241
-    components:
-    - type: Transform
-      pos: -32.5,-20.5
-      parent: 2
-  - uid: 3242
-    components:
-    - type: Transform
-      pos: -31.5,-20.5
-      parent: 2
-  - uid: 3243
-    components:
-    - type: Transform
-      pos: -35.5,12.5
-      parent: 2
-  - uid: 3244
-    components:
-    - type: Transform
-      pos: -36.5,12.5
-      parent: 2
-  - uid: 3245
-    components:
-    - type: Transform
-      pos: -37.5,12.5
-      parent: 2
-  - uid: 3246
-    components:
-    - type: Transform
-      pos: -37.5,11.5
-      parent: 2
-  - uid: 3247
-    components:
-    - type: Transform
-      pos: -38.5,12.5
-      parent: 2
-  - uid: 3248
-    components:
-    - type: Transform
-      pos: -39.5,12.5
+      pos: -34.5,-5.5
       parent: 2
   - uid: 3249
     components:
     - type: Transform
-      pos: -40.5,12.5
+      pos: 0.5,1.5
       parent: 2
   - uid: 3250
     components:
     - type: Transform
-      pos: -45.5,3.5
+      pos: 0.5,-7.5
       parent: 2
   - uid: 3251
     components:
     - type: Transform
-      pos: -46.5,3.5
+      pos: -0.5,-7.5
       parent: 2
   - uid: 3252
     components:
     - type: Transform
-      pos: -47.5,3.5
+      pos: -1.5,-7.5
       parent: 2
   - uid: 3253
     components:
     - type: Transform
-      pos: -48.5,3.5
+      pos: -1.5,-8.5
       parent: 2
   - uid: 3254
     components:
     - type: Transform
-      pos: -49.5,4.5
+      pos: -1.5,-9.5
       parent: 2
   - uid: 3255
     components:
     - type: Transform
-      pos: -49.5,5.5
+      pos: -1.5,-10.5
       parent: 2
   - uid: 3256
     components:
     - type: Transform
-      pos: -49.5,6.5
+      pos: -1.5,-11.5
       parent: 2
   - uid: 3257
     components:
     - type: Transform
-      pos: -49.5,8.5
+      pos: -5.5,-11.5
       parent: 2
   - uid: 3258
     components:
     - type: Transform
-      pos: -49.5,9.5
+      pos: -5.5,-10.5
       parent: 2
   - uid: 3259
     components:
     - type: Transform
-      pos: -49.5,10.5
+      pos: -5.5,-9.5
       parent: 2
   - uid: 3260
     components:
     - type: Transform
-      pos: -49.5,11.5
+      pos: -5.5,-7.5
       parent: 2
   - uid: 3261
     components:
     - type: Transform
-      pos: -49.5,3.5
+      pos: -14.5,-10.5
       parent: 2
   - uid: 3262
     components:
     - type: Transform
-      pos: -33.5,13.5
+      pos: -14.5,-11.5
       parent: 2
   - uid: 3263
     components:
     - type: Transform
-      pos: -42.5,12.5
+      pos: -15.5,-11.5
       parent: 2
   - uid: 3264
     components:
     - type: Transform
-      pos: -43.5,12.5
+      pos: -18.5,-11.5
       parent: 2
   - uid: 3265
     components:
     - type: Transform
-      pos: -44.5,12.5
+      pos: -19.5,-11.5
       parent: 2
   - uid: 3266
     components:
     - type: Transform
-      pos: -45.5,12.5
+      pos: -19.5,-12.5
       parent: 2
   - uid: 3267
     components:
     - type: Transform
-      pos: -46.5,12.5
+      pos: -19.5,-13.5
       parent: 2
   - uid: 3268
     components:
     - type: Transform
-      pos: -47.5,12.5
+      pos: -19.5,-14.5
       parent: 2
   - uid: 3269
     components:
     - type: Transform
-      pos: -48.5,12.5
+      pos: -27.5,-7.5
       parent: 2
   - uid: 3270
     components:
     - type: Transform
-      pos: -49.5,12.5
+      pos: -27.5,-8.5
       parent: 2
   - uid: 3271
     components:
     - type: Transform
-      pos: -50.5,5.5
+      pos: -27.5,-9.5
       parent: 2
   - uid: 3272
     components:
     - type: Transform
-      pos: -51.5,5.5
+      pos: -27.5,-10.5
       parent: 2
   - uid: 3273
     components:
     - type: Transform
-      pos: -52.5,5.5
+      pos: -27.5,-11.5
       parent: 2
   - uid: 3274
     components:
     - type: Transform
-      pos: -52.5,6.5
+      pos: -27.5,-12.5
       parent: 2
   - uid: 3275
     components:
     - type: Transform
-      pos: -52.5,7.5
+      pos: -27.5,-13.5
       parent: 2
   - uid: 3276
     components:
     - type: Transform
-      pos: -52.5,8.5
+      pos: -27.5,-14.5
       parent: 2
   - uid: 3277
     components:
     - type: Transform
-      pos: -52.5,9.5
+      pos: -6.5,-11.5
       parent: 2
   - uid: 3278
     components:
     - type: Transform
-      pos: -52.5,10.5
+      pos: -7.5,-11.5
       parent: 2
   - uid: 3279
     components:
     - type: Transform
-      pos: -44.5,-1.5
+      pos: -8.5,-11.5
       parent: 2
   - uid: 3280
     components:
     - type: Transform
-      pos: -43.5,-1.5
+      pos: -12.5,-11.5
       parent: 2
   - uid: 3281
     components:
     - type: Transform
-      pos: -42.5,-1.5
+      pos: -13.5,-11.5
       parent: 2
   - uid: 3282
     components:
     - type: Transform
-      pos: -41.5,-1.5
+      pos: -0.5,1.5
       parent: 2
   - uid: 3283
     components:
     - type: Transform
-      pos: -40.5,-1.5
+      pos: -1.5,2.5
       parent: 2
   - uid: 3284
     components:
     - type: Transform
-      pos: -39.5,-1.5
+      pos: -1.5,3.5
       parent: 2
   - uid: 3285
     components:
     - type: Transform
-      pos: -45.5,2.5
+      pos: -3.5,4.5
       parent: 2
   - uid: 3286
     components:
     - type: Transform
-      pos: -45.5,1.5
+      pos: -4.5,4.5
       parent: 2
   - uid: 3287
     components:
     - type: Transform
-      pos: -45.5,0.5
+      pos: -5.5,4.5
       parent: 2
   - uid: 3288
     components:
     - type: Transform
-      pos: -45.5,-0.5
+      pos: -6.5,4.5
       parent: 2
   - uid: 3289
     components:
     - type: Transform
-      pos: -45.5,-1.5
+      pos: -7.5,4.5
       parent: 2
   - uid: 3290
     components:
     - type: Transform
-      pos: -51.5,3.5
+      pos: -11.5,4.5
       parent: 2
   - uid: 3291
     components:
     - type: Transform
-      pos: -51.5,2.5
+      pos: -12.5,4.5
       parent: 2
   - uid: 3292
     components:
     - type: Transform
-      pos: -51.5,1.5
+      pos: -13.5,4.5
       parent: 2
   - uid: 3293
     components:
     - type: Transform
-      pos: -51.5,0.5
+      pos: -17.5,9.5
       parent: 2
   - uid: 3294
     components:
     - type: Transform
-      pos: -49.5,0.5
+      pos: -17.5,8.5
       parent: 2
   - uid: 3295
     components:
     - type: Transform
-      pos: -50.5,0.5
+      pos: -24.5,9.5
       parent: 2
   - uid: 3296
     components:
     - type: Transform
-      pos: -48.5,0.5
+      pos: -23.5,9.5
       parent: 2
   - uid: 3297
     components:
     - type: Transform
-      pos: -47.5,0.5
+      pos: -25.5,9.5
       parent: 2
   - uid: 3298
     components:
     - type: Transform
-      pos: -48.5,-15.5
+      pos: -26.5,9.5
       parent: 2
   - uid: 3299
     components:
     - type: Transform
-      pos: -47.5,-15.5
+      pos: -27.5,9.5
       parent: 2
   - uid: 3300
     components:
     - type: Transform
-      pos: -45.5,-2.5
+      pos: -27.5,10.5
       parent: 2
   - uid: 3301
     components:
     - type: Transform
-      pos: -47.5,-0.5
+      pos: -27.5,12.5
       parent: 2
   - uid: 3302
     components:
     - type: Transform
-      pos: -52.5,3.5
+      pos: -33.5,14.5
       parent: 2
   - uid: 3303
     components:
     - type: Transform
-      pos: -45.5,-11.5
+      pos: -23.5,8.5
       parent: 2
   - uid: 3304
     components:
     - type: Transform
-      pos: -45.5,-9.5
+      pos: -24.5,8.5
       parent: 2
   - uid: 3305
     components:
     - type: Transform
-      pos: -45.5,-8.5
+      pos: -25.5,8.5
       parent: 2
   - uid: 3306
     components:
     - type: Transform
-      pos: -45.5,-7.5
+      pos: -26.5,8.5
       parent: 2
   - uid: 3307
     components:
     - type: Transform
-      pos: -45.5,-6.5
+      pos: -27.5,8.5
       parent: 2
   - uid: 3308
     components:
     - type: Transform
-      pos: -45.5,-3.5
+      pos: -20.5,-15.5
       parent: 2
   - uid: 3309
     components:
     - type: Transform
-      pos: -43.5,-12.5
+      pos: -26.5,-15.5
       parent: 2
   - uid: 3310
     components:
     - type: Transform
-      pos: -44.5,-12.5
+      pos: -42.5,-10.5
       parent: 2
   - uid: 3311
     components:
     - type: Transform
-      pos: -45.5,-12.5
+      pos: -33.5,12.5
       parent: 2
   - uid: 3312
     components:
     - type: Transform
-      pos: -42.5,-12.5
+      pos: -33.5,11.5
       parent: 2
   - uid: 3313
     components:
     - type: Transform
-      pos: -46.5,-13.5
+      pos: -42.5,-9.5
       parent: 2
   - uid: 3314
     components:
     - type: Transform
-      pos: -46.5,-15.5
+      pos: -27.5,-15.5
       parent: 2
   - uid: 3315
     components:
     - type: Transform
-      pos: -46.5,-16.5
+      pos: -34.5,12.5
       parent: 2
   - uid: 3316
     components:
     - type: Transform
-      pos: -45.5,-16.5
+      pos: -27.5,-16.5
       parent: 2
   - uid: 3317
     components:
     - type: Transform
-      pos: -47.5,-1.5
+      pos: -27.5,-20.5
       parent: 2
   - uid: 3318
     components:
     - type: Transform
-      pos: -47.5,-2.5
+      pos: -27.5,-21.5
       parent: 2
   - uid: 3319
     components:
     - type: Transform
-      pos: -47.5,14.5
+      pos: -27.5,-22.5
       parent: 2
   - uid: 3320
     components:
     - type: Transform
-      pos: -36.5,16.5
+      pos: -28.5,-22.5
       parent: 2
   - uid: 3321
     components:
     - type: Transform
-      pos: -47.5,16.5
+      pos: -29.5,-22.5
       parent: 2
   - uid: 3322
     components:
     - type: Transform
-      pos: -37.5,17.5
+      pos: -30.5,-22.5
       parent: 2
   - uid: 3323
     components:
     - type: Transform
-      pos: -37.5,15.5
+      pos: -30.5,-21.5
       parent: 2
   - uid: 3324
     components:
     - type: Transform
-      pos: -34.5,16.5
+      pos: -30.5,-20.5
       parent: 2
   - uid: 3325
     components:
     - type: Transform
-      pos: -50.5,-15.5
+      pos: -33.5,-20.5
       parent: 2
   - uid: 3326
     components:
     - type: Transform
-      pos: -49.5,-15.5
+      pos: -32.5,-20.5
       parent: 2
   - uid: 3327
     components:
     - type: Transform
-      pos: -50.5,-16.5
+      pos: -31.5,-20.5
       parent: 2
   - uid: 3328
     components:
     - type: Transform
-      pos: -50.5,-21.5
+      pos: -35.5,12.5
       parent: 2
   - uid: 3329
     components:
     - type: Transform
-      pos: -49.5,-21.5
+      pos: -36.5,12.5
       parent: 2
   - uid: 3330
     components:
     - type: Transform
-      pos: -48.5,-21.5
+      pos: -37.5,12.5
       parent: 2
   - uid: 3331
     components:
     - type: Transform
-      pos: -47.5,-21.5
+      pos: -37.5,11.5
       parent: 2
   - uid: 3332
     components:
     - type: Transform
-      pos: -46.5,-21.5
+      pos: -38.5,12.5
       parent: 2
   - uid: 3333
     components:
     - type: Transform
-      pos: -45.5,-21.5
+      pos: -39.5,12.5
       parent: 2
   - uid: 3334
     components:
     - type: Transform
-      pos: -51.5,-21.5
+      pos: -40.5,12.5
       parent: 2
   - uid: 3335
     components:
     - type: Transform
-      pos: -51.5,-17.5
+      pos: -45.5,3.5
       parent: 2
   - uid: 3336
     components:
     - type: Transform
-      pos: -51.5,-16.5
+      pos: -46.5,3.5
       parent: 2
   - uid: 3337
     components:
     - type: Transform
-      pos: -33.5,15.5
+      pos: -47.5,3.5
       parent: 2
   - uid: 3338
     components:
     - type: Transform
-      pos: -42.5,-11.5
+      pos: -48.5,3.5
       parent: 2
   - uid: 3339
     components:
     - type: Transform
-      pos: -29.5,-23.5
+      pos: -49.5,4.5
       parent: 2
   - uid: 3340
     components:
     - type: Transform
-      pos: -29.5,-24.5
+      pos: -49.5,5.5
       parent: 2
   - uid: 3341
     components:
     - type: Transform
-      pos: -29.5,-25.5
+      pos: -49.5,6.5
       parent: 2
   - uid: 3342
     components:
     - type: Transform
-      pos: -41.5,-21.5
+      pos: -49.5,8.5
       parent: 2
   - uid: 3343
     components:
     - type: Transform
-      pos: -42.5,-21.5
+      pos: -49.5,9.5
       parent: 2
   - uid: 3344
     components:
     - type: Transform
-      pos: -43.5,-21.5
+      pos: -49.5,10.5
       parent: 2
   - uid: 3345
     components:
     - type: Transform
-      pos: -44.5,-21.5
+      pos: -49.5,11.5
       parent: 2
   - uid: 3346
     components:
     - type: Transform
-      pos: -41.5,-22.5
+      pos: -49.5,3.5
       parent: 2
   - uid: 3347
     components:
     - type: Transform
-      pos: -41.5,-24.5
+      pos: -33.5,13.5
       parent: 2
   - uid: 3348
     components:
     - type: Transform
-      pos: -41.5,-25.5
+      pos: -42.5,12.5
       parent: 2
   - uid: 3349
     components:
     - type: Transform
-      pos: -29.5,-26.5
+      pos: -43.5,12.5
       parent: 2
   - uid: 3350
     components:
     - type: Transform
-      pos: -29.5,-29.5
+      pos: -44.5,12.5
       parent: 2
   - uid: 3351
     components:
     - type: Transform
-      pos: -29.5,-30.5
+      pos: -45.5,12.5
       parent: 2
   - uid: 3352
     components:
     - type: Transform
-      pos: -30.5,-30.5
+      pos: -46.5,12.5
       parent: 2
   - uid: 3353
     components:
     - type: Transform
-      pos: -38.5,-30.5
+      pos: -47.5,12.5
       parent: 2
   - uid: 3354
     components:
     - type: Transform
-      pos: -39.5,-30.5
+      pos: -48.5,12.5
       parent: 2
   - uid: 3355
     components:
     - type: Transform
-      pos: -40.5,-30.5
+      pos: -49.5,12.5
       parent: 2
   - uid: 3356
     components:
     - type: Transform
-      pos: -41.5,-30.5
+      pos: -50.5,5.5
       parent: 2
   - uid: 3357
     components:
     - type: Transform
-      pos: -41.5,-26.5
+      pos: -51.5,5.5
       parent: 2
   - uid: 3358
     components:
     - type: Transform
-      pos: -42.5,-26.5
+      pos: -52.5,5.5
       parent: 2
   - uid: 3359
     components:
     - type: Transform
-      pos: -43.5,-26.5
+      pos: -52.5,6.5
       parent: 2
   - uid: 3360
     components:
     - type: Transform
-      pos: -44.5,-26.5
+      pos: -52.5,7.5
       parent: 2
   - uid: 3361
     components:
     - type: Transform
-      pos: -44.5,-27.5
+      pos: -52.5,8.5
       parent: 2
   - uid: 3362
     components:
     - type: Transform
-      pos: -44.5,-29.5
+      pos: -52.5,9.5
       parent: 2
   - uid: 3363
     components:
     - type: Transform
-      pos: -44.5,-30.5
+      pos: -52.5,10.5
       parent: 2
   - uid: 3364
     components:
     - type: Transform
-      pos: -43.5,-30.5
+      pos: -44.5,-1.5
       parent: 2
   - uid: 3365
     components:
     - type: Transform
-      pos: -42.5,-30.5
+      pos: -43.5,-1.5
       parent: 2
   - uid: 3366
     components:
     - type: Transform
-      pos: -44.5,-25.5
+      pos: -42.5,-1.5
       parent: 2
   - uid: 3367
     components:
     - type: Transform
-      pos: -44.5,-24.5
+      pos: -41.5,-1.5
       parent: 2
   - uid: 3368
     components:
     - type: Transform
-      pos: -44.5,-23.5
+      pos: -40.5,-1.5
       parent: 2
   - uid: 3369
     components:
     - type: Transform
-      pos: -44.5,-22.5
+      pos: -39.5,-1.5
       parent: 2
   - uid: 3370
     components:
     - type: Transform
-      pos: -41.5,-27.5
+      pos: -45.5,2.5
       parent: 2
   - uid: 3371
     components:
     - type: Transform
-      pos: -41.5,-29.5
+      pos: -45.5,1.5
       parent: 2
   - uid: 3372
     components:
     - type: Transform
-      pos: -37.5,16.5
+      pos: -45.5,0.5
       parent: 2
   - uid: 3373
     components:
     - type: Transform
-      pos: -37.5,13.5
+      pos: -45.5,-0.5
       parent: 2
   - uid: 3374
     components:
     - type: Transform
-      pos: -35.5,16.5
+      pos: -45.5,-1.5
       parent: 2
   - uid: 3375
     components:
     - type: Transform
-      pos: -47.5,15.5
+      pos: -51.5,3.5
       parent: 2
   - uid: 3376
     components:
     - type: Transform
-      pos: -16.5,9.5
+      pos: -51.5,2.5
       parent: 2
   - uid: 3377
     components:
     - type: Transform
-      pos: -47.5,17.5
+      pos: -51.5,1.5
       parent: 2
   - uid: 3378
     components:
     - type: Transform
-      pos: -27.5,11.5
+      pos: -51.5,0.5
       parent: 2
   - uid: 3379
     components:
     - type: Transform
-      pos: -13.5,8.5
+      pos: -49.5,0.5
       parent: 2
   - uid: 3380
     components:
     - type: Transform
-      pos: -14.5,9.5
+      pos: -50.5,0.5
       parent: 2
   - uid: 3381
     components:
     - type: Transform
-      pos: -15.5,9.5
+      pos: -48.5,0.5
       parent: 2
   - uid: 3382
     components:
     - type: Transform
-      pos: -13.5,7.5
+      pos: -47.5,0.5
       parent: 2
   - uid: 3383
     components:
     - type: Transform
-      pos: -13.5,6.5
+      pos: -48.5,-15.5
       parent: 2
   - uid: 3384
     components:
     - type: Transform
-      pos: -13.5,5.5
+      pos: -47.5,-15.5
       parent: 2
   - uid: 3385
     components:
     - type: Transform
-      pos: -5.5,-6.5
+      pos: -45.5,-2.5
       parent: 2
   - uid: 3386
     components:
     - type: Transform
-      pos: -6.5,-6.5
+      pos: -47.5,-0.5
       parent: 2
   - uid: 3387
     components:
     - type: Transform
-      pos: -19.5,-6.5
+      pos: -52.5,3.5
       parent: 2
   - uid: 3388
     components:
     - type: Transform
-      pos: -14.5,-6.5
+      pos: -45.5,-11.5
       parent: 2
   - uid: 3389
     components:
     - type: Transform
-      pos: -19.5,-7.5
+      pos: -45.5,-9.5
       parent: 2
   - uid: 3390
     components:
     - type: Transform
-      pos: -18.5,-6.5
+      pos: -45.5,-8.5
       parent: 2
   - uid: 3391
     components:
     - type: Transform
-      pos: -17.5,-6.5
+      pos: -45.5,-7.5
       parent: 2
   - uid: 3392
     components:
     - type: Transform
-      pos: -16.5,-6.5
+      pos: -45.5,-6.5
       parent: 2
   - uid: 3393
     components:
     - type: Transform
-      pos: -15.5,-6.5
+      pos: -45.5,-3.5
       parent: 2
   - uid: 3394
     components:
     - type: Transform
-      pos: -20.5,-6.5
+      pos: -43.5,-12.5
       parent: 2
   - uid: 3395
     components:
     - type: Transform
-      pos: -21.5,-6.5
+      pos: -44.5,-12.5
       parent: 2
   - uid: 3396
     components:
     - type: Transform
-      pos: -21.5,-7.5
+      pos: -45.5,-12.5
       parent: 2
   - uid: 3397
     components:
     - type: Transform
-      pos: -21.5,-5.5
+      pos: -42.5,-12.5
       parent: 2
   - uid: 3398
     components:
     - type: Transform
-      pos: -22.5,-5.5
+      pos: -46.5,-15.5
       parent: 2
   - uid: 3399
     components:
     - type: Transform
-      pos: -21.5,-4.5
+      pos: -46.5,-16.5
       parent: 2
   - uid: 3400
     components:
     - type: Transform
-      pos: -24.5,-5.5
+      pos: -45.5,-16.5
       parent: 2
   - uid: 3401
     components:
     - type: Transform
-      pos: -25.5,-5.5
+      pos: -47.5,-1.5
       parent: 2
   - uid: 3402
     components:
     - type: Transform
-      pos: -25.5,-4.5
+      pos: -47.5,-2.5
       parent: 2
   - uid: 3403
     components:
     - type: Transform
-      pos: -25.5,-6.5
+      pos: -47.5,14.5
       parent: 2
   - uid: 3404
     components:
     - type: Transform
-      pos: -25.5,-7.5
+      pos: -36.5,16.5
       parent: 2
   - uid: 3405
     components:
     - type: Transform
-      pos: -26.5,-6.5
+      pos: -47.5,16.5
       parent: 2
   - uid: 3406
     components:
     - type: Transform
-      pos: -26.5,-4.5
+      pos: -37.5,17.5
       parent: 2
   - uid: 3407
     components:
     - type: Transform
-      pos: -11.5,-6.5
+      pos: -37.5,15.5
       parent: 2
   - uid: 3408
     components:
     - type: Transform
-      pos: -9.5,-6.5
+      pos: -34.5,16.5
       parent: 2
   - uid: 3409
     components:
     - type: Transform
-      pos: -7.5,-6.5
+      pos: -50.5,-15.5
       parent: 2
   - uid: 3410
     components:
     - type: Transform
-      pos: -2.5,-6.5
+      pos: -49.5,-15.5
       parent: 2
   - uid: 3411
     components:
     - type: Transform
-      pos: -1.5,1.5
+      pos: -50.5,-16.5
       parent: 2
   - uid: 3412
     components:
     - type: Transform
-      pos: -2.5,1.5
+      pos: -50.5,-21.5
       parent: 2
   - uid: 3413
     components:
     - type: Transform
-      pos: -4.5,1.5
+      pos: -49.5,-21.5
       parent: 2
   - uid: 3414
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -48.5,-21.5
       parent: 2
   - uid: 3415
     components:
     - type: Transform
-      pos: -6.5,1.5
+      pos: -47.5,-21.5
       parent: 2
   - uid: 3416
     components:
     - type: Transform
-      pos: -6.5,3.5
+      pos: -46.5,-21.5
       parent: 2
   - uid: 3417
     components:
     - type: Transform
-      pos: -6.5,0.5
+      pos: -45.5,-21.5
       parent: 2
   - uid: 3418
     components:
     - type: Transform
-      pos: -18.5,0.5
+      pos: -51.5,-21.5
       parent: 2
   - uid: 3419
     components:
     - type: Transform
-      pos: -13.5,3.5
+      pos: -51.5,-17.5
       parent: 2
   - uid: 3420
     components:
     - type: Transform
-      pos: -13.5,0.5
+      pos: -51.5,-16.5
       parent: 2
   - uid: 3421
     components:
     - type: Transform
-      pos: -19.5,-5.5
+      pos: -33.5,15.5
       parent: 2
   - uid: 3422
     components:
     - type: Transform
-      pos: -19.5,-4.5
+      pos: -42.5,-11.5
       parent: 2
   - uid: 3423
     components:
     - type: Transform
-      pos: -17.5,0.5
+      pos: -29.5,-23.5
       parent: 2
   - uid: 3424
     components:
     - type: Transform
-      pos: -19.5,0.5
+      pos: -29.5,-24.5
       parent: 2
   - uid: 3425
     components:
     - type: Transform
-      pos: -19.5,-0.5
+      pos: -29.5,-25.5
       parent: 2
   - uid: 3426
     components:
     - type: Transform
-      pos: -23.5,0.5
+      pos: -41.5,-21.5
       parent: 2
   - uid: 3427
     components:
     - type: Transform
-      pos: -17.5,6.5
+      pos: -42.5,-21.5
       parent: 2
   - uid: 3428
     components:
     - type: Transform
-      pos: -17.5,4.5
+      pos: -43.5,-21.5
       parent: 2
   - uid: 3429
     components:
     - type: Transform
-      pos: -18.5,4.5
+      pos: -44.5,-21.5
       parent: 2
   - uid: 3430
     components:
     - type: Transform
-      pos: -19.5,4.5
+      pos: -41.5,-22.5
       parent: 2
   - uid: 3431
     components:
     - type: Transform
-      pos: -17.5,5.5
+      pos: -41.5,-24.5
       parent: 2
   - uid: 3432
     components:
     - type: Transform
-      pos: -23.5,6.5
+      pos: -41.5,-25.5
       parent: 2
   - uid: 3433
     components:
     - type: Transform
-      pos: -23.5,3.5
+      pos: -29.5,-26.5
       parent: 2
   - uid: 3434
     components:
     - type: Transform
-      pos: -23.5,4.5
+      pos: -29.5,-29.5
       parent: 2
   - uid: 3435
     components:
     - type: Transform
-      pos: -27.5,0.5
+      pos: -29.5,-30.5
       parent: 2
   - uid: 3436
     components:
     - type: Transform
-      pos: -27.5,1.5
+      pos: -30.5,-30.5
       parent: 2
   - uid: 3437
     components:
     - type: Transform
-      pos: -27.5,7.5
+      pos: -38.5,-30.5
       parent: 2
   - uid: 3438
     components:
     - type: Transform
-      pos: -27.5,6.5
+      pos: -39.5,-30.5
       parent: 2
   - uid: 3439
     components:
     - type: Transform
-      pos: -15.5,6.5
+      pos: -40.5,-30.5
       parent: 2
   - uid: 3440
     components:
     - type: Transform
-      pos: -16.5,0.5
+      pos: -41.5,-30.5
       parent: 2
   - uid: 3441
     components:
     - type: Transform
-      pos: -33.5,7.5
+      pos: -41.5,-26.5
       parent: 2
   - uid: 3442
     components:
     - type: Transform
-      pos: -30.5,0.5
+      pos: -42.5,-26.5
       parent: 2
   - uid: 3443
     components:
     - type: Transform
-      pos: -33.5,0.5
+      pos: -43.5,-26.5
       parent: 2
   - uid: 3444
     components:
     - type: Transform
-      pos: -33.5,1.5
+      pos: -44.5,-26.5
       parent: 2
   - uid: 3445
     components:
     - type: Transform
-      pos: -33.5,2.5
+      pos: -44.5,-27.5
       parent: 2
   - uid: 3446
     components:
     - type: Transform
-      pos: -33.5,3.5
+      pos: -44.5,-29.5
       parent: 2
   - uid: 3447
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: -44.5,-30.5
       parent: 2
   - uid: 3448
     components:
     - type: Transform
-      pos: -31.5,3.5
+      pos: -43.5,-30.5
       parent: 2
   - uid: 3449
     components:
     - type: Transform
-      pos: -30.5,3.5
+      pos: -42.5,-30.5
       parent: 2
   - uid: 3450
     components:
     - type: Transform
-      pos: -33.5,4.5
+      pos: -44.5,-25.5
       parent: 2
   - uid: 3451
     components:
     - type: Transform
-      pos: -33.5,6.5
+      pos: -44.5,-24.5
       parent: 2
   - uid: 3452
     components:
     - type: Transform
-      pos: -28.5,-4.5
+      pos: -44.5,-23.5
       parent: 2
   - uid: 3453
     components:
     - type: Transform
-      pos: -29.5,-4.5
+      pos: -44.5,-22.5
       parent: 2
   - uid: 3454
     components:
     - type: Transform
-      pos: -30.5,-4.5
+      pos: -41.5,-27.5
       parent: 2
   - uid: 3455
     components:
     - type: Transform
-      pos: -30.5,-5.5
+      pos: -41.5,-29.5
       parent: 2
   - uid: 3456
     components:
     - type: Transform
-      pos: -30.5,-6.5
+      pos: -37.5,16.5
       parent: 2
   - uid: 3457
     components:
     - type: Transform
-      pos: -30.5,-7.5
+      pos: -37.5,13.5
       parent: 2
   - uid: 3458
     components:
     - type: Transform
-      pos: -30.5,-8.5
+      pos: -35.5,16.5
       parent: 2
   - uid: 3459
     components:
     - type: Transform
-      pos: -30.5,-9.5
+      pos: -47.5,15.5
       parent: 2
   - uid: 3460
     components:
     - type: Transform
-      pos: -30.5,-10.5
+      pos: -16.5,9.5
       parent: 2
   - uid: 3461
     components:
     - type: Transform
-      pos: -30.5,-11.5
+      pos: -47.5,17.5
       parent: 2
   - uid: 3462
     components:
     - type: Transform
-      pos: -29.5,-11.5
+      pos: -27.5,11.5
       parent: 2
   - uid: 3463
     components:
     - type: Transform
-      pos: -28.5,-11.5
+      pos: -13.5,8.5
       parent: 2
   - uid: 3464
     components:
     - type: Transform
-      pos: -31.5,-4.5
+      pos: -14.5,9.5
       parent: 2
   - uid: 3465
     components:
     - type: Transform
-      pos: -32.5,-4.5
+      pos: -15.5,9.5
       parent: 2
   - uid: 3466
     components:
     - type: Transform
-      pos: -33.5,-4.5
+      pos: -13.5,7.5
       parent: 2
   - uid: 3467
     components:
     - type: Transform
-      pos: -34.5,-4.5
+      pos: -13.5,6.5
       parent: 2
   - uid: 3468
     components:
     - type: Transform
-      pos: -31.5,-7.5
+      pos: -13.5,5.5
       parent: 2
   - uid: 3469
     components:
     - type: Transform
-      pos: -32.5,-7.5
+      pos: -5.5,-6.5
       parent: 2
   - uid: 3470
     components:
     - type: Transform
-      pos: -33.5,-7.5
+      pos: -6.5,-6.5
       parent: 2
   - uid: 3471
     components:
     - type: Transform
-      pos: -34.5,-7.5
+      pos: -19.5,-6.5
       parent: 2
   - uid: 3472
     components:
     - type: Transform
-      pos: -31.5,-11.5
+      pos: -14.5,-6.5
       parent: 2
   - uid: 3473
     components:
     - type: Transform
-      pos: -32.5,-11.5
+      pos: -19.5,-7.5
       parent: 2
   - uid: 3474
     components:
     - type: Transform
-      pos: -33.5,-11.5
+      pos: -18.5,-6.5
       parent: 2
   - uid: 3475
     components:
     - type: Transform
-      pos: -34.5,-11.5
+      pos: -17.5,-6.5
       parent: 2
   - uid: 3476
     components:
     - type: Transform
-      pos: -34.5,-12.5
+      pos: -16.5,-6.5
       parent: 2
   - uid: 3477
     components:
     - type: Transform
-      pos: -34.5,-15.5
+      pos: -15.5,-6.5
       parent: 2
   - uid: 3478
     components:
     - type: Transform
-      pos: -33.5,-15.5
+      pos: -20.5,-6.5
       parent: 2
   - uid: 3479
     components:
     - type: Transform
-      pos: -29.5,-15.5
+      pos: -21.5,-6.5
       parent: 2
   - uid: 3480
     components:
     - type: Transform
-      pos: -28.5,-15.5
+      pos: -21.5,-7.5
       parent: 2
   - uid: 3481
     components:
     - type: Transform
-      pos: -34.5,-16.5
+      pos: -21.5,-5.5
       parent: 2
   - uid: 3482
     components:
     - type: Transform
-      pos: -34.5,-20.5
+      pos: -22.5,-5.5
       parent: 2
   - uid: 3483
     components:
     - type: Transform
-      pos: -37.5,10.5
+      pos: -21.5,-4.5
       parent: 2
   - uid: 3484
     components:
     - type: Transform
-      pos: -37.5,9.5
+      pos: -24.5,-5.5
       parent: 2
   - uid: 3485
     components:
     - type: Transform
-      pos: -37.5,8.5
+      pos: -25.5,-5.5
       parent: 2
   - uid: 3486
     components:
     - type: Transform
-      pos: -37.5,7.5
+      pos: -25.5,-4.5
       parent: 2
   - uid: 3487
     components:
     - type: Transform
-      pos: -36.5,7.5
+      pos: -25.5,-6.5
       parent: 2
   - uid: 3488
     components:
     - type: Transform
-      pos: -35.5,7.5
+      pos: -25.5,-7.5
       parent: 2
   - uid: 3489
     components:
     - type: Transform
-      pos: -34.5,7.5
+      pos: -26.5,-6.5
       parent: 2
   - uid: 3490
     components:
     - type: Transform
-      pos: -37.5,6.5
+      pos: -26.5,-4.5
       parent: 2
   - uid: 3491
     components:
     - type: Transform
-      pos: -37.5,5.5
+      pos: -11.5,-6.5
       parent: 2
   - uid: 3492
     components:
     - type: Transform
-      pos: -37.5,4.5
+      pos: -9.5,-6.5
       parent: 2
   - uid: 3493
     components:
     - type: Transform
-      pos: -37.5,3.5
+      pos: -7.5,-6.5
       parent: 2
   - uid: 3494
     components:
     - type: Transform
-      pos: -36.5,3.5
+      pos: -2.5,-6.5
       parent: 2
   - uid: 3495
     components:
     - type: Transform
-      pos: -35.5,3.5
+      pos: -1.5,1.5
       parent: 2
   - uid: 3496
     components:
     - type: Transform
-      pos: -34.5,3.5
+      pos: -2.5,1.5
       parent: 2
   - uid: 3497
     components:
     - type: Transform
-      pos: -38.5,7.5
+      pos: -4.5,1.5
       parent: 2
   - uid: 3498
     components:
     - type: Transform
-      pos: -39.5,7.5
+      pos: -5.5,1.5
       parent: 2
   - uid: 3499
     components:
     - type: Transform
-      pos: -40.5,7.5
+      pos: -6.5,1.5
       parent: 2
   - uid: 3500
     components:
     - type: Transform
-      pos: -38.5,9.5
+      pos: -6.5,3.5
       parent: 2
   - uid: 3501
     components:
     - type: Transform
-      pos: -39.5,9.5
+      pos: -6.5,0.5
       parent: 2
   - uid: 3502
     components:
     - type: Transform
-      pos: -40.5,9.5
+      pos: -18.5,0.5
       parent: 2
   - uid: 3503
     components:
     - type: Transform
-      pos: -38.5,11.5
+      pos: -13.5,3.5
       parent: 2
   - uid: 3504
     components:
     - type: Transform
-      pos: -39.5,11.5
+      pos: -13.5,0.5
       parent: 2
   - uid: 3505
     components:
     - type: Transform
-      pos: -40.5,11.5
+      pos: -19.5,-5.5
       parent: 2
   - uid: 3506
     components:
     - type: Transform
-      pos: -38.5,5.5
+      pos: -19.5,-4.5
       parent: 2
   - uid: 3507
     components:
     - type: Transform
-      pos: -39.5,5.5
+      pos: -17.5,0.5
       parent: 2
   - uid: 3508
     components:
     - type: Transform
-      pos: -40.5,5.5
+      pos: -19.5,0.5
       parent: 2
   - uid: 3509
     components:
     - type: Transform
-      pos: -38.5,-2.5
+      pos: -19.5,-0.5
       parent: 2
   - uid: 3510
     components:
     - type: Transform
-      pos: -45.5,8.5
+      pos: -23.5,0.5
       parent: 2
   - uid: 3511
     components:
     - type: Transform
-      pos: -45.5,9.5
+      pos: -17.5,6.5
       parent: 2
   - uid: 3512
     components:
     - type: Transform
-      pos: -45.5,10.5
+      pos: -17.5,4.5
       parent: 2
   - uid: 3513
     components:
     - type: Transform
-      pos: -45.5,11.5
+      pos: -18.5,4.5
       parent: 2
   - uid: 3514
     components:
     - type: Transform
-      pos: -46.5,11.5
+      pos: -19.5,4.5
       parent: 2
   - uid: 3515
     components:
     - type: Transform
-      pos: -47.5,11.5
+      pos: -17.5,5.5
       parent: 2
   - uid: 3516
     components:
     - type: Transform
-      pos: -48.5,11.5
+      pos: -23.5,6.5
       parent: 2
   - uid: 3517
     components:
     - type: Transform
-      pos: -38.5,3.5
+      pos: -23.5,3.5
       parent: 2
   - uid: 3518
     components:
     - type: Transform
-      pos: -39.5,3.5
+      pos: -23.5,4.5
       parent: 2
   - uid: 3519
     components:
     - type: Transform
-      pos: -40.5,3.5
+      pos: -27.5,0.5
       parent: 2
   - uid: 3520
     components:
     - type: Transform
-      pos: -34.5,0.5
+      pos: -27.5,1.5
       parent: 2
   - uid: 3521
     components:
     - type: Transform
-      pos: -38.5,-1.5
+      pos: -27.5,7.5
       parent: 2
   - uid: 3522
     components:
     - type: Transform
-      pos: -39.5,-2.5
-      parent: 2
-  - uid: 3523
-    components:
-    - type: Transform
-      pos: -40.5,-2.5
+      pos: -27.5,6.5
       parent: 2
   - uid: 3524
     components:
     - type: Transform
-      pos: -41.5,-2.5
+      pos: -16.5,0.5
       parent: 2
   - uid: 3525
     components:
     - type: Transform
-      pos: -42.5,-2.5
+      pos: -33.5,7.5
       parent: 2
   - uid: 3526
     components:
     - type: Transform
-      pos: -43.5,-2.5
+      pos: -30.5,0.5
       parent: 2
   - uid: 3527
     components:
     - type: Transform
-      pos: -44.5,-2.5
+      pos: -33.5,0.5
       parent: 2
   - uid: 3528
     components:
     - type: Transform
-      pos: -43.5,-15.5
+      pos: -33.5,1.5
       parent: 2
   - uid: 3529
     components:
     - type: Transform
-      pos: -38.5,-16.5
+      pos: -33.5,2.5
       parent: 2
   - uid: 3530
     components:
     - type: Transform
-      pos: -43.5,-14.5
+      pos: -33.5,3.5
       parent: 2
   - uid: 3531
     components:
     - type: Transform
-      pos: -38.5,-4.5
+      pos: -32.5,3.5
       parent: 2
   - uid: 3532
     components:
     - type: Transform
-      pos: -42.5,-16.5
+      pos: -31.5,3.5
       parent: 2
   - uid: 3533
     components:
     - type: Transform
-      pos: -41.5,-16.5
+      pos: -30.5,3.5
       parent: 2
   - uid: 3534
     components:
     - type: Transform
-      pos: -40.5,-16.5
+      pos: -33.5,4.5
       parent: 2
   - uid: 3535
     components:
     - type: Transform
-      pos: -39.5,-16.5
+      pos: -33.5,6.5
       parent: 2
   - uid: 3536
     components:
     - type: Transform
-      pos: -39.5,-12.5
+      pos: -28.5,-4.5
       parent: 2
   - uid: 3537
     components:
     - type: Transform
-      pos: -40.5,-12.5
+      pos: -29.5,-4.5
       parent: 2
   - uid: 3538
     components:
     - type: Transform
-      pos: -41.5,-12.5
+      pos: -30.5,-4.5
       parent: 2
   - uid: 3539
     components:
     - type: Transform
-      pos: -14.5,6.5
+      pos: -30.5,-5.5
       parent: 2
   - uid: 3540
     components:
     - type: Transform
-      pos: -38.5,-3.5
+      pos: -30.5,-6.5
       parent: 2
   - uid: 3541
     components:
     - type: Transform
-      pos: -38.5,-5.5
+      pos: -30.5,-7.5
       parent: 2
   - uid: 3542
     components:
     - type: Transform
-      pos: -38.5,-6.5
+      pos: -30.5,-8.5
       parent: 2
   - uid: 3543
     components:
     - type: Transform
-      pos: -38.5,-12.5
+      pos: -30.5,-9.5
       parent: 2
   - uid: 3544
     components:
     - type: Transform
-      pos: -38.5,-11.5
+      pos: -30.5,-10.5
       parent: 2
   - uid: 3545
     components:
     - type: Transform
-      pos: -38.5,-10.5
+      pos: -30.5,-11.5
       parent: 2
   - uid: 3546
     components:
     - type: Transform
-      pos: -43.5,-16.5
+      pos: -29.5,-11.5
       parent: 2
   - uid: 3547
     components:
     - type: Transform
-      pos: -43.5,-13.5
+      pos: -28.5,-11.5
       parent: 2
   - uid: 3548
     components:
     - type: Transform
-      pos: -38.5,-15.5
+      pos: -31.5,-4.5
       parent: 2
   - uid: 3549
     components:
     - type: Transform
-      pos: -38.5,-13.5
+      pos: -32.5,-4.5
       parent: 2
   - uid: 3550
     components:
     - type: Transform
-      pos: -30.5,-25.5
+      pos: -33.5,-4.5
       parent: 2
   - uid: 3551
     components:
     - type: Transform
-      pos: -33.5,-25.5
+      pos: -34.5,-4.5
       parent: 2
   - uid: 3552
     components:
     - type: Transform
-      pos: -34.5,-25.5
+      pos: -31.5,-7.5
       parent: 2
   - uid: 3553
     components:
     - type: Transform
-      pos: -34.5,-21.5
+      pos: -32.5,-7.5
       parent: 2
   - uid: 3554
     components:
     - type: Transform
-      pos: -34.5,-24.5
+      pos: -33.5,-7.5
       parent: 2
   - uid: 3555
     components:
     - type: Transform
-      pos: -38.5,-24.5
+      pos: -34.5,-7.5
       parent: 2
   - uid: 3556
     components:
     - type: Transform
-      pos: -38.5,-25.5
+      pos: -31.5,-11.5
       parent: 2
   - uid: 3557
     components:
     - type: Transform
-      pos: -38.5,-21.5
+      pos: -32.5,-11.5
       parent: 2
   - uid: 3558
     components:
     - type: Transform
-      pos: -39.5,-21.5
+      pos: -33.5,-11.5
       parent: 2
   - uid: 3559
+    components:
+    - type: Transform
+      pos: -34.5,-11.5
+      parent: 2
+  - uid: 3560
+    components:
+    - type: Transform
+      pos: -34.5,-12.5
+      parent: 2
+  - uid: 3561
+    components:
+    - type: Transform
+      pos: -34.5,-15.5
+      parent: 2
+  - uid: 3562
+    components:
+    - type: Transform
+      pos: -33.5,-15.5
+      parent: 2
+  - uid: 3563
+    components:
+    - type: Transform
+      pos: -29.5,-15.5
+      parent: 2
+  - uid: 3564
+    components:
+    - type: Transform
+      pos: -28.5,-15.5
+      parent: 2
+  - uid: 3565
+    components:
+    - type: Transform
+      pos: -34.5,-16.5
+      parent: 2
+  - uid: 3566
+    components:
+    - type: Transform
+      pos: -34.5,-20.5
+      parent: 2
+  - uid: 3567
+    components:
+    - type: Transform
+      pos: -37.5,10.5
+      parent: 2
+  - uid: 3568
+    components:
+    - type: Transform
+      pos: -37.5,9.5
+      parent: 2
+  - uid: 3569
+    components:
+    - type: Transform
+      pos: -37.5,8.5
+      parent: 2
+  - uid: 3570
+    components:
+    - type: Transform
+      pos: -37.5,7.5
+      parent: 2
+  - uid: 3571
+    components:
+    - type: Transform
+      pos: -36.5,7.5
+      parent: 2
+  - uid: 3572
+    components:
+    - type: Transform
+      pos: -35.5,7.5
+      parent: 2
+  - uid: 3573
+    components:
+    - type: Transform
+      pos: -34.5,7.5
+      parent: 2
+  - uid: 3574
+    components:
+    - type: Transform
+      pos: -37.5,6.5
+      parent: 2
+  - uid: 3575
+    components:
+    - type: Transform
+      pos: -37.5,5.5
+      parent: 2
+  - uid: 3576
+    components:
+    - type: Transform
+      pos: -37.5,4.5
+      parent: 2
+  - uid: 3577
+    components:
+    - type: Transform
+      pos: -37.5,3.5
+      parent: 2
+  - uid: 3578
+    components:
+    - type: Transform
+      pos: -36.5,3.5
+      parent: 2
+  - uid: 3579
+    components:
+    - type: Transform
+      pos: -35.5,3.5
+      parent: 2
+  - uid: 3580
+    components:
+    - type: Transform
+      pos: -34.5,3.5
+      parent: 2
+  - uid: 3581
+    components:
+    - type: Transform
+      pos: -38.5,7.5
+      parent: 2
+  - uid: 3582
+    components:
+    - type: Transform
+      pos: -39.5,7.5
+      parent: 2
+  - uid: 3583
+    components:
+    - type: Transform
+      pos: -40.5,7.5
+      parent: 2
+  - uid: 3584
+    components:
+    - type: Transform
+      pos: -38.5,9.5
+      parent: 2
+  - uid: 3585
+    components:
+    - type: Transform
+      pos: -39.5,9.5
+      parent: 2
+  - uid: 3586
+    components:
+    - type: Transform
+      pos: -40.5,9.5
+      parent: 2
+  - uid: 3587
+    components:
+    - type: Transform
+      pos: -38.5,11.5
+      parent: 2
+  - uid: 3588
+    components:
+    - type: Transform
+      pos: -39.5,11.5
+      parent: 2
+  - uid: 3589
+    components:
+    - type: Transform
+      pos: -40.5,11.5
+      parent: 2
+  - uid: 3590
+    components:
+    - type: Transform
+      pos: -38.5,5.5
+      parent: 2
+  - uid: 3591
+    components:
+    - type: Transform
+      pos: -39.5,5.5
+      parent: 2
+  - uid: 3592
+    components:
+    - type: Transform
+      pos: -40.5,5.5
+      parent: 2
+  - uid: 3593
+    components:
+    - type: Transform
+      pos: -38.5,-2.5
+      parent: 2
+  - uid: 3594
+    components:
+    - type: Transform
+      pos: -45.5,8.5
+      parent: 2
+  - uid: 3595
+    components:
+    - type: Transform
+      pos: -45.5,9.5
+      parent: 2
+  - uid: 3596
+    components:
+    - type: Transform
+      pos: -45.5,10.5
+      parent: 2
+  - uid: 3597
+    components:
+    - type: Transform
+      pos: -45.5,11.5
+      parent: 2
+  - uid: 3598
+    components:
+    - type: Transform
+      pos: -46.5,11.5
+      parent: 2
+  - uid: 3599
+    components:
+    - type: Transform
+      pos: -47.5,11.5
+      parent: 2
+  - uid: 3600
+    components:
+    - type: Transform
+      pos: -48.5,11.5
+      parent: 2
+  - uid: 3601
+    components:
+    - type: Transform
+      pos: -38.5,3.5
+      parent: 2
+  - uid: 3602
+    components:
+    - type: Transform
+      pos: -39.5,3.5
+      parent: 2
+  - uid: 3603
+    components:
+    - type: Transform
+      pos: -40.5,3.5
+      parent: 2
+  - uid: 3604
+    components:
+    - type: Transform
+      pos: -34.5,0.5
+      parent: 2
+  - uid: 3605
+    components:
+    - type: Transform
+      pos: -38.5,-1.5
+      parent: 2
+  - uid: 3606
+    components:
+    - type: Transform
+      pos: -43.5,-15.5
+      parent: 2
+  - uid: 3607
+    components:
+    - type: Transform
+      pos: -38.5,-16.5
+      parent: 2
+  - uid: 3608
+    components:
+    - type: Transform
+      pos: -43.5,-14.5
+      parent: 2
+  - uid: 3609
+    components:
+    - type: Transform
+      pos: -38.5,-4.5
+      parent: 2
+  - uid: 3610
+    components:
+    - type: Transform
+      pos: -42.5,-16.5
+      parent: 2
+  - uid: 3611
+    components:
+    - type: Transform
+      pos: -41.5,-16.5
+      parent: 2
+  - uid: 3612
+    components:
+    - type: Transform
+      pos: -40.5,-16.5
+      parent: 2
+  - uid: 3613
+    components:
+    - type: Transform
+      pos: -39.5,-16.5
+      parent: 2
+  - uid: 3614
+    components:
+    - type: Transform
+      pos: -39.5,-12.5
+      parent: 2
+  - uid: 3615
+    components:
+    - type: Transform
+      pos: -40.5,-12.5
+      parent: 2
+  - uid: 3616
+    components:
+    - type: Transform
+      pos: -41.5,-12.5
+      parent: 2
+  - uid: 3617
+    components:
+    - type: Transform
+      pos: -14.5,6.5
+      parent: 2
+  - uid: 3618
+    components:
+    - type: Transform
+      pos: -38.5,-3.5
+      parent: 2
+  - uid: 3619
+    components:
+    - type: Transform
+      pos: -38.5,-5.5
+      parent: 2
+  - uid: 3620
+    components:
+    - type: Transform
+      pos: -38.5,-6.5
+      parent: 2
+  - uid: 3621
+    components:
+    - type: Transform
+      pos: -38.5,-12.5
+      parent: 2
+  - uid: 3622
+    components:
+    - type: Transform
+      pos: -38.5,-11.5
+      parent: 2
+  - uid: 3623
+    components:
+    - type: Transform
+      pos: -38.5,-10.5
+      parent: 2
+  - uid: 3624
+    components:
+    - type: Transform
+      pos: -43.5,-16.5
+      parent: 2
+  - uid: 3625
+    components:
+    - type: Transform
+      pos: -43.5,-13.5
+      parent: 2
+  - uid: 3626
+    components:
+    - type: Transform
+      pos: -38.5,-15.5
+      parent: 2
+  - uid: 3627
+    components:
+    - type: Transform
+      pos: -38.5,-13.5
+      parent: 2
+  - uid: 3628
+    components:
+    - type: Transform
+      pos: -30.5,-25.5
+      parent: 2
+  - uid: 3629
+    components:
+    - type: Transform
+      pos: -33.5,-25.5
+      parent: 2
+  - uid: 3630
+    components:
+    - type: Transform
+      pos: -34.5,-25.5
+      parent: 2
+  - uid: 3631
+    components:
+    - type: Transform
+      pos: -34.5,-21.5
+      parent: 2
+  - uid: 3632
+    components:
+    - type: Transform
+      pos: -34.5,-24.5
+      parent: 2
+  - uid: 3633
+    components:
+    - type: Transform
+      pos: -38.5,-24.5
+      parent: 2
+  - uid: 3634
+    components:
+    - type: Transform
+      pos: -38.5,-25.5
+      parent: 2
+  - uid: 3635
+    components:
+    - type: Transform
+      pos: -38.5,-21.5
+      parent: 2
+  - uid: 3636
+    components:
+    - type: Transform
+      pos: -39.5,-21.5
+      parent: 2
+  - uid: 3637
     components:
     - type: Transform
       pos: -40.5,-21.5
       parent: 2
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 3560
+  - uid: 3638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-15.5
       parent: 2
-  - uid: 3561
+  - uid: 3639
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 2
-  - uid: 3562
+  - uid: 3640
     components:
     - type: Transform
       pos: -27.5,-6.5
       parent: 2
-  - uid: 3563
+  - uid: 3641
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 2
-  - uid: 3564
+  - uid: 3642
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 2
-  - uid: 3565
+  - uid: 3643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,10.5
       parent: 2
-  - uid: 3566
+  - uid: 3644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 2
-  - uid: 3567
+  - uid: 3645
     components:
     - type: Transform
       pos: -46.5,-12.5
       parent: 2
-  - uid: 3568
+  - uid: 3646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,15.5
       parent: 2
-  - uid: 3569
+  - uid: 3647
     components:
     - type: Transform
       pos: -34.5,13.5
       parent: 2
-  - uid: 3570
+  - uid: 3648
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,16.5
       parent: 2
-  - uid: 3571
+  - uid: 3649
     components:
     - type: Transform
       pos: -51.5,-15.5
       parent: 2
-  - uid: 3572
+  - uid: 3650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,13.5
       parent: 2
-  - uid: 3573
+  - uid: 3651
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,15.5
       parent: 2
-  - uid: 3574
+  - uid: 3652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24903,7 +25293,7 @@ entities:
       parent: 2
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 3575
+  - uid: 3
     components:
     - type: Transform
       pos: -30.5,-12.5
@@ -24914,24 +25304,25 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 3578
-          - 3576
-          - 3577
+          - 4
+          - 6
+          - 5
+          - 7
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: WarningN2
   entities:
-  - uid: 3579
+  - uid: 3653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24941,7 +25332,7 @@ entities:
       fixtures: {}
 - proto: WarningO2
   entities:
-  - uid: 3580
+  - uid: 3654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24951,7 +25342,7 @@ entities:
       fixtures: {}
 - proto: WarningPlasma
   entities:
-  - uid: 3581
+  - uid: 3655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24961,7 +25352,7 @@ entities:
       fixtures: {}
 - proto: WarningWaste
   entities:
-  - uid: 1491
+  - uid: 3656
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -24971,90 +25362,78 @@ entities:
       fixtures: {}
 - proto: WaterCooler
   entities:
-  - uid: 3584
+  - uid: 3657
     components:
     - type: Transform
       pos: -30.5,-14.5
       parent: 2
-  - uid: 3585
+  - uid: 3658
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 2
-  - uid: 3586
+  - uid: 3659
     components:
     - type: Transform
       pos: -16.5,-0.5
       parent: 2
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 2503
+  - uid: 3660
     components:
     - type: Transform
       pos: -42.5,-15.5
       parent: 2
-  - uid: 3587
+  - uid: 3661
     components:
     - type: Transform
       pos: -20.5,-7.5
       parent: 2
-  - uid: 3588
+  - uid: 3662
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
 - proto: WaterVaporCanister
   entities:
-  - uid: 3591
+  - uid: 3663
     components:
     - type: Transform
       pos: -51.5,6.5
       parent: 2
 - proto: WeaponGrapplingGun
   entities:
-  - uid: 3592
+  - uid: 3664
     components:
     - type: Transform
-      pos: -43.489838,11.839426
+      pos: -38.709408,13.334447
       parent: 2
-  - uid: 3593
+  - uid: 3665
     components:
     - type: Transform
       pos: -22.415903,-6.254816
       parent: 2
-  - uid: 3594
+  - uid: 3666
     components:
     - type: Transform
       pos: -22.381283,-6.37093
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 3595
+  - uid: 3667
     components:
     - type: Transform
       pos: -44.5,11.5
       parent: 2
 - proto: Windoor
   entities:
-  - uid: 3596
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,-6.5
-      parent: 2
-  - uid: 3597
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-6.5
-      parent: 2
-  - uid: 3598
+  - uid: 3668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-6.5
       parent: 2
-  - uid: 3599
+  - uid: 3669
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25062,13 +25441,7 @@ entities:
       parent: 2
 - proto: WindoorBarLocked
   entities:
-  - uid: 3600
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,2.5
-      parent: 2
-  - uid: 3601
+  - uid: 3670
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25076,37 +25449,37 @@ entities:
       parent: 2
 - proto: WindoorHydroponicsLocked
   entities:
-  - uid: 3602
+  - uid: 3671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
-  - uid: 3603
+  - uid: 3672
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,3.5
       parent: 2
-  - uid: 3604
+  - uid: 3673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,2.5
       parent: 2
-  - uid: 3606
+  - uid: 3674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,7.5
       parent: 2
-  - uid: 3607
+  - uid: 3675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,1.5
       parent: 2
-  - uid: 3608
+  - uid: 3676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25114,37 +25487,25 @@ entities:
       parent: 2
 - proto: WindoorKitchenLocked
   entities:
-  - uid: 3609
+  - uid: 3677
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,3.5
       parent: 2
-  - uid: 3610
+  - uid: 3678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
-  - uid: 3611
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,0.5
-      parent: 2
-  - uid: 3612
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,0.5
-      parent: 2
-  - uid: 3613
+  - uid: 3679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,1.5
       parent: 2
-  - uid: 3614
+  - uid: 3680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25152,128 +25513,134 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
-  - uid: 3615
+  - uid: 3681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 3616
+  - uid: 3682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-9.5
       parent: 2
-  - uid: 3617
+  - uid: 3683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-8.5
       parent: 2
-  - uid: 3618
+  - uid: 3684
     components:
+    - type: MetaData
+      name: Vox Box
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-4.5
       parent: 2
-  - uid: 3619
+  - uid: 3685
     components:
+    - type: MetaData
+      name: Vox Box
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-4.5
       parent: 2
-  - uid: 3620
+  - uid: 3686
     components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -38.5,-9.5
-      parent: 2
-  - uid: 3621
-    components:
+    - type: MetaData
+      name: Shuttle Construction Bay
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-8.5
       parent: 2
-  - uid: 3622
+    - type: AccessReader
+      accessListsOriginal: []
+  - uid: 3687
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-8.5
       parent: 2
-  - uid: 3623
+  - uid: 3688
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-8.5
       parent: 2
-- proto: WindoorSecureBarLocked
-  entities:
-  - uid: 3624
-    components:
-    - type: Transform
-      pos: -7.5,0.5
-      parent: 2
 - proto: WindoorSecureCargoLocked
   entities:
-  - uid: 3625
+  - uid: 3690
+    components:
+    - type: Transform
+      pos: -11.5,-10.5
+      parent: 2
+  - uid: 3691
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-6.5
+      parent: 2
+  - uid: 3692
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
-  - uid: 3626
+  - uid: 3693
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-9.5
       parent: 2
-  - uid: 3627
+  - uid: 3694
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 3628
-    components:
-    - type: Transform
-      pos: -12.5,-6.5
-      parent: 2
-  - uid: 3629
+  - uid: 3695
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 2
+  - uid: 3696
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 2
 - proto: WindoorSecureChemistryLocked
   entities:
-  - uid: 3630
+  - uid: 3697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,2.5
       parent: 2
-  - uid: 3632
+  - uid: 3698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,7.5
       parent: 2
-  - uid: 3633
+  - uid: 3699
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,4.5
       parent: 2
-  - uid: 3634
+  - uid: 3700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,5.5
       parent: 2
-  - uid: 3635
+  - uid: 3701
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,2.5
       parent: 2
-  - uid: 3636
+  - uid: 3702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25281,33 +25648,47 @@ entities:
       parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
-  - uid: 3637
+  - uid: 3703
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-22.5
       parent: 2
-  - uid: 3638
+  - uid: 3704
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-23.5
       parent: 2
+- proto: WindoorSecureKitchenLocked
+  entities:
+  - uid: 3705
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,0.5
+      parent: 2
+  - uid: 3706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,0.5
+      parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 3639
+  - uid: 3707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,4.5
       parent: 2
-  - uid: 3640
+  - uid: 3708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,5.5
       parent: 2
-  - uid: 3641
+  - uid: 3709
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25315,25 +25696,25 @@ entities:
       parent: 2
 - proto: WindoorSecureSalvageLocked
   entities:
-  - uid: 3642
+  - uid: 3710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 2
-  - uid: 3643
+  - uid: 3711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-9.5
       parent: 2
-  - uid: 3644
+  - uid: 3712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-8.5
       parent: 2
-  - uid: 3645
+  - uid: 3713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25341,71 +25722,70 @@ entities:
       parent: 2
 - proto: WindoorSecureScienceLocked
   entities:
-  - uid: 3646
+  - uid: 3714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-9.5
       parent: 2
-- proto: WindoorServiceLocked
+- proto: WindoorSecureServiceLocked
   entities:
-  - uid: 3647
+  - uid: 3689
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,2.5
+      pos: -7.5,0.5
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 2202
+  - uid: 3715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-4.5
       parent: 2
-  - uid: 3648
+  - uid: 3716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 2
-  - uid: 3649
+  - uid: 3717
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-4.5
       parent: 2
-  - uid: 3650
+  - uid: 3718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-4.5
       parent: 2
-  - uid: 3651
+  - uid: 3719
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-4.5
       parent: 2
-  - uid: 3652
+  - uid: 3720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-8.5
       parent: 2
-  - uid: 3653
+  - uid: 3721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-8.5
       parent: 2
-  - uid: 3654
+  - uid: 3722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-8.5
       parent: 2
-  - uid: 3655
+  - uid: 3723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25413,26 +25793,26 @@ entities:
       parent: 2
 - proto: WoodenBench
   entities:
-  - uid: 3656
+  - uid: 3724
     components:
     - type: Transform
       pos: -26.5,-0.5
       parent: 2
-  - uid: 3657
+  - uid: 3725
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 2
-  - uid: 3658
+  - uid: 3726
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 3659
+  - uid: 3727
     components:
     - type: Transform
-      pos: -40.501057,-11.49375
+      pos: -41.53122,-9.439894
       parent: 2
 ...

--- a/Resources/Maps/_starcup/banana.yml
+++ b/Resources/Maps/_starcup/banana.yml
@@ -2551,7 +2551,7 @@ entities:
   - uid: 76
     components:
     - type: MetaData
-      name: HoP's Object
+      name: HoP's Office
     - type: Transform
       pos: -32.5,-25.5
       parent: 2
@@ -8777,13 +8777,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: ClosetChefFilled
-  entities:
-  - uid: 1617
-    components:
-    - type: Transform
-      pos: -14.5,-2.5
-      parent: 2
 - proto: ClosetEmergencyFilledRandom
   entities:
   - uid: 1225
@@ -18047,7 +18040,7 @@ entities:
   - uid: 2497
     components:
     - type: Transform
-      pos: -32.5,7.5
+      pos: -34.5,11.5
       parent: 2
 - proto: LockerEngineerFilledHardsuit
   entities:
@@ -18116,7 +18109,7 @@ entities:
   - uid: 2503
     components:
     - type: Transform
-      pos: -34.5,11.5
+      pos: -32.5,7.5
       parent: 2
 - proto: LockerPsychologistFilled
   entities:

--- a/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Markers/Spawners/mobs.yml
@@ -1,6 +1,6 @@
 
 - type: entity
-  name: frank spawner
+  name: Frank Spawner
   suffix: UraniumCrab
   id: UraniumCrabSpawnerFrank
   parent: MarkerBase

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/miscellaneous.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent: MobUraniumCrab
   id: MobFrank
-  name: frank
+  name: Frank
   description: A friendly ore crab. Its little eyes watch you with great interest.
   components:
   - type: PointLight

--- a/Resources/Prototypes/_starcup/Maps/banana.yml
+++ b/Resources/Prototypes/_starcup/Maps/banana.yml
@@ -19,7 +19,7 @@
           path: /Maps/_starcup/Shuttles/cargo_banana.yml
         - type: StationJobs
           availableJobs:
-            # command
+            # Command
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -28,7 +28,7 @@
             HeadOfSecurity: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
             AdministrativeAssistant: [ 1, 1 ]
-            # service
+            # Service
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
             Chef: [ 1, 1 ]
@@ -39,29 +39,31 @@
             Chaplain: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             Librarian: [ 1,1 ]
-            # engineering
+            Lawyer: [ 1,1 ]
+            # Engineering
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 1 ]
             TechnicalAssistant: [ 1, 1 ]
-            # medical
+            # Medical
             Chemist: [ 1, 1 ]
             MedicalDoctor: [ 1, 1 ]
             MedicalIntern: [ 1, 1 ]
             Psychologist: [ 1, 1 ]
-            # science
+            Paramedic: [ 1, 1 ]
+            # Science
             Borg: [ 1, 1 ]
             ResearchAssistant: [ 1, 1 ]
             Scientist: [ 1, 1 ]
             Roboticist: [ 1, 1 ]
-            # security
+            # Security
             SecurityCadet: [ 1, 1 ]
             SecurityOfficer: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            # cargo
+            # Logistics
             CargoTechnician: [ 1, 1 ]
             Courier: [ 1, 1 ]
             SalvageSpecialist: [ 1, 1 ]
             CargoAssistant: [ 1, 1 ]
-            # civilian
-            Prisoner: [ 1, 1 ]
+            # Civilian
+            Prisoner: [ 0, 1 ]
             Passenger: [ -1, -1 ]


### PR DESCRIPTION
This PR mostly constitutes small fixes and QOL tweaks to Banana--some Syndiefied decals here, an extra toolbox there--but particularly notable changes and fixes:
- **Fixed Vox Box and Freezer vent rotations, plus the upside-down benches at Evac.**
- Fixed unnamed faxes and beacons.
- **Added a slot apiece for Lawyer and Paramedic.**
- **Kitchen now has a ChefDrobe, and the ChefVend is no longer in the Freezer. Added more table space.**
- Kitchen, Bar, and Botany are now Service access.
- Frank's name is now capitalized.
- Updated the Engineering note slightly.
- Expanded Science north 1 tile to get rid of a 2-wide wall
  - Artifact Chamber now has an (incomplete) gas filter in place of the waste pump.
  - **Roboticist now has their own corner with a Robotics Control Console.**
  - **Removed an APE.**
  - **Gave Science a filled silo.**
- **Added a firebot to Botany.**
- Randomized the Engineering pet.
- Replaced one of the Brig's arcades with an art supplies crate.
- Added some more mats and doodads to the Service Supply Room.
- Named most of the doors, APCs, substations, and SMESes.
- Autolathe is no longer publicly accessible, but Cargo can unlock it. Or someone can sneak under the flaps.
- Removed extra dirt decals.

## Why / Balance
Banana is a messy map. It's clunky, cramped, and all the hangout areas are hallways. There's basically no Maintenance tunnels that aren't in space, and the anomaly vessel basically destroys most of Science if it blows up. Worst of all, it is not shaped remotely like a banana.

None of these issues are really fixed in this update.

I think more can be done to improve Banana. The Chapel and Library could perhaps be merged into a nicer gathering area. The anomaly vessel could be given a separate area. The Arrivals area could be expanded and/or split off more, to allow for more private hangouts. The map could be renamed to Octopus, or "thing you stick on the sharp corner of the wall so the kid doesn't get hurt running into it".
<img width="177" height="174" alt="image" src="https://github.com/user-attachments/assets/70a67138-f7e5-471a-8891-b70c9927d925" /> <img width="177" height="174" alt="image" src="https://github.com/user-attachments/assets/3469bb94-4de3-44cf-8502-1eaca84f39a6" />

For now, the focus is on QOL. Banana's strengths are the Shipyard, the cute Engineering gimmick, and being small enough for a cozy crew to keep track of everything, so the priority was to fix major bugs and make things slightly more breathable. I'm honestly not sure how much more work Banana merits--part of me just wants to make our own shipyard map rather than keep trying to salvage a station this quirky--but I hope people can enjoy Banana more with these small issues handled.

## Media
**The New Version**
<img width="1824" height="1792" alt="Banana-0" src="https://github.com/user-attachments/assets/10afea00-b0ba-4e87-91a1-9119c74d311a" />

The old version, for comparison:
<img width="1824" height="1792" alt="image" src="https://github.com/user-attachments/assets/b10bea23-a1e0-42b6-b1c5-b13e63003ec3" />

**Changelog**
:cl:
- fix: Fixed various Banana Station object rotations.
- tweak: Added Lawyer and Paramedic slots to Banana.
- tweak: Added various QOL bits and bobs to Banana, *slightly* expanding Science in the process.
- add: Banana's Botany now has a pet firebot. Not that we don't trust you, but...