### PR TITLE
fix: unsavable trees

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -42,7 +42,7 @@
           acts: [ "Destruction" ]
 
 - type: entity
-  parent: MobBloodstream # starcup: add bloodstream to trees
+  parent: VascularSystemPlant # starcup: add a bloodstream-like mechanic to trees
   id: BaseTree
   description: Yep, it's a tree.
   abstract: true
@@ -107,13 +107,6 @@
           # end starcup
   - type: TypingIndicator # Add diona typing indicator here so that diona players keep the same typing bubble when polymorphed into a tree.
     proto: diona
-    # begin starcup: add bloodstream to trees
-  - type: Bloodstream
-    bloodReferenceSolution:
-      reagents:
-      - ReagentId: Resin
-        Quantity: 50
-    # end starcup
 
 - type: entity
   parent: BaseTree
@@ -181,7 +174,7 @@
         density: 2000
         layer:
         - WallLayer
-  # begin starcup: add stumps and bloodstream to trees
+  # begin starcup: add stumps and a bloodstream-like mechanic to trees
   - type: Destructible
     thresholds:
     - trigger:
@@ -211,11 +204,13 @@
             min: 1
             max: 1
         offset: 0
-  - type: Bloodstream
-    bloodReferenceSolution:
-      reagents:
-      - ReagentId: Resin
-        Quantity: 70
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 50
+        reagents:
+        - ReagentId: Resin
+          Quantity: 50
     # end starcup
 
 - type: entity

--- a/Resources/Prototypes/_starcup/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/base.yml
@@ -22,6 +22,5 @@
     #solution: pool
   - type: DrawableSolution
     solution: pool
-    drainTime: 2
   - type: InjectableSolution
     solution: pool

--- a/Resources/Prototypes/_starcup/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/base.yml
@@ -18,7 +18,7 @@
       reagents:
       - ReagentId: Resin
         Quantity: 0.1
-  #- type: DrainableSolution
+  #- type: DrainableSolution # Left here in case we want to add taps to them later.
     #solution: pool
   - type: DrawableSolution
     solution: pool

--- a/Resources/Prototypes/_starcup/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/base.yml
@@ -1,0 +1,27 @@
+# Used in lieu of bloodstream for trees, plants, etc.
+# I tried giving them bloodstream but it made them map unsavable.
+# Rather than mess with powers beyond comprehension, we made this alternative.
+- type: entity
+  id: VascularSystemPlant
+  abstract: true
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 30
+        reagents:
+        - ReagentId: Resin
+          Quantity: 30
+  - type: SolutionRegeneration
+    solution: pool
+    generated:
+      reagents:
+      - ReagentId: Resin
+        Quantity: 0.1
+  #- type: DrainableSolution
+    #solution: pool
+  - type: DrawableSolution
+    solution: pool
+    drainTime: 2
+  - type: InjectableSolution
+    solution: pool

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_plants.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent:
   - FloraPlantBaseStarcup
-  - MobBloodstream
+  - VascularSystemPlant
   id: FloraAlienPlant
   description: Pox Polyps, commonly known as honeybulb and lamptrap, is a predatory plant whose glowing, sweet nectar is deadly to the insects it lures.
   name: lamptrap
@@ -34,8 +34,16 @@
     radius: 2.0
     energy: 1.5
     color: "#ecca87"
-  - type: Bloodstream
-    bloodReferenceSolution:
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 30
+        reagents:
+        - ReagentId: Honey
+          Quantity: 30
+  - type: SolutionRegeneration
+    solution: pool
+    generated:
       reagents:
       - ReagentId: Honey
-        Quantity: 40
+        Quantity: 0.1

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
@@ -156,11 +156,19 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Bloodstream
-    bloodReferenceSolution:
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 25
+        reagents:
+        - ReagentId: Sap
+          Quantity: 25
+  - type: SolutionRegeneration
+    solution: pool
+    generated:
       reagents:
       - ReagentId: Sap
-        Quantity: 25
+        Quantity: 0.1
 
 - type: entity
   parent: BaseStumpStarcup
@@ -263,11 +271,13 @@
         offset: 0
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Bloodstream
-    bloodReferenceSolution:
-      reagents:
-      - ReagentId: Resin
-        Quantity: 15
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 15
+        reagents:
+        - ReagentId: Resin
+          Quantity: 15
 
 - type: entity
   parent: BaseTreeLarge
@@ -327,11 +337,13 @@
         offset: 0
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Bloodstream
-    bloodReferenceSolution:
-      reagents:
-      - ReagentId: Resin
-        Quantity: 25
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 15
+        reagents:
+        - ReagentId: Resin
+          Quantity: 15
 
 - type: entity
   parent: BaseStumpStarcup

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/deciduous_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/deciduous_trees.yml
@@ -324,11 +324,19 @@
             min: 1
             max: 1
         offset: 0
-  - type: Bloodstream
-    bloodReferenceSolution:
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 45
+        reagents:
+        - ReagentId: Sap
+          Quantity: 45
+  - type: SolutionRegeneration
+    solution: pool
+    generated:
       reagents:
       - ReagentId: Sap
-        Quantity: 50
+        Quantity: 0.1
 
 - type: entity
   parent: BaseStumpStarcup


### PR DESCRIPTION
[Adding a bloodstream to trees](https://github.com/teamstarcup/starcup/pull/874) broke them because MobBloodstream has the variable to make them map-savable toggled off. As we don't know why, but we assume there's a good reason, we made this alternate entity that's just a solution container manager you can draw from and inject to.

Thanks to @KoboldCatgirl and @foxcurl for showing me how to fix it.

## Why / Balance
As said in https://github.com/teamstarcup/starcup/pull/874:
> Giving trees a bloodstream opens up a lot of new possibilities, as certain species or even rare specimens can have different chemicals that can be sampled by botanists or scientists for round objectives or story purposes. Giving them the existing sap reagent wasn't deemed a good idea, as sap can be consumed to satiate hunger or thirst, that's why we made resin. There are some trees (notably the reeds of paradise) that do have easily consumable sap. The lamptrap plant also now comes with honey.

## Technical details
- Created a new entity, VascularSystemPlant, and re-parented trees and plants previously parented to MobBloodstream to it.
**Note:** SolutionContainerManagerComponent in the new entity should be replaced with SolutionManagerComponent when we have it. The reason I say SolutionManagerComponent and not SolutionComponent is that some future trees may have more than one reagent in their vascular system.

**Changelog**
:cl:
- fix: Trees should now be normally savable in maps.
