### PR TITLE
fix: re-comments out ashing behaviors

### DIFF
--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -196,36 +196,36 @@
   # end starcup
   - type: Destructible
     thresholds:
-    # begin starcup: reintroduce blunt damage gibbing
+    # begin starcup: reintroduce blunt damage gibbing and remove ashing
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    # end starcup
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          FoodMeatChickenFriedVox:
-            min: 3
-            max: 5
-      - !type:BurnBodyBehavior
-        popupMessage: bodyburn-vox-text-others
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+#    - trigger:
+#        !type:DamageTypeTrigger
+#        damageType: Blunt
+#        damage: 400
+#      behaviors:
+#      - !type:GibBehavior { }
+#    - trigger:
+#        !type:DamageTypeTrigger
+#        damageType: Heat
+#        damage: 1500
+#      behaviors:
+#      - !type:SpawnEntitiesBehavior
+#        spawnInContainer: true
+#        spawn:
+#          FoodMeatChickenFriedVox:
+#            min: 3
+#            max: 5
+#      - !type:BurnBodyBehavior
+#        popupMessage: bodyburn-vox-text-others
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MeatLaserImpact
+# end starcup
     - trigger:
         !type:DamageTypeTrigger
         damageType: Radiation

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -196,19 +196,13 @@
   # end starcup
   - type: Destructible
     thresholds:
-    # begin starcup: reintroduce blunt damage gibbing and remove ashing
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-#    - trigger:
-#        !type:DamageTypeTrigger
-#        damageType: Blunt
-#        damage: 400
-#      behaviors:
-#      - !type:GibBehavior { }
+# begin starcup: remove ashing
 #    - trigger:
 #        !type:DamageTypeTrigger
 #        damageType: Heat

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -73,19 +73,13 @@
     damageContainer: Biological
   - type: Destructible
     thresholds:
-    # begin starcup: reintroduce blunt damage gibbing and remove ashing
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-#    - trigger:
-#        !type:DamageTypeTrigger
-#        damageType: Blunt
-#        damage: 400
-#      behaviors:
-#      - !type:GibBehavior { }
+    # begin starcup: remove ashing
 #    - trigger:
 #        !type:DamageTypeTrigger
 #        damageType: Heat

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -73,35 +73,35 @@
     damageContainer: Biological
   - type: Destructible
     thresholds:
-    # begin starcup: reintroduce blunt damage gibbing
+    # begin starcup: reintroduce blunt damage gibbing and remove ashing
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    # end starcup
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+#    - trigger:
+#        !type:DamageTypeTrigger
+#        damageType: Blunt
+#        damage: 400
+#      behaviors:
+#      - !type:GibBehavior { }
+#    - trigger:
+#        !type:DamageTypeTrigger
+#        damageType: Heat
+#        damage: 1500
+#      behaviors:
+#      - !type:SpawnEntitiesBehavior
+#        spawnInContainer: true
+#        spawn:
+#          Ash:
+#            min: 1
+#            max: 1
+#      - !type:BurnBodyBehavior
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MeatLaserImpact
+# end starcup
     - trigger:
         !type:DamageTypeTrigger
         damageType: Radiation


### PR DESCRIPTION
This PR should just be re-implementing [#653](https://github.com/teamstarcup/starcup/pull/653)!

> removes the destructible trigger from heat damage ("ashing") from player species

## Why / Balance
> permadeath doesn't suit starcup's focus on narrative continuity, and in terms of what a gm can handle, uncapped heat damage is the lesser of two evils compared to the total destruction of ashing.

## Technical Details
Modifies the BaseControllable (and thus BaseMob) prototype.

## Media
<img width="300" height="293" alt="image" src="https://github.com/user-attachments/assets/ff2b6127-abaf-4ec5-bb5d-64ace2d0098e" />

**Changelog**
:cl:
- fix: players will once again not disintegrate into ash upon taking excessive heat damage