### PR TITLE
fix: removes redundant courier bag from courier starting gear

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Jobs/Cargo/courier.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Cargo/courier.yml
@@ -15,7 +15,7 @@
   id: CourierGear
   equipment:
     ears: ClothingHeadsetCargo
-    belt: CourierBag
+    # belt: CourierBag # starcup: This is now a loadout option
 
 # begin starcup: add chameleon outfit
 - type: chameleonOutfit


### PR DESCRIPTION
## Why / Balance

Fixes #890 

Courier bags are now provided via loadout. Avoid spawning a duplicate one via the job gear.

**Changelog**
:cl:
- fix: Couriers are now issued a single courier or mail bag.
