### PR TITLE
tweak: Terrestrial Station Cleanup

### DIFF
--- a/Resources/Maps/_starcup/Shuttles/silent_moon_surface_shuttle.yml
+++ b/Resources/Maps/_starcup/Shuttles/silent_moon_surface_shuttle.yml
@@ -75,6 +75,11 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: GridPathfinding
     - type: DecalGrid
       chunkCollection:

--- a/Resources/Maps/_starcup/Shuttles/snowy_trade_outpost.yml
+++ b/Resources/Maps/_starcup/Shuttles/snowy_trade_outpost.yml
@@ -1,0 +1,1090 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 272.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 04/26/2026 03:20:57
+  entityCount: 171
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  1: Space
+  4: FloorDarkMono
+  8: FloorGrayConcrete
+  3: FloorGrayConcreteMono
+  6: FloorMetalDiamond
+  0: FloorPlanetGrassBlue
+  7: FloorSnow
+  5: FloorTechMaint2
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Automated Trade Outpost
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: BwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAABwAAAAADAAcAAAAABQAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAACAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAADAAAAAAAACAAAAAABAAgAAAAAAQAIAAAAAAMACAAAAAACAAgAAAAAAAADAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAwAAAAADAAIAAAAAAAACAAAAAAAABgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAMAAAAAAgACAAAAAAAAAgAAAAAAAAYAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAAGAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAwAAAAAAAAgAAAAAAQAIAAAAAAMACAAAAAACAAgAAAAAAgAIAAAAAAIAAwAAAAACAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAIAAAAAAAADAAAAAAEAAwAAAAACAAYAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAkABwAAAAAAAAcAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: Roof
+      weatherOcclusionData:
+        -1,1: 0
+        -1,0: 18374403900871474688
+        0,1: 0
+        0,0: 0
+      data:
+        -1,1: 0
+        -1,0: 9402526996149076480
+        0,1: 0
+        0,0: 0
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineGreyscaleE
+          decals:
+            23: -7,3
+            30: -7,4
+            31: -7,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineGreyscaleN
+          decals:
+            10: -5,1
+            11: -4,1
+            12: -3,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineGreyscaleW
+          decals:
+            16: -1,3
+            17: -1,4
+            18: -1,5
+        - node:
+            color: '#FFFFFFFF'
+            id: bushsnowa1
+          decals:
+            24: 0.07886219,0.77645195
+        - node:
+            color: '#FFFFFFFF'
+            id: bushsnowb1
+          decals:
+            26: -7.8729157,7.299139
+        - node:
+            color: '#FFFFFFFF'
+            id: grasssnow09
+          decals:
+            27: 0.10370827,3.1414003
+            28: -0.10421181,4.5493855
+            29: -4.4460745,0.10504913
+            34: -7.854965,3.6936755
+            35: 0.14779663,7.452384
+            36: -7.9886475,1.1490152
+        - node:
+            color: '#FFFFFFFF'
+            id: grasssnow10
+          decals:
+            33: -7.568763,4.9792275
+        - node:
+            color: '#FFFFFFFF'
+            id: grasssnowc1
+          decals:
+            32: -3.0434418,0.41245747
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 4369
+          -1,0:
+            0: 65407
+          0,1:
+            0: 4369
+          -1,1:
+            0: 32767
+          0,2:
+            0: 1
+          -1,2:
+            0: 15
+          -2,0:
+            0: 65503
+          -2,1:
+            0: 57343
+          -2,2:
+            0: 15
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
+    - type: TradeStation
+- proto: APCBasic
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+- proto: AtmosFixFreezerMarker
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: CableApcStack1
+  entities:
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -3.2858057,7.3887224
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+- proto: CargoPalletBuy
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+- proto: CargoPalletSell
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+- proto: ComputerPalletConsole
+  entities:
+  - uid: 122
+    components:
+    - type: MetaData
+      desc: Used to sell goods loaded onto cargo pallets, for transport off-planet.
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+    - type: FaxMachine
+      name: Automated Trade Outpost
+- proto: GeneratorBasic
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: Anchorable
+      flags: Anchorable
+- proto: HolopadCargoAts
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+- proto: PosterLegitHawkmoonAd
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+- proto: PowerCellSmallPrinted
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -3.5956473,7.576454
+      parent: 1
+- proto: PoweredlightCold
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+- proto: PoweredLightPostSmallSodium
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 147
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: ReinforcedGirder
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,7.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+- proto: SyndieFlag
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: TableCounterMetal
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,7.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 171
+    components:
+    - type: MetaData
+      name: Automated Trade Outpost
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+...

--- a/Resources/Prototypes/_starcup/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_starcup/Entities/Stations/base.yml
@@ -1,0 +1,28 @@
+# Terrestrial Stations with a Charonic surface trading outpost
+- type: entity
+  id: BaseTerrestrialStationTradingCharonic
+  abstract: true
+  components:
+  - type: GridSpawn
+    groups:
+      trade: !type:GridSpawnGroup
+        addComponents:
+        - type: ProtectedGrid
+        - type: TradeStation
+        paths:
+        - /Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml
+
+# Terrestrial Stations with a snowy surface trading outpost
+- type: entity
+  id: BaseTerrestrialStationTradingSnowy
+  abstract: true
+  components:
+  - type: GridSpawn
+    groups:
+      trade: !type:GridSpawnGroup
+        addComponents:
+        - type: ProtectedGrid
+        - type: TradeStation
+        paths:
+        - /Maps/_starcup/Shuttles/snowy_trade_outpost.yml
+# could add custom ruins later

--- a/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
+++ b/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
@@ -1,52 +1,4 @@
-# like a space station, but on a terrestrial surface
-# lacks salvage jobs, magnet, debris spawning, evacuation etc.
-- type: entity
-  id: StandardTerrestrialStationNoEvac
-  parent:
-  - BaseStation
-  - BaseStationNews
-  - BaseStationCargo
-  - BaseStationJobsSpawning
-  - BaseStationRecords
-#  - BaseStationArrivals
-  - BaseStationGateway
-  - BaseStationCentcomm
-  - BaseStationAlertLevels
-  - BaseStationSiliconLawCrewsimov
-  - BaseStationAllEventsEligible
-  - BaseStationNanotrasen
-  - BaseStationDeliveries
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Transform
-
-- type: entity
-  id: StandardTerrestrialStation
-  parent:
-  - StandardTerrestrialStationNoEvac
-  - BaseStationEvacuation
-  categories: [ HideSpawnMenu ]
-
-# like a basic station, but no evac, no salvage stuff, no trash, etc. epilogue station is meant for syndcomm, generally.
-- type: entity
-  id: StandardEpilogueStationNoEvacNoEvents
-  parent:
-  - BaseStation
-#  - BaseStationNews
-#  - BaseStationCargo
-  - BaseStationJobsSpawning
-  - BaseStationRecords
-  #  - BaseStationArrivals
-  - BaseStationGateway
-  - BaseStationCentcomm
-  - BaseStationAlertLevels
-  - BaseStationSiliconLawCrewsimov
-#  - BaseStationAllEventsEligible # we don't want any interruptions
-  - BaseStationNanotrasen
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Transform
-
+# Epilogue Stations (for EOR+)
 - type: entity
   id: StandardEpilogueStation
   parent:
@@ -56,23 +8,71 @@
   categories: [ HideSpawnMenu ]
 
 - type: entity
+  id: StandardEpilogueStationNoEvacNoEvents
+  parent:
+  - BaseStation
+  - BaseStationJobsSpawning
+  - BaseStationRecords
+  - BaseStationCentcomm
+  - BaseStationAlertLevels
+  - BaseStationSiliconLawCrewsimov
+  - BaseStationNanotrasen
+#  - BaseStationGateway
+#  - BaseStationExpeditions
+#  - BaseStationSalvageJobs
+#  - BaseStationAllEventsEligible
+#  - BaseStationNews
+#  - BaseStationCargo
+#  - BaseStationDeliveries
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Transform
+
+# Terrestrial Stations
+- type: entity
+  id: StandardTerrestrialStation
+  parent:
+  - StandardTerrestrialStationNoEvac
+  - BaseStationEvacuation
+  categories: [ HideSpawnMenu ]
+
+- type: entity
+  id: StandardTerrestrialStationNoEvac
+  parent:
+  - BaseStation
+  - BaseStationNews
+  - BaseStationCargo
+  - BaseStationJobsSpawning
+  - BaseStationRecords
+  - BaseStationGateway
+  - BaseStationCentcomm
+  - BaseStationAlertLevels
+  - BaseStationExpeditions
+  - BaseStationSalvageJobs
+  - BaseStationSiliconLawCrewsimov
+  - BaseStationAllEventsEligible
+  - BaseStationNanotrasen
+  - BaseStationDeliveries
+#  - BaseStationArrivals
+#  - BaseStationShuttles - unwanted ATS/space wrecks
+#  - BaseStationEvacuation
+#  - BaseStationMagnet - makes no sense for planetside
+#  - BaseStationLavaland
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Transform
+
+## Terrestrial Stations with Trading Outposts
+- type: entity
   id: StandardTerrestrialStationTradingCharonic
   parent:
   - StandardTerrestrialStation
   - BaseTerrestrialStationTradingCharonic
-  - BaseStationExpeditions
   categories: [ HideSpawnMenu ]
 
-# Terrestrial Stations with a surface trading outpost
 - type: entity
-  id: BaseTerrestrialStationTradingCharonic
-  abstract: true
-  components:
-  - type: GridSpawn
-    groups:
-      trade: !type:GridSpawnGroup
-        addComponents:
-        - type: ProtectedGrid
-        - type: TradeStation
-        paths:
-        - /Maps/_starcup/Events/SilentMoonGrids/T1-ats-9x9.yml
+  id: StandardTerrestrialStationTradingSnowy
+  parent:
+  - StandardTerrestrialStation
+  - BaseTerrestrialStationTradingSnowy
+  categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
+++ b/Resources/Prototypes/_starcup/Entities/Stations/stations.yml
@@ -40,19 +40,19 @@
   id: StandardTerrestrialStationNoEvac
   parent:
   - BaseStation
-  - BaseStationNews
-  - BaseStationCargo
-  - BaseStationJobsSpawning
-  - BaseStationRecords
-  - BaseStationGateway
-  - BaseStationCentcomm
   - BaseStationAlertLevels
-  - BaseStationExpeditions
-  - BaseStationSalvageJobs
-  - BaseStationSiliconLawCrewsimov
-  - BaseStationAllEventsEligible
-  - BaseStationNanotrasen
+  - BaseStationCargo
+  - BaseStationCentcomm
   - BaseStationDeliveries
+  - BaseStationSiliconLawCrewsimov
+  - BaseStationExpeditions
+  - BaseStationGateway
+  - BaseStationJobsSpawning
+  - BaseStationNanotrasen
+  - BaseStationNews
+  - BaseStationRecords
+  - BaseStationSalvageJobs
+#  - BaseStationAllEventsEligible
 #  - BaseStationArrivals
 #  - BaseStationShuttles - unwanted ATS/space wrecks
 #  - BaseStationEvacuation


### PR DESCRIPTION
This PR is largely coding-side for now, as part of the preparation for Ptarmigan!

- Terrestrial stations now have access by default to a wider array of components, including Expeditions and Gateways.
- New "Trading" variant added for Snowy terrestrial stations, allowing a snowy ATO to spawn.
- Charon-Epsilon's shuttle now transmits to the ShuttleTimer properly.

## Why / Balance
By default, the basic terrestrial station prototypes should be left as generic as possible to allow for greater modifications. It's harmless to allow expeditions; mappers can easily prevent those if desired.

The snowy trading station will be necessary for Ptarmigan!

## Media
<img width="288" height="288" alt="tradeoutpost-0" src="https://github.com/user-attachments/assets/fb0e41a8-2563-4514-ba01-cbcced3e2975" />

**Changelog**
:cl:
- fix: Charon-Epsilon's evac clocks will now count properly. Not that you'd ever want to leave.