### PR TITLE
tweak: allow all SuitStorage items for winter coats

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothingGasTanks] # DeltaV - allow tanks for winter coats
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing] # starcup - allow any compat. item for winter coats
   id: ClothingOuterWinterCoat
   name: winter coat
   description: A heavy jacket made from 'synthetic' animal furs.


### PR DESCRIPTION

## Why / Balance

This allows stuff like slinging a longarm onto your back while wearing an armored coat as sec in glacier, or PKAs

Originally it was set that only gas tanks can be worn on winter coat suit storages, which was from DeltaV.
Plus this makes winter coats a little more viable for glacier/MKCs as glacier isnt spaced and MKCs don't need to breathe.

**Changelog**

:cl:
- tweak: All winter coats are now able to equip any compatible item in suit storage