### PR TITLE
tweak: disables freigher feedback popup

### DIFF
--- a/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
+++ b/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
@@ -38,7 +38,7 @@
     If you have any thoughts on this map or noticed something wrong, let us know on our forum!
   responseType: "Forum Thread"
   responseLink: "https://forum.starcup.cc/t/trimaran-freighter-feedback-thread/444"
-  showRoundEnd: true
+  showRoundEnd: false
 
 - type: feedbackPopup
   id: FeedbackPopupMapGlacier


### PR DESCRIPTION
Disables the feedback popup for Freighter.

## Why / Balance
should have been done a while ago..! we dont want these becoming just noise people close instantly 

**Changelog**
no cl