### PR TITLE
tweak: restore arachnids

### DIFF
--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Arachnid
   name: species-name-arachnid
-  roundStart: false # starcup - disable arachnids
+  roundStart: true
   prototype: MobArachnid
   defaultSkinTone: "#385878"
   dollPrototype: AppearanceArachnid


### PR DESCRIPTION
Re-adds arachnids to character creation.

Tagged as DO NOT MERGE as there was talk in the team about possibly reintroducing them during an event.

**Changelog**
:cl:
- add: Arachnid personnel have now joined Syndicate Communications! Report for duty at the character creation screen.