### PR TITLE
tweak: let windows and highsec doors replace walls/doors in mapping

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -127,6 +127,8 @@
   - type: Construction
     graph: Airlock
     node: highSecDoor
+  - type: PlacementReplacement # starcup - all doors should replace walls and doors
+    key: walls
   - type: Tag
     tags:
       - HighSecDoor

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -96,6 +96,8 @@
   - type: StaticPrice
     price: 100
   - type: BlockWeather
+  - type: PlacementReplacement # starcup - windows should replace walls and doors
+    key: walls
 
 - type: entity
   parent: Window

--- a/Resources/Prototypes/_starcup/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Devices/Electronics/door_access.yml
@@ -85,3 +85,11 @@
   components:
   - type: AccessReader
     access: [["SyndicateCommunications"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsArmoryVault
+  suffix: Command, Armory, Locked
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Armory"]]

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
@@ -432,7 +432,7 @@
 
 - type: entity
   parent: HighSecCommandLocked
-  id: AirlockArmoryVault # for small stations where the Armory and Vault are combined.
+  id: HighSecArmoryVault # for small stations where the Armory and Vault are combined.
   suffix: Command, Armory
   components:
   - type: ContainerFill

--- a/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Doors/Airlocks/access.yml
@@ -73,7 +73,7 @@
     containers:
       board: [ DoorElectronicsParamedic ]
   - type: Sprite
-    sprite: _starcup/Structures/Doors/Airlocks/Glass/paramedic.rsi
+    sprite: _starcup/Structures/Doors/Airlocks/Standard/paramedic.rsi
 
 - type: entity
   parent: AirlockMedicalLocked
@@ -251,7 +251,7 @@
     containers:
       board: [ DoorElectronicsParamedic ]
   - type: Sprite
-    sprite: _starcup/Structures/Doors/Airlocks/Standard/paramedic.rsi
+    sprite: _starcup/Structures/Doors/Airlocks/Glass/paramedic.rsi
 
 - type: entity
   parent: AirlockMedicalGlassLocked
@@ -429,6 +429,15 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSyndicateCommunications ]
+
+- type: entity
+  parent: HighSecCommandLocked
+  id: AirlockArmoryVault # for small stations where the Armory and Vault are combined.
+  suffix: Command, Armory
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsArmoryVault ]
 
 # Charon-epsilon only (spawns the C-E surface shuttle)
 - type: entity


### PR DESCRIPTION
This PR makes it so that when an aghost places a highsec door or window, it automatically replaces any walls, windows, or airlocks that were in the way.

It also adds a warden/command-access highsec dor.

## Why / Balance
The highsec door thing is clearly a mistake--they're airlocks, they're supposed to replace walls and airlocks.

With windows, there is basically no scenario in which we want to place a window overlapping with a wall, or vice versa. This is a QOL change to allow mappers to speedily tweak their room layouts.

The warden/command highsec door is a little out-of-scopey, but it's a missing function for High-Security Doors--an Armory door that Command can enter, which is useful for small maps where the Vault and Armory might be effectively the same location. The Warden is generally treated as almost-Command, so I think this is a useful way to reflect that on certain maps.

## Technical details
Adds the PlacementReplacement component to the base parents for all windows and high-security doors.

## Media

https://github.com/user-attachments/assets/fc34db04-5a76-45d0-b712-212486c9251c

**Changelog**
No player-side changes.

**Mapper's Changelog**
- fix: highsec doors will now replace other doors or walls when placing entities.
- tweak: windows will now replace walls and doors when placing entities.
- add: added an Armory/Command-access high-security door!