### PR TITLE
tweak(mkc): change default organic health icons to borg variant

### DIFF
--- a/Resources/Prototypes/_starcup/Body/species_base.yml
+++ b/Resources/Prototypes/_starcup/Body/species_base.yml
@@ -95,3 +95,8 @@
   - type: LightningTarget
     priority: 1
     lightningExplode: false
+  - type: MobThresholds
+    stateAlertDict:
+      Alive: BorgHealth
+      Critical: BorgCrit
+      Dead: BorgDead


### PR DESCRIPTION

## Why / Balance
MKCs having organic health icons is weird, lets change that

## Technical details
Hijacks the `MobThreshold` component in prototype `BaseSpeciesMobSilicon`.

## Media
<img width="949" height="308" alt="image" src="https://github.com/user-attachments/assets/b5eb64e8-5a3d-4810-95ac-f146bf704c8b" />

**Changelog**
:cl:
- tweak: Changed the health icons for MKCs to cyborg variants.


