### PR TITLE
fix: extra 40th entry in female moth name datasets

### DIFF
--- a/Resources/Locale/en-US/datasets/names/moth_first_female.ftl
+++ b/Resources/Locale/en-US/datasets/names/moth_first_female.ftl
@@ -95,8 +95,7 @@ names-moth-first-female-dataset-38 = Zoey
 ## begin starcup: more genus and species derivatives
 
 # Sphingidae
-names-moth-first-female-dataset-39 = Sphinx
-names-moth-first-female-dataset-40 = Sphynx
+names-moth-first-female-dataset-39 = Sphynx
 names-moth-first-female-dataset-40 = Sphinga
 names-moth-first-female-dataset-41 = Esfinice
 


### PR DESCRIPTION
Quick PR to fix #905 so there's only one entry number 40 and not two.