### PR TITLE
fix: fix Lavaland's fax machine and air alarms

### DIFF
--- a/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
+++ b/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
@@ -32,7 +32,6 @@ entities:
     - type: MetaData
       name: Mining Base
     - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -715,238 +714,6 @@ entities:
       chunkHistory: {}
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
-  - uid: 4
-    components:
-    - type: MetaData
-      name: solution - lvcable
-    - type: Transform
-      parent: 3
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: lvcable
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 3
-        - data: []
-          ReagentId: Copper
-          Quantity: 2
-    - type: ContainedSolution
-      containerName: lvcable
-      container: 3
-  - uid: 11
-    components:
-    - type: MetaData
-      name: solution - smokable
-    - type: Transform
-      parent: 10
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: smokable
-        reagents: []
-    - type: ContainedSolution
-      containerName: smokable
-      container: 10
-  - uid: 13
-    components:
-    - type: MetaData
-      name: solution - smokable
-    - type: Transform
-      parent: 12
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: smokable
-        reagents: []
-    - type: ContainedSolution
-      containerName: smokable
-      container: 12
-  - uid: 21
-    components:
-    - type: MetaData
-      name: solution - steel
-    - type: Transform
-      parent: 20
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: steel
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 9
-        - data: []
-          ReagentId: Carbon
-          Quantity: 1
-    - type: ContainedSolution
-      containerName: steel
-      container: 20
-  - uid: 23
-    components:
-    - type: MetaData
-      name: solution - lvcable
-    - type: Transform
-      parent: 22
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: lvcable
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 3
-        - data: []
-          ReagentId: Copper
-          Quantity: 2
-    - type: ContainedSolution
-      containerName: lvcable
-      container: 22
-  - uid: 31
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 30
-    - type: Solution
-      solution:
-        maxVol: 1
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 1
-    - type: ContainedSolution
-      containerName: food
-      container: 30
-  - uid: 33
-    components:
-    - type: MetaData
-      name: solution - rod
-    - type: Transform
-      parent: 32
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: rod
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 4.5
-        - data: []
-          ReagentId: Carbon
-          Quantity: 0.5
-    - type: ContainedSolution
-      containerName: rod
-      container: 32
-  - uid: 36
-    components:
-    - type: MetaData
-      name: solution - lvcable
-    - type: Transform
-      parent: 35
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: lvcable
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 3
-        - data: []
-          ReagentId: Copper
-          Quantity: 2
-    - type: ContainedSolution
-      containerName: lvcable
-      container: 35
-  - uid: 42
-    components:
-    - type: MetaData
-      name: solution - mvcable
-    - type: Transform
-      parent: 41
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: mvcable
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 3
-        - data: []
-          ReagentId: Copper
-          Quantity: 2
-    - type: ContainedSolution
-      containerName: mvcable
-      container: 41
-  - uid: 44
-    components:
-    - type: MetaData
-      name: solution - hvcable
-    - type: Transform
-      parent: 43
-    - type: Solution
-      solution:
-        maxVol: 6
-        name: hvcable
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 3
-        - data: []
-          ReagentId: Copper
-          Quantity: 2
-        - data: []
-          ReagentId: Carbon
-          Quantity: 1
-    - type: ContainedSolution
-      containerName: hvcable
-      container: 43
-  - uid: 46
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 45
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 45
-- proto: ActionSleep
-  entities:
-  - uid: 55
-    components:
-    - type: Transform
-      parent: 54
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 54
-  - uid: 57
-    components:
-    - type: Transform
-      parent: 56
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 56
-  - uid: 59
-    components:
-    - type: Transform
-      parent: 58
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 58
-  - uid: 61
-    components:
-    - type: Transform
-      parent: 60
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 60
 - proto: AirAlarmAutoLink
   entities:
   - uid: 63
@@ -1158,16 +925,6 @@ entities:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-    - type: AccessReader
-      accessListsOriginal:
-      - - Engineering
-    - type: Battery
-      lastCharge: 50000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 940
-      currentReceiving: 939.96185
-      currentSupply: 940
-      supplyRampPosition: 0.038146973
   - uid: 85
     components:
     - type: MetaData
@@ -1176,13 +933,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-    - type: Battery
-      lastCharge: 50000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 210
-      currentReceiving: 210.0002
-      currentSupply: 210
-      supplyRampPosition: -0.00019836426
   - uid: 86
     components:
     - type: MetaData
@@ -1191,13 +941,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-    - type: Battery
-      lastCharge: 50000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 111
-      currentReceiving: 110.97667
-      currentSupply: 111
-      supplyRampPosition: 0.023330688
   - uid: 87
     components:
     - type: MetaData
@@ -1206,13 +949,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-    - type: Battery
-      lastCharge: 50000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 175
-      currentReceiving: 174.9611
-      currentSupply: 175
-      supplyRampPosition: 0.038879395
   - uid: 88
     components:
     - type: MetaData
@@ -1221,25 +957,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
-    - type: Battery
-      lastCharge: 50000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 1656
-      currentReceiving: 1655.9781
-      currentSupply: 1656
-      supplyRampPosition: 0.021972656
   - uid: 89
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-1.5
       parent: 1
-    - type: Battery
-      lastCharge: 50000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 1640
-      currentReceiving: 1640.0406
-      currentSupply: 1640
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 90
@@ -1255,40 +978,16 @@ entities:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-    - type: HealOnBuckle
-      sleepAction: 55
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 55
   - uid: 56
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-    - type: HealOnBuckle
-      sleepAction: 57
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 57
   - uid: 58
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-    - type: HealOnBuckle
-      sleepAction: 59
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 59
 - proto: BedsheetBlack
   entities:
   - uid: 91
@@ -1323,13 +1022,6 @@ entities:
     - type: Transform
       pos: 7.4469547,-4.492324
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles: {}
-      open: True
 - proto: BodyBagFolded
   entities:
   - uid: 95
@@ -1337,14 +1029,6 @@ entities:
     - type: Transform
       pos: 4.696921,-4.2438545
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
 - proto: BorgCharger
   entities:
   - uid: 2
@@ -1352,39 +1036,6 @@ entities:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 5
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 6
-          - 3
-- proto: BorgChargerCircuitboard
-  entities:
-  - uid: 5
-    components:
-    - type: Transform
-      parent: 2
-    - type: Physics
-      canCollide: False
 - proto: BoxLatexGloves
   entities:
   - uid: 8
@@ -1723,56 +1374,6 @@ entities:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-- proto: CableApcStack1
-  entities:
-  - uid: 3
-    components:
-    - type: Transform
-      parent: 2
-    - type: Stack
-      count: 5
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - lvcable
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@lvcable: !type:ContainerSlot
-          ent: 4
-  - uid: 22
-    components:
-    - type: Transform
-      parent: 19
-    - type: Stack
-      count: 2
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - lvcable
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@lvcable: !type:ContainerSlot
-          ent: 23
-  - uid: 35
-    components:
-    - type: Transform
-      parent: 34
-    - type: Stack
-      count: 5
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - lvcable
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@lvcable: !type:ContainerSlot
-          ent: 36
 - proto: CableHV
   entities:
   - uid: 181
@@ -1795,24 +1396,6 @@ entities:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-- proto: CableHVStack1
-  entities:
-  - uid: 43
-    components:
-    - type: Transform
-      parent: 40
-    - type: Stack
-      count: 5
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - hvcable
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@hvcable: !type:ContainerSlot
-          ent: 44
 - proto: CableMV
   entities:
   - uid: 98
@@ -2010,48 +1593,6 @@ entities:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-- proto: CableMVStack1
-  entities:
-  - uid: 41
-    components:
-    - type: Transform
-      parent: 40
-    - type: Stack
-      count: 5
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - mvcable
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@mvcable: !type:ContainerSlot
-          ent: 42
-- proto: CapacitorStockPart
-  entities:
-  - uid: 6
-    components:
-    - type: Transform
-      parent: 2
-    - type: Stack
-      count: 2
-    - type: Physics
-      canCollide: False
-  - uid: 37
-    components:
-    - type: Transform
-      parent: 34
-    - type: Stack
-      count: 2
-    - type: Physics
-      canCollide: False
-  - uid: 47
-    components:
-    - type: Transform
-      parent: 40
-    - type: Physics
-      canCollide: False
 - proto: Catwalk
   entities:
   - uid: 201
@@ -3741,14 +3282,6 @@ entities:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-    - type: HealOnBuckle
-      sleepAction: 61
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 61
 - proto: MiningWindow
   entities:
   - uid: 357
@@ -4321,33 +3854,6 @@ entities:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 39
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 38
-          - 37
-          - 35
-    - type: SpaceHeater
-      mode: Cool
-    - type: GasThermoMachine
-      coefficientOfPerformance: 1
-      heatCapacity: 3500
-- proto: SpaceHeaterMachineCircuitBoard
-  entities:
-  - uid: 39
-    components:
-    - type: Transform
-      parent: 34
-    - type: Physics
-      canCollide: False
 - proto: SubstationBasic
   entities:
   - uid: 40
@@ -4357,35 +3863,6 @@ entities:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-    - type: Battery
-      lastCharge: 2500000
-    - type: PowerNetworkBattery
-      loadingNetworkDemand: 4731.919
-      currentReceiving: 4732.5044
-      currentSupply: 4731.919
-    - type: ContainerContainer
-      containers:
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 48
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 47
-          - 41
-          - 43
-          - 45
-- proto: SubstationMachineCircuitboard
-  entities:
-  - uid: 48
-    components:
-    - type: Transform
-      parent: 40
-    - type: Physics
-      canCollide: False
 - proto: SuitStorageSalv
   entities:
   - uid: 49
@@ -4487,27 +3964,6 @@ entities:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-    - type: PointLight
-      enabled: True
-    - type: ContainerContainer
-      containers:
-        key_slots: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 24
-          - 25
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 26
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 20
-          - 22
 - proto: TelecomServerCircuitboard
   entities:
   - uid: 26
@@ -5136,26 +4592,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -8.5,-4.5
       parent: 1
-- proto: WallmountGeneratorAPUElectronics
-  entities:
-  - uid: 302
-    components:
-    - type: Transform
-      parent: 301
-    - type: Physics
-      canCollide: False
-  - uid: 304
-    components:
-    - type: Transform
-      parent: 303
-    - type: Physics
-      canCollide: False
-  - uid: 306
-    components:
-    - type: Transform
-      parent: 305
-    - type: Physics
-      canCollide: False
 - proto: WarpPoint
   entities:
   - uid: 494

--- a/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
+++ b/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 275.2.0
+  engineVersion: 275.2.1
   forkId: ""
   forkVersion: ""
-  time: 06/21/2026 19:46:16
-  entityCount: 769
+  time: 06/29/2026 03:00:20
+  entityCount: 600
 maps: []
 grids:
 - 1
@@ -32,6 +32,7 @@ entities:
     - type: MetaData
       name: Mining Base
     - type: Transform
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -293,12 +294,12 @@ entities:
             5: 32768
           -2,1:
             4: 130
-            54: 32
-            56: 8192
+            56: 32
+            57: 8192
             55: 4
             5: 72
-            57: 16384
-            58: 32768
+            58: 16384
+            59: 32768
             37: 4096
           -2,-1:
             0: 57582
@@ -313,10 +314,10 @@ entities:
             0: 47104
           1,-2:
             38: 243
-            59: 4096
+            60: 4096
             18: 8192
             0: 16384
-            60: 32768
+            61: 32768
             37: 12
           -3,-2:
             38: 32768
@@ -327,16 +328,16 @@ entities:
             37: 22
           0,2:
             6: 1
-            61: 16
-            62: 2
-            63: 4
-            64: 8
+            62: 16
+            63: 2
+            64: 4
+            65: 8
             37: 480
           -1,2:
-            65: 2
+            66: 2
             6: 12
-            66: 64
-            67: 128
+            67: 64
+            68: 128
             37: 3105
           0,-3:
             38: 28672
@@ -385,10 +386,10 @@ entities:
             Oxygen: 21.436878
             Nitrogen: 80.64349
         - volume: 2500
-          temperature: 293.14975
+          temperature: 293.1495
           moles:
-            Oxygen: 21.32824
-            Nitrogen: 80.23481
+            Oxygen: 19.62198
+            Nitrogen: 73.816025
         - volume: 2500
           temperature: 293.15
           moles:
@@ -635,13 +636,18 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-            Oxygen: 21.592077
-            Nitrogen: 81.22734
+            Oxygen: 21.471024
+            Nitrogen: 80.77194
         - volume: 2500
           temperature: 293.15
           moles:
             Oxygen: 21.59208
             Nitrogen: 81.22735
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.592077
+            Nitrogen: 81.22734
         - volume: 2500
           temperature: 2.7000103
           moles:
@@ -710,8 +716,6 @@ entities:
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
   - uid: 4
-    mapInit: true
-    paused: true
     components:
     - type: MetaData
       name: solution - lvcable
@@ -731,306 +735,40 @@ entities:
     - type: ContainedSolution
       containerName: lvcable
       container: 3
-  - uid: 9
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 8
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 8
   - uid: 11
-    mapInit: true
-    paused: true
     components:
     - type: MetaData
-      name: solution - food
+      name: solution - smokable
     - type: Transform
       parent: 10
     - type: Solution
       solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
+        maxVol: 20
+        name: smokable
+        reagents: []
     - type: ContainedSolution
-      containerName: food
+      containerName: smokable
       container: 10
   - uid: 13
-    mapInit: true
-    paused: true
     components:
     - type: MetaData
-      name: solution - food
+      name: solution - smokable
     - type: Transform
       parent: 12
     - type: Solution
       solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
+        maxVol: 20
+        name: smokable
+        reagents: []
     - type: ContainedSolution
-      containerName: food
+      containerName: smokable
       container: 12
-  - uid: 15
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 14
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 14
-  - uid: 18
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - drink
-    - type: Transform
-      parent: 17
-    - type: Solution
-      solution:
-        maxVol: 50
-        name: drink
-        reagents:
-        - data: []
-          ReagentId: Water
-          Quantity: 50
-    - type: ContainedSolution
-      containerName: drink
-      container: 17
-  - uid: 20
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 19
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Nutriment
-          Quantity: 15
-    - type: ContainedSolution
-      containerName: food
-      container: 19
-  - uid: 24
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - pen
-    - type: Transform
-      parent: 23
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: pen
-        reagents:
-        - data: []
-          ReagentId: Dermaline
-          Quantity: 10
-        - data: []
-          ReagentId: Leporazine
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: pen
-      container: 23
-  - uid: 26
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - smokable
-    - type: Transform
-      parent: 25
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: smokable
-        reagents: []
-    - type: ContainedSolution
-      containerName: smokable
-      container: 25
-  - uid: 28
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - smokable
-    - type: Transform
-      parent: 27
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: smokable
-        reagents: []
-    - type: ContainedSolution
-      containerName: smokable
-      container: 27
-  - uid: 31
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 30
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 30
-  - uid: 33
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 32
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 32
-  - uid: 37
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - spray
-    - type: Transform
-      parent: 36
-    - type: Solution
-      solution:
-        maxVol: 100
-        name: spray
-        reagents:
-        - data: []
-          ReagentId: Water
-          Quantity: 100
-    - type: ContainedSolution
-      containerName: spray
-      container: 36
-  - uid: 45
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 44
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 44
-  - uid: 47
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - drink
-    - type: Transform
-      parent: 46
-    - type: Solution
-      solution:
-        maxVol: 50
-        name: drink
-        reagents:
-        - data: []
-          ReagentId: Beer
-          Quantity: 50
-    - type: ContainedSolution
-      containerName: drink
-      container: 46
-  - uid: 49
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - drink
-    - type: Transform
-      parent: 48
-    - type: Solution
-      solution:
-        maxVol: 50
-        name: drink
-        reagents:
-        - data: []
-          ReagentId: Beer
-          Quantity: 50
-    - type: ContainedSolution
-      containerName: drink
-      container: 48
-  - uid: 51
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - drink
-    - type: Transform
-      parent: 50
-    - type: Solution
-      solution:
-        maxVol: 50
-        name: drink
-        reagents: []
-    - type: ContainedSolution
-      containerName: drink
-      container: 50
-  - uid: 54
-    mapInit: true
-    paused: true
+  - uid: 21
     components:
     - type: MetaData
       name: solution - steel
     - type: Transform
-      parent: 53
+      parent: 20
     - type: Solution
       solution:
         maxVol: 10
@@ -1044,15 +782,13 @@ entities:
           Quantity: 1
     - type: ContainedSolution
       containerName: steel
-      container: 53
-  - uid: 56
-    mapInit: true
-    paused: true
+      container: 20
+  - uid: 23
     components:
     - type: MetaData
       name: solution - lvcable
     - type: Transform
-      parent: 55
+      parent: 22
     - type: Solution
       solution:
         maxVol: 5
@@ -1066,195 +802,13 @@ entities:
           Quantity: 2
     - type: ContainedSolution
       containerName: lvcable
-      container: 55
-  - uid: 62
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - drink
-    - type: Transform
-      parent: 61
-    - type: Solution
-      solution:
-        maxVol: 30
-        name: drink
-        reagents:
-        - data: []
-          ReagentId: Bicaridine
-          Quantity: 30
-    - type: ContainedSolution
-      containerName: drink
-      container: 61
-  - uid: 64
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - drink
-    - type: Transform
-      parent: 63
-    - type: Solution
-      solution:
-        maxVol: 30
-        name: drink
-        reagents:
-        - data: []
-          ReagentId: Saline
-          Quantity: 30
-    - type: ContainedSolution
-      containerName: drink
-      container: 63
-  - uid: 75
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 74
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 74
-  - uid: 79
-    mapInit: true
-    paused: true
+      container: 22
+  - uid: 31
     components:
     - type: MetaData
       name: solution - food
     - type: Transform
-      parent: 78
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 78
-  - uid: 82
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - Welder
-    - type: Transform
-      parent: 81
-    - type: Solution
-      solution:
-        maxVol: 100
-        name: Welder
-        reagents:
-        - data: []
-          ReagentId: WeldingFuel
-          Quantity: 100
-    - type: ContainedSolution
-      containerName: Welder
-      container: 81
-  - uid: 89
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - flare
-    - type: Transform
-      parent: 88
-    - type: Solution
-      solution:
-        maxVol: 20
-        name: flare
-        reagents:
-        - data: []
-          ReagentId: Iron
-          Quantity: 10
-        - data: []
-          ReagentId: Phosphorus
-          Quantity: 3
-        - data: []
-          ReagentId: Carbon
-          Quantity: 1
-        - data: []
-          ReagentId: Oxygen
-          Quantity: 2
-        - data: []
-          ReagentId: Charcoal
-          Quantity: 2
-        - data: []
-          ReagentId: Sulfur
-          Quantity: 2
-    - type: ContainedSolution
-      containerName: flare
-      container: 88
-  - uid: 104
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 103
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 103
-  - uid: 108
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 107
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 107
-  - uid: 111
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - Welder
-    - type: Transform
-      parent: 110
-    - type: Solution
-      solution:
-        maxVol: 100
-        name: Welder
-        reagents:
-        - data: []
-          ReagentId: WeldingFuel
-          Quantity: 100
-    - type: ContainedSolution
-      containerName: Welder
-      container: 110
-  - uid: 129
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 128
+      parent: 30
     - type: Solution
       solution:
         maxVol: 1
@@ -1265,15 +819,13 @@ entities:
           Quantity: 1
     - type: ContainedSolution
       containerName: food
-      container: 128
-  - uid: 131
-    mapInit: true
-    paused: true
+      container: 30
+  - uid: 33
     components:
     - type: MetaData
       name: solution - rod
     - type: Transform
-      parent: 130
+      parent: 32
     - type: Solution
       solution:
         maxVol: 5
@@ -1287,15 +839,13 @@ entities:
           Quantity: 0.5
     - type: ContainedSolution
       containerName: rod
-      container: 130
-  - uid: 134
-    mapInit: true
-    paused: true
+      container: 32
+  - uid: 36
     components:
     - type: MetaData
       name: solution - lvcable
     - type: Transform
-      parent: 133
+      parent: 35
     - type: Solution
       solution:
         maxVol: 5
@@ -1309,15 +859,13 @@ entities:
           Quantity: 2
     - type: ContainedSolution
       containerName: lvcable
-      container: 133
-  - uid: 140
-    mapInit: true
-    paused: true
+      container: 35
+  - uid: 42
     components:
     - type: MetaData
       name: solution - mvcable
     - type: Transform
-      parent: 139
+      parent: 41
     - type: Solution
       solution:
         maxVol: 5
@@ -1331,15 +879,13 @@ entities:
           Quantity: 2
     - type: ContainedSolution
       containerName: mvcable
-      container: 139
-  - uid: 142
-    mapInit: true
-    paused: true
+      container: 41
+  - uid: 44
     components:
     - type: MetaData
       name: solution - hvcable
     - type: Transform
-      parent: 141
+      parent: 43
     - type: Solution
       solution:
         maxVol: 6
@@ -1356,15 +902,13 @@ entities:
           Quantity: 1
     - type: ContainedSolution
       containerName: hvcable
-      container: 141
-  - uid: 144
-    mapInit: true
-    paused: true
+      container: 43
+  - uid: 46
     components:
     - type: MetaData
       name: solution - battery
     - type: Transform
-      parent: 143
+      parent: 45
     - type: Solution
       solution:
         maxVol: 5
@@ -1372,553 +916,80 @@ entities:
         reagents: []
     - type: ContainedSolution
       containerName: battery
-      container: 143
-  - uid: 149
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 148
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 148
-  - uid: 160
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 159
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 159
-  - uid: 171
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 170
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 170
-  - uid: 181
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - injector
-    - type: Transform
-      parent: 180
-    - type: Solution
-      solution:
-        maxVol: 15
-        name: injector
-        reagents:
-        - data: []
-          ReagentId: Bicaridine
-          Quantity: 15
-    - type: ContainedSolution
-      containerName: injector
-      container: 180
-  - uid: 184
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - Welder
-    - type: Transform
-      parent: 183
-    - type: Solution
-      solution:
-        maxVol: 100
-        name: Welder
-        reagents:
-        - data: []
-          ReagentId: WeldingFuel
-          Quantity: 100
-    - type: ContainedSolution
-      containerName: Welder
-      container: 183
-  - uid: 187
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 186
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 186
-  - uid: 191
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - food
-    - type: Transform
-      parent: 190
-    - type: Solution
-      solution:
-        maxVol: 10
-        name: food
-        reagents:
-        - data: []
-          ReagentId: Fiber
-          Quantity: 10
-    - type: ContainedSolution
-      containerName: food
-      container: 190
-  - uid: 193
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: solution - battery
-    - type: Transform
-      parent: 192
-    - type: Solution
-      solution:
-        maxVol: 5
-        name: battery
-        reagents: []
-    - type: ContainedSolution
-      containerName: battery
-      container: 192
+      container: 45
 - proto: ActionSleep
   entities:
-  - uid: 200
-    mapInit: true
-    paused: true
+  - uid: 55
     components:
     - type: Transform
-      parent: 199
+      parent: 54
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 199
-  - uid: 202
-    mapInit: true
-    paused: true
+      container: 54
+  - uid: 57
     components:
     - type: Transform
-      parent: 201
+      parent: 56
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 201
-  - uid: 204
-    mapInit: true
-    paused: true
+      container: 56
+  - uid: 59
     components:
     - type: Transform
-      parent: 203
+      parent: 58
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 203
-  - uid: 206
-    mapInit: true
-    paused: true
+      container: 58
+  - uid: 61
     components:
     - type: Transform
-      parent: 205
+      parent: 60
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 205
-- proto: ActionToggleJetpack
+      container: 60
+- proto: AirAlarmAutoLink
   entities:
-  - uid: 91
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 90
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 90
-  - uid: 93
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 92
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 92
-  - uid: 118
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 117
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 117
-  - uid: 120
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 119
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 119
-- proto: ActionToggleLight
-  entities:
-  - uid: 34
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 30
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 30
-  - uid: 35
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 30
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 30
-      attachedEntity: 30
-  - uid: 76
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 73
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 73
-  - uid: 77
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 73
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 73
-      attachedEntity: 73
-  - uid: 105
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 102
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 102
-  - uid: 106
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 102
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 102
-      attachedEntity: 102
-  - uid: 153
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 152
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 152
-  - uid: 154
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 152
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 152
-      attachedEntity: 152
-  - uid: 164
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 163
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 163
-  - uid: 165
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 163
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 163
-      attachedEntity: 163
-  - uid: 175
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 174
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 174
-  - uid: 176
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 174
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 174
-      attachedEntity: 174
-  - uid: 188
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 185
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 185
-  - uid: 189
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 185
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 185
-      attachedEntity: 185
-  - uid: 194
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 190
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 190
-  - uid: 195
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 190
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 190
-      attachedEntity: 190
-- proto: ActionToggleMagboots
-  entities:
-  - uid: 150
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 148
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 148
-      attachedEntity: 148
-  - uid: 161
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 159
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 159
-      attachedEntity: 159
-  - uid: 172
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 170
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 170
-      attachedEntity: 170
-- proto: ActionToggleSuitPiece
-  entities:
-  - uid: 155
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 151
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 151
-      entIcon: 152
-  - uid: 166
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 162
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 162
-      entIcon: 163
-  - uid: 177
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 173
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 173
-      entIcon: 174
-- proto: ActionVendingThrow
-  entities:
-  - uid: 208
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 207
-    - type: Action
-      originalIconColor: '#FFFFFFFF'
-      container: 207
-      attachedEntity: 207
-- proto: AirAlarm
-  entities:
-  - uid: 209
+  - uid: 63
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 517
-      - 503
-      - 380
-  - uid: 210
+  - uid: 64
     components:
     - type: Transform
-      pos: -5.5,2.5
+      pos: 3.5,2.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 390
-      - 388
-      - 386
-      - 514
-      - 504
-  - uid: 211
+  - uid: 65
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 378
-      - 516
-      - 505
-  - uid: 212
+  - uid: 66
     components:
     - type: Transform
-      pos: 3.5,2.5
+      pos: -5.5,2.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 382
-      - 384
-      - 509
-      - 520
-      - 386
-      - 388
-      - 390
-      - 378
-      - 506
-      - 380
-      - 515
-      - 521
-      - 510
-      - 376
-  - uid: 213
+  - uid: 67
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 519
-      - 507
-      - 518
-      - 384
-  - uid: 214
+  - uid: 68
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 523
-      - 512
-      - 524
-      - 382
-      - 513
-  - uid: 215
+  - uid: 69
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-    - type: DeviceList
-      devices:
-      - 511
-      - 522
-      - 376
 - proto: AirlockExternalGlass
   entities:
-  - uid: 216
+  - uid: 70
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1928,10 +999,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        217:
+        71:
         - - DoorStatus
           - DoorBolt
-  - uid: 217
+  - uid: 71
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1941,17 +1012,15 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        216:
+        70:
         - - DoorStatus
           - DoorBolt
-        367:
+        217:
         - - DoorStatus
           - InputA
 - proto: AirlockExternalGlassShuttleMining
   entities:
-  - uid: 218
-    mapInit: true
-    paused: true
+  - uid: 72
     components:
     - type: MetaData
       name: Mining Shuttle Dock
@@ -1965,7 +1034,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 219
+          - 73
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -1975,9 +1044,7 @@ entities:
       receiveFrequency: 1280
 - proto: AirlockMining
   entities:
-  - uid: 220
-    mapInit: true
-    paused: true
+  - uid: 74
     components:
     - type: MetaData
       name: Engineering
@@ -1990,7 +1057,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 221
+          - 75
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -1998,9 +1065,7 @@ entities:
     - type: DeviceNetwork
       address: 2586-5645
       receiveFrequency: 1280
-  - uid: 222
-    mapInit: true
-    paused: true
+  - uid: 76
     components:
     - type: MetaData
       name: Medbay
@@ -2013,7 +1078,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 223
+          - 77
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -2021,9 +1086,7 @@ entities:
     - type: DeviceNetwork
       address: 77AF-12B3
       receiveFrequency: 1280
-  - uid: 224
-    mapInit: true
-    paused: true
+  - uid: 78
     components:
     - type: MetaData
       name: Dorms
@@ -2036,7 +1099,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 225
+          - 79
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -2044,9 +1107,7 @@ entities:
     - type: DeviceNetwork
       address: 5C0A-7D31
       receiveFrequency: 1280
-  - uid: 226
-    mapInit: true
-    paused: true
+  - uid: 80
     components:
     - type: Transform
       pos: 4.5,0.5
@@ -2057,7 +1118,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 227
+          - 81
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -2067,9 +1128,7 @@ entities:
       receiveFrequency: 1280
 - proto: AirlockMiningLocked
   entities:
-  - uid: 228
-    mapInit: true
-    paused: true
+  - uid: 82
     components:
     - type: MetaData
       name: Supply Room
@@ -2082,7 +1141,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 229
+          - 83
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -2092,26 +1151,24 @@ entities:
       receiveFrequency: 1280
 - proto: APCBasic
   entities:
-  - uid: 230
-    mapInit: true
-    paused: true
+  - uid: 84
     components:
     - type: MetaData
       name: Hallway APC
     - type: Transform
       pos: -2.5,2.5
       parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
     - type: Battery
       lastCharge: 50000
-      lastUpdate: -81.6002792
     - type: PowerNetworkBattery
       loadingNetworkDemand: 940
       currentReceiving: 939.96185
       currentSupply: 940
       supplyRampPosition: 0.038146973
-  - uid: 231
-    mapInit: true
-    paused: true
+  - uid: 85
     components:
     - type: MetaData
       name: Dorms APC
@@ -2121,15 +1178,12 @@ entities:
       parent: 1
     - type: Battery
       lastCharge: 50000
-      lastUpdate: -81.6002792
     - type: PowerNetworkBattery
       loadingNetworkDemand: 210
       currentReceiving: 210.0002
       currentSupply: 210
       supplyRampPosition: -0.00019836426
-  - uid: 232
-    mapInit: true
-    paused: true
+  - uid: 86
     components:
     - type: MetaData
       name: Medbay APC
@@ -2139,15 +1193,12 @@ entities:
       parent: 1
     - type: Battery
       lastCharge: 50000
-      lastUpdate: -81.6002792
     - type: PowerNetworkBattery
       loadingNetworkDemand: 111
       currentReceiving: 110.97667
       currentSupply: 111
       supplyRampPosition: 0.023330688
-  - uid: 233
-    mapInit: true
-    paused: true
+  - uid: 87
     components:
     - type: MetaData
       name: Supply Room APC
@@ -2157,15 +1208,12 @@ entities:
       parent: 1
     - type: Battery
       lastCharge: 50000
-      lastUpdate: -81.6002792
     - type: PowerNetworkBattery
       loadingNetworkDemand: 175
       currentReceiving: 174.9611
       currentSupply: 175
       supplyRampPosition: 0.038879395
-  - uid: 234
-    mapInit: true
-    paused: true
+  - uid: 88
     components:
     - type: MetaData
       name: Engineering APC
@@ -2175,15 +1223,12 @@ entities:
       parent: 1
     - type: Battery
       lastCharge: 50000
-      lastUpdate: -81.6002792
     - type: PowerNetworkBattery
       loadingNetworkDemand: 1656
       currentReceiving: 1655.9781
       currentSupply: 1656
       supplyRampPosition: 0.021972656
-  - uid: 235
-    mapInit: true
-    paused: true
+  - uid: 89
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2191,50 +1236,13 @@ entities:
       parent: 1
     - type: Battery
       lastCharge: 50000
-      lastUpdate: -81.6002792
     - type: PowerNetworkBattery
       loadingNetworkDemand: 1640
       currentReceiving: 1640.0406
       currentSupply: 1640
-- proto: AppraisalTool
-  entities:
-  - uid: 94
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 3
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 121
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 3
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 236
-    mapInit: true
-    paused: true
+  - uid: 90
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2242,148 +1250,75 @@ entities:
       parent: 1
 - proto: Bed
   entities:
-  - uid: 199
-    mapInit: true
-    paused: true
+  - uid: 54
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
     - type: HealOnBuckle
-      sleepAction: 200
-      nextHealTime: -6051.3877489
+      sleepAction: 55
     - type: ActionsContainer
     - type: ContainerContainer
       containers:
         actions: !type:Container
           ents:
-          - 200
-  - uid: 201
-    mapInit: true
-    paused: true
+          - 55
+  - uid: 56
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
     - type: HealOnBuckle
-      sleepAction: 202
-      nextHealTime: -6051.3877489
+      sleepAction: 57
     - type: ActionsContainer
     - type: ContainerContainer
       containers:
         actions: !type:Container
           ents:
-          - 202
-  - uid: 203
-    mapInit: true
-    paused: true
+          - 57
+  - uid: 58
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
     - type: HealOnBuckle
-      sleepAction: 204
-      nextHealTime: -6051.3877489
+      sleepAction: 59
     - type: ActionsContainer
     - type: ContainerContainer
       containers:
         actions: !type:Container
           ents:
-          - 204
+          - 59
 - proto: BedsheetBlack
   entities:
-  - uid: 237
-    mapInit: true
-    paused: true
+  - uid: 91
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
 - proto: BedsheetGrey
   entities:
-  - uid: 238
-    mapInit: true
-    paused: true
+  - uid: 92
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
 - proto: BedsheetWhite
   entities:
-  - uid: 239
-    mapInit: true
-    paused: true
+  - uid: 93
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-- proto: Bloodpack
-  entities:
-  - uid: 65
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
-  - uid: 66
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
-  - uid: 67
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
-  - uid: 68
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
 - proto: BodyBag
   entities:
-  - uid: 240
-    mapInit: true
-    paused: true
+  - uid: 94
     components:
     - type: Transform
       pos: 7.4469547,-4.492324
@@ -2397,9 +1332,7 @@ entities:
       open: True
 - proto: BodyBagFolded
   entities:
-  - uid: 241
-    mapInit: true
-    paused: true
+  - uid: 95
     components:
     - type: Transform
       pos: 4.696921,-4.2438545
@@ -2415,8 +1348,6 @@ entities:
 - proto: BorgCharger
   entities:
   - uid: 2
-    mapInit: true
-    paused: true
     components:
     - type: Transform
       pos: 4.5,3.5
@@ -2449,185 +1380,42 @@ entities:
 - proto: BorgChargerCircuitboard
   entities:
   - uid: 5
-    mapInit: true
-    paused: true
     components:
     - type: Transform
       parent: 2
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
 - proto: BoxLatexGloves
   entities:
-  - uid: 7
-    mapInit: true
-    paused: true
+  - uid: 8
     components:
     - type: Transform
-      pos: 4.071921,-4.337702
+      pos: 4.05182,-4.204806
       parent: 1
-    - type: Storage
-      storedItems:
-        8:
-          position: 0,0
-          _rotation: South
-        10:
-          position: 1,0
-          _rotation: South
-        12:
-          position: 2,0
-          _rotation: South
-        14:
-          position: 0,2
-          _rotation: East
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 8
-          - 10
-          - 12
-          - 14
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
 - proto: BoxMRE
   entities:
-  - uid: 16
-    mapInit: true
-    paused: true
+  - uid: 503
     components:
     - type: Transform
-      pos: -2.5376823,-2.2962513
+      pos: -2.4599435,-2.2426603
       parent: 1
-    - type: Storage
-      storedItems:
-        17:
-          position: 0,0
-          _rotation: South
-        22:
-          position: 1,0
-          _rotation: South
-        21:
-          position: 2,0
-          _rotation: South
-        19:
-          position: 2,1
-          _rotation: South
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 17
-          - 22
-          - 21
-          - 19
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
 - proto: BoxSterileMask
   entities:
-  - uid: 242
-    mapInit: true
-    paused: true
+  - uid: 506
     components:
     - type: Transform
-      pos: 3.4156709,-4.337702
+      pos: 3.4111948,-4.2517295
       parent: 1
-    - type: Storage
-      storedItems:
-        243:
-          position: 0,0
-          _rotation: South
-        244:
-          position: 1,0
-          _rotation: South
-        245:
-          position: 2,0
-          _rotation: South
-        246:
-          position: 0,1
-          _rotation: South
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 243
-          - 244
-          - 245
-          - 246
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
-- proto: Brutepack
-  entities:
-  - uid: 69
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
 - proto: BurnAutoInjector
   entities:
-  - uid: 23
-    mapInit: true
-    paused: true
+  - uid: 52
     components:
     - type: Transform
-      pos: 7.488419,-3.2650843
+      pos: 7.4981174,-3.2380114
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - pen
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@pen: !type:ContainerSlot
-          ent: 24
 - proto: ButtonFrameCaution
   entities:
-  - uid: 769
+  - uid: 97
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2635,431 +1423,309 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 247
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 1
-  - uid: 248
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -5.5,0.5
-      parent: 1
-  - uid: 249
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 250
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 251
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 252
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 253
-    mapInit: true
-    paused: true
+  - uid: 226
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 254
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 255
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 256
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 257
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 258
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 259
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 260
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 261
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 262
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 263
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 264
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 1
-  - uid: 265
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 266
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-  - uid: 267
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 5.5,4.5
-      parent: 1
-  - uid: 268
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 6.5,4.5
-      parent: 1
-  - uid: 269
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 1
-  - uid: 270
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 1
-  - uid: 271
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -4.5,4.5
-      parent: 1
-  - uid: 272
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -5.5,4.5
-      parent: 1
-  - uid: 273
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -3.5,4.5
-      parent: 1
-  - uid: 274
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 1
-  - uid: 275
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 276
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 277
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 1
-  - uid: 278
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 279
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 280
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 281
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-  - uid: 282
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 283
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
-  - uid: 284
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 1
-  - uid: 285
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 1
-  - uid: 286
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -4.5,-3.5
-      parent: 1
-  - uid: 287
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 288
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 289
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
-  - uid: 290
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 4.5,-3.5
-      parent: 1
-  - uid: 291
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 5.5,-3.5
-      parent: 1
-  - uid: 292
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 293
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 294
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 295
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 296
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 297
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 298
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 7.5,4.5
-      parent: 1
-  - uid: 299
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 300
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 301
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 302
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 10.5,0.5
-      parent: 1
-  - uid: 303
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 10.5,-0.5
-      parent: 1
-  - uid: 304
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 11.5,-0.5
-      parent: 1
-  - uid: 305
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 12.5,-0.5
-      parent: 1
-  - uid: 306
-    mapInit: true
-    paused: true
+  - uid: 227
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
 - proto: CableApcStack1
   entities:
   - uid: 3
-    mapInit: true
-    paused: true
     components:
     - type: Transform
       parent: 2
@@ -3069,500 +1735,368 @@ entities:
       solutions: null
       containers:
       - lvcable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@lvcable: !type:ContainerSlot
           ent: 4
-  - uid: 55
-    mapInit: true
-    paused: true
+  - uid: 22
     components:
     - type: Transform
-      parent: 52
+      parent: 19
     - type: Stack
       count: 2
     - type: SolutionContainerManager
       solutions: null
       containers:
       - lvcable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@lvcable: !type:ContainerSlot
-          ent: 56
-  - uid: 133
-    mapInit: true
-    paused: true
+          ent: 23
+  - uid: 35
     components:
     - type: Transform
-      parent: 132
+      parent: 34
     - type: Stack
       count: 5
     - type: SolutionContainerManager
       solutions: null
       containers:
       - lvcable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@lvcable: !type:ContainerSlot
-          ent: 134
+          ent: 36
 - proto: CableHV
   entities:
-  - uid: 307
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 7.5,3.5
-      parent: 1
-  - uid: 308
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 8.5,3.5
-      parent: 1
-  - uid: 309
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 8.5,4.5
-      parent: 1
-  - uid: 310
-    mapInit: true
-    paused: true
+  - uid: 181
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-- proto: CableHVStack1
-  entities:
-  - uid: 141
-    mapInit: true
-    paused: true
+  - uid: 184
     components:
     - type: Transform
-      parent: 138
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: CableHVStack1
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      parent: 40
     - type: Stack
       count: 5
     - type: SolutionContainerManager
       solutions: null
       containers:
       - hvcable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@hvcable: !type:ContainerSlot
-          ent: 142
+          ent: 44
 - proto: CableMV
   entities:
-  - uid: 311
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 312
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 313
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 314
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 315
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 316
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 317
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 318
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 319
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 1
-  - uid: 320
-    mapInit: true
-    paused: true
+  - uid: 98
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 321
-    mapInit: true
-    paused: true
+  - uid: 99
     components:
     - type: Transform
-      pos: 0.5,5.5
+      pos: -0.5,0.5
       parent: 1
-  - uid: 322
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 1
-  - uid: 323
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 324
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 325
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 326
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 327
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-  - uid: 328
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 329
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 330
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 331
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 332
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 333
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 334
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 335
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 336
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 337
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 7.5,3.5
-      parent: 1
-  - uid: 338
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 6.5,3.5
-      parent: 1
-  - uid: 339
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 1
-  - uid: 340
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 1
-  - uid: 341
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 342
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 343
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 1
-  - uid: 344
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 345
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 346
-    mapInit: true
-    paused: true
+  - uid: 100
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 347
-    mapInit: true
-    paused: true
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 112
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 348
-    mapInit: true
-    paused: true
+  - uid: 113
     components:
     - type: Transform
-      pos: 6.5,-1.5
+      pos: -1.5,-4.5
       parent: 1
-  - uid: 349
-    mapInit: true
-    paused: true
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 130
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-- proto: CableMVStack1
-  entities:
-  - uid: 139
-    mapInit: true
-    paused: true
+  - uid: 131
     components:
     - type: Transform
-      parent: 138
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+- proto: CableMVStack1
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      parent: 40
     - type: Stack
       count: 5
     - type: SolutionContainerManager
       solutions: null
       containers:
       - mvcable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@mvcable: !type:ContainerSlot
-          ent: 140
+          ent: 42
 - proto: CapacitorStockPart
   entities:
   - uid: 6
-    mapInit: true
-    paused: true
     components:
     - type: Transform
       parent: 2
     - type: Stack
       count: 2
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-  - uid: 135
-    mapInit: true
-    paused: true
+  - uid: 37
     components:
     - type: Transform
-      parent: 132
+      parent: 34
     - type: Stack
       count: 2
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-  - uid: 145
-    mapInit: true
-    paused: true
+  - uid: 47
     components:
     - type: Transform
-      parent: 138
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 40
     - type: Physics
       canCollide: False
 - proto: Catwalk
   entities:
-  - uid: 350
-    mapInit: true
-    paused: true
+  - uid: 201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 351
-    mapInit: true
-    paused: true
+  - uid: 202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 352
-    mapInit: true
-    paused: true
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,4.5
       parent: 1
-  - uid: 353
-    mapInit: true
-    paused: true
+  - uid: 204
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,3.5
       parent: 1
-  - uid: 354
-    mapInit: true
-    paused: true
+  - uid: 205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,5.5
       parent: 1
-  - uid: 355
-    mapInit: true
-    paused: true
+  - uid: 206
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,5.5
       parent: 1
-  - uid: 356
-    mapInit: true
-    paused: true
+  - uid: 207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 1
-  - uid: 357
-    mapInit: true
-    paused: true
+  - uid: 208
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3570,107 +2104,33 @@ entities:
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 358
-    mapInit: true
-    paused: true
+  - uid: 209
     components:
     - type: Transform
       pos: 0.46296036,-5.44565
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-  - uid: 359
-    mapInit: true
-    paused: true
+  - uid: 210
     components:
     - type: Transform
       pos: 1.5158348,-5.406741
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
 - proto: ChairWood
   entities:
-  - uid: 360
-    mapInit: true
-    paused: true
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.0518155,-3.4772594
       parent: 1
-  - uid: 361
-    mapInit: true
-    paused: true
+  - uid: 212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.0674405,-3.4303844
       parent: 1
-- proto: ChemistryBottleBicaridine
-  entities:
-  - uid: 61
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: bottle (bicaridine)
-    - type: Transform
-      parent: 60
-    - type: Label
-      currentLabel: bicaridine
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - drink
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: NameModifier
-      baseName: bottle
-    - type: ContainerContainer
-      containers:
-        solution@drink: !type:ContainerSlot
-          ent: 62
-    - type: InsideEntityStorage
-      storage: 60
-- proto: ChemistryBottleSaline
-  entities:
-  - uid: 63
-    mapInit: true
-    paused: true
-    components:
-    - type: MetaData
-      name: bottle (saline)
-    - type: Transform
-      parent: 60
-    - type: Label
-      currentLabel: saline
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - drink
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: NameModifier
-      baseName: bottle
-    - type: ContainerContainer
-      containers:
-        solution@drink: !type:ContainerSlot
-          ent: 64
-    - type: InsideEntityStorage
-      storage: 60
 - proto: CigaretteSpent
   entities:
-  - uid: 25
-    mapInit: true
-    paused: true
+  - uid: 10
     components:
     - type: Transform
       pos: -0.09953964,-5.4144
@@ -3679,17 +2139,13 @@ entities:
       solutions: null
       containers:
       - smokable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@smokable: !type:ContainerSlot
-          ent: 26
-  - uid: 27
-    mapInit: true
-    paused: true
+          ent: 11
+  - uid: 12
     components:
     - type: Transform
       pos: -0.25578964,-5.555025
@@ -3698,767 +2154,29 @@ entities:
       solutions: null
       containers:
       - smokable
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@smokable: !type:ContainerSlot
-          ent: 28
+          ent: 13
 - proto: ClosetFireFilled
   entities:
-  - uid: 29
-    mapInit: true
-    paused: true
+  - uid: 14
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 39
-          - 30
-          - 38
-          - 41
-          - 40
-          - 36
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-- proto: ClothingBeltUtilityFilled
-  entities:
-  - uid: 80
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: Storage
-      storedItems:
-        83:
-          position: 0,0
-          _rotation: South
-        84:
-          position: 1,0
-          _rotation: South
-        86:
-          position: 2,0
-          _rotation: South
-        87:
-          position: 3,0
-          _rotation: South
-        81:
-          position: 4,0
-          _rotation: South
-        85:
-          position: 5,0
-          _rotation: South
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 83
-          - 84
-          - 86
-          - 87
-          - 81
-          - 85
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
-  - uid: 109
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: Storage
-      storedItems:
-        112:
-          position: 0,0
-          _rotation: South
-        116:
-          position: 1,0
-          _rotation: South
-        114:
-          position: 2,0
-          _rotation: South
-        115:
-          position: 3,0
-          _rotation: South
-        110:
-          position: 4,0
-          _rotation: South
-        113:
-          position: 5,0
-          _rotation: South
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 112
-          - 116
-          - 114
-          - 115
-          - 110
-          - 113
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
-- proto: ClothingHandsGlovesLatex
-  entities:
-  - uid: 8
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 7
-    - type: Fiber
-      fiberprint: 22F59467C4217A
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 9
-  - uid: 10
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 7
-    - type: Fiber
-      fiberprint: 3BA649EE59DBB4
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 11
-  - uid: 12
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 7
-    - type: Fiber
-      fiberprint: C6167B307642B4
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 13
-  - uid: 14
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 7
-    - type: Fiber
-      fiberprint: 369326F409E540
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 15
-- proto: ClothingHeadHatHardhatBlue
-  entities:
-  - uid: 190
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 182
-    - type: HandheldLight
-      selfToggleActionEntity: 195
-      toggleActionEntity: 194
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 192
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 194
-          - 195
-        solution@food: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 191
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: Actions
-      actions:
-      - 195
-- proto: ClothingHeadHelmetFire
-  entities:
-  - uid: 30
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 29
-    - type: HandheldLight
-      selfToggleActionEntity: 35
-      toggleActionEntity: 34
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 32
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 34
-          - 35
-        solution@food: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 31
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: Actions
-      actions:
-      - 35
-- proto: ClothingHeadHelmetHardsuitSpatio
-  entities:
-  - uid: 152
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 151
-    - type: HandheldLight
-      selfToggleActionEntity: 154
-      toggleActionEntity: 153
-    - type: Battery
-      lastCharge: 599.9465
-    - type: BatterySelfRecharger
-      nextAutoRecharge: null
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 153
-          - 154
-    - type: Actions
-      actions:
-      - 154
-    - type: AttachedClothing
-      attachedUid: 151
-  - uid: 163
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 162
-    - type: HandheldLight
-      selfToggleActionEntity: 165
-      toggleActionEntity: 164
-    - type: Battery
-      lastCharge: 599.9465
-    - type: BatterySelfRecharger
-      nextAutoRecharge: null
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 164
-          - 165
-    - type: Actions
-      actions:
-      - 165
-    - type: AttachedClothing
-      attachedUid: 162
-  - uid: 174
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 173
-    - type: HandheldLight
-      selfToggleActionEntity: 176
-      toggleActionEntity: 175
-    - type: Battery
-      lastCharge: 599.9465
-    - type: BatterySelfRecharger
-      nextAutoRecharge: null
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 175
-          - 176
-    - type: Actions
-      actions:
-      - 176
-    - type: AttachedClothing
-      attachedUid: 173
-- proto: ClothingMaskGas
-  entities:
-  - uid: 38
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 29
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: ClothingMaskGasExplorer
-  entities:
-  - uid: 156
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 147
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 167
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 158
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 178
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 169
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: ClothingMaskSterile
-  entities:
-  - uid: 243
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 242
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 244
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 242
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 245
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 242
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 246
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 242
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: ClothingOuterHardsuitSpatio
-  entities:
-  - uid: 151
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 147
-    - type: ToggleableClothing
-      clothingUid: 152
-      actionEntity: 155
-    - type: ContainerContainer
-      containers:
-        toggleable-clothing: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 152
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 155
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-  - uid: 162
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 158
-    - type: ToggleableClothing
-      clothingUid: 163
-      actionEntity: 166
-    - type: ContainerContainer
-      containers:
-        toggleable-clothing: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 163
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 166
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-  - uid: 173
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 169
-    - type: ToggleableClothing
-      clothingUid: 174
-      actionEntity: 177
-    - type: ContainerContainer
-      containers:
-        toggleable-clothing: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 174
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 177
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-- proto: ClothingOuterSuitFire
-  entities:
-  - uid: 39
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 29
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: ClothingShoesBootsMag
-  entities:
-  - uid: 148
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 147
-    - type: ToggleClothing
-      actionEntity: 150
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 150
-        solution@food: !type:ContainerSlot
-          ent: 149
-    - type: Actions
-      actions:
-      - 150
-  - uid: 159
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 158
-    - type: ToggleClothing
-      actionEntity: 161
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 161
-        solution@food: !type:ContainerSlot
-          ent: 160
-    - type: Actions
-      actions:
-      - 161
-  - uid: 170
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 169
-    - type: ToggleClothing
-      actionEntity: 172
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 172
-        solution@food: !type:ContainerSlot
-          ent: 171
-    - type: Actions
-      actions:
-      - 172
-- proto: ClothingShoesBootsWinterMiner
-  entities:
-  - uid: 78
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 79
-  - uid: 107
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 108
 - proto: ComputerShuttleMining
   entities:
-  - uid: 362
-    mapInit: true
-    paused: true
+  - uid: 213
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-    - type: PointLight
-      enabled: True
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 363
 - proto: CrateSecure
   entities:
-  - uid: 364
+  - uid: 214
     components:
     - type: Transform
       pos: 9.5,-2.5
@@ -4469,6204 +2187,1227 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 366
-          - 367
-          - 368
+          - 216
+          - 217
+          - 215
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 365
-- proto: Crowbar
-  entities:
-  - uid: 83
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 80
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 112
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 109
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: CrowbarOrange
-  entities:
-  - uid: 196
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 182
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: CrowbarRed
-  entities:
-  - uid: 40
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 29
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: Defibrillator
-  entities:
-  - uid: 43
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 42
-    - type: PowerCellDraw
-      enabled: False
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 44
-    - type: InsideCharger
+          ent: 218
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 42
-    mapInit: true
-    paused: true
+  - uid: 15
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        ItemCabinet: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 43
 - proto: DoorElectronics
   entities:
-  - uid: 221
-    mapInit: true
-    paused: true
+  - uid: 75
     components:
     - type: Transform
-      parent: 220
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 74
     - type: Physics
       canCollide: False
-  - uid: 223
-    mapInit: true
-    paused: true
+  - uid: 77
     components:
     - type: Transform
-      parent: 222
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 76
     - type: Physics
       canCollide: False
-  - uid: 225
-    mapInit: true
-    paused: true
+  - uid: 79
     components:
     - type: Transform
-      parent: 224
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 78
+    - type: AccessReader
+      accessListsOriginal: []
     - type: Physics
       canCollide: False
-  - uid: 227
-    mapInit: true
-    paused: true
+  - uid: 81
     components:
     - type: Transform
-      parent: 226
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 80
     - type: Physics
       canCollide: False
-  - uid: 370
-    mapInit: true
-    paused: true
+  - uid: 220
     components:
     - type: Transform
-      parent: 369
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 219
     - type: Physics
       canCollide: False
-  - uid: 372
-    mapInit: true
-    paused: true
+  - uid: 222
     components:
     - type: Transform
-      parent: 371
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 221
     - type: Physics
       canCollide: False
 - proto: DoorElectronicsExternal
   entities:
-  - uid: 219
-    mapInit: true
-    paused: true
+  - uid: 73
     components:
     - type: Transform
-      parent: 218
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 72
     - type: Physics
       canCollide: False
 - proto: DoorElectronicsSalvage
   entities:
-  - uid: 229
-    mapInit: true
-    paused: true
+  - uid: 83
     components:
     - type: Transform
-      parent: 228
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 82
     - type: Physics
       canCollide: False
 - proto: DrinkBeerBottleFull
   entities:
-  - uid: 46
-    mapInit: true
-    paused: true
+  - uid: 18
     components:
-    - type: MetaData
-      name: beer bottle (beer)
     - type: Transform
       rot: 0.0004646051675081253 rad
       pos: -3.2899663,-2.2630794
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - drink
-    - type: Label
-      currentLabel: beer
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.73724115
-    - type: NameModifier
-      baseName: beer bottle
-    - type: ContainerContainer
-      containers:
-        solution@drink: !type:ContainerSlot
-          ent: 47
-  - uid: 48
-    mapInit: true
-    paused: true
+  - uid: 110
     components:
-    - type: MetaData
-      name: beer bottle (beer)
     - type: Transform
       pos: -3.6018643,-2.2650013
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - drink
-    - type: Label
-      currentLabel: beer
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.104903206
-    - type: NameModifier
-      baseName: beer bottle
-    - type: ContainerContainer
-      containers:
-        solution@drink: !type:ContainerSlot
-          ent: 49
 - proto: DrinkBottleBeer
   entities:
-  - uid: 50
-    mapInit: true
-    paused: true
+  - uid: 102
     components:
-    - type: MetaData
-      name: beer bottle (beer)
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.1643643,-2.6087513
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - drink
-    - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.040080175
-    - type: Label
-      currentLabel: beer
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: NameModifier
-      baseName: beer bottle
-    - type: ContainerContainer
-      containers:
-        solution@drink: !type:ContainerSlot
-          ent: 51
-- proto: DrinkMREFlask
-  entities:
-  - uid: 17
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 16
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - drink
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.3561985
-    - type: ContainerContainer
-      containers:
-        solution@drink: !type:ContainerSlot
-          ent: 18
 - proto: EdgeDetector
   entities:
-  - uid: 368
+  - uid: 215
     components:
     - type: Transform
-      parent: 364
+      parent: 214
     - type: Physics
       canCollide: False
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        631:
+        397:
         - - OutputHigh
           - Open
         - - OutputLow
           - Close
     - type: InsideEntityStorage
-      storage: 364
+      storage: 214
 - proto: EmergencyLight
   entities:
-  - uid: 373
-    mapInit: true
-    paused: true
+  - uid: 223
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-    - type: Battery
-      lastUpdate: -81.6002792
-  - uid: 374
-    mapInit: true
-    paused: true
+  - uid: 224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 1
-    - type: Battery
-      lastUpdate: -81.6002792
-- proto: EmergencyOxygenTankFilled
-  entities:
-  - uid: 41
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 29
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: EncryptionKeyCargo
   entities:
-  - uid: 57
-    mapInit: true
-    paused: true
+  - uid: 24
     components:
     - type: Transform
-      parent: 52
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 19
     - type: Physics
       canCollide: False
 - proto: EncryptionKeyCommon
   entities:
-  - uid: 58
-    mapInit: true
-    paused: true
+  - uid: 25
     components:
     - type: Transform
-      parent: 52
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 19
     - type: Physics
       canCollide: False
 - proto: FaxMachineBase
   entities:
-  - uid: 375
+  - uid: 225
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-    - type: FaxMachine
-      name: Mining Base
-- proto: FireExtinguisher
-  entities:
-  - uid: 36
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 29
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - spray
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@spray: !type:ContainerSlot
-          ent: 37
-- proto: FirelockElectronics
-  entities:
-  - uid: 377
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 376
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 379
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 378
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 381
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 380
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 383
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 382
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 385
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 384
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 387
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 386
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 389
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 388
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 391
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 390
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: FirelockGlass
   entities:
-  - uid: 376
-    mapInit: true
-    paused: true
+  - uid: 279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 377
-    - type: DeviceNetwork
-      deviceLists:
-      - 215
-      - 212
-      address: 04FD-7AC7
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 378
-    mapInit: true
-    paused: true
+  - uid: 280
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 379
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      - 211
-      address: 5CE0-7EFD
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 380
-    mapInit: true
-    paused: true
+  - uid: 281
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 381
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      - 209
-      address: 0766-351F
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 382
-    mapInit: true
-    paused: true
+  - uid: 282
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 383
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      - 214
-      address: 2BF8-6D2C
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 384
-    mapInit: true
-    paused: true
+  - uid: 283
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 385
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      - 213
-      address: 4FCC-2CD6
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 386
-    mapInit: true
-    paused: true
+  - uid: 284
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 387
-    - type: DeviceNetwork
-      deviceLists:
-      - 210
-      - 212
-      address: 443C-7EDD
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 388
-    mapInit: true
-    paused: true
+  - uid: 285
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 389
-    - type: DeviceNetwork
-      deviceLists:
-      - 210
-      - 212
-      address: 0B74-34EA
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-  - uid: 390
-    mapInit: true
-    paused: true
+  - uid: 286
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 391
-    - type: DeviceNetwork
-      deviceLists:
-      - 210
-      - 212
-      address: 7975-34CD
-      receiveFrequency: 1621
-    - type: Firelock
-      powered: True
-- proto: Flare
-  entities:
-  - uid: 88
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - flare
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@flare: !type:ContainerSlot
-          ent: 89
-- proto: FlashlightLantern
-  entities:
-  - uid: 73
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: HandheldLight
-      selfToggleActionEntity: 77
-      toggleActionEntity: 76
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 74
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 76
-          - 77
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: Actions
-      actions:
-      - 77
-  - uid: 102
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: HandheldLight
-      selfToggleActionEntity: 106
-      toggleActionEntity: 105
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 103
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 105
-          - 106
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: Actions
-      actions:
-      - 106
-- proto: FlashlightLanternPurple
-  entities:
-  - uid: 185
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 182
-    - type: HandheldLight
-      selfToggleActionEntity: 189
-      toggleActionEntity: 188
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 186
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 188
-          - 189
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: Actions
-      actions:
-      - 189
 - proto: FloorLavaEntity
   entities:
-  - uid: 392
-    mapInit: true
-    paused: true
+  - uid: 234
     components:
     - type: Transform
       pos: 12.5,5.5
       parent: 1
-  - uid: 393
-    mapInit: true
-    paused: true
+  - uid: 235
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 394
-    mapInit: true
-    paused: true
+  - uid: 236
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 1
-  - uid: 395
-    mapInit: true
-    paused: true
+  - uid: 237
     components:
     - type: Transform
       pos: 11.5,5.5
       parent: 1
-  - uid: 396
-    mapInit: true
-    paused: true
+  - uid: 238
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 397
-    mapInit: true
-    paused: true
+  - uid: 239
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
 - proto: FoodPSB
   entities:
-  - uid: 398
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -4.5806994,-2.5397594
-      parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 399
-    mapInit: true
-    paused: true
+  - uid: 16
     components:
     - type: Transform
       pos: -4.5650744,-2.2741344
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: FoodSnackMREBrownie
-  entities:
-  - uid: 21
-    mapInit: true
-    paused: true
+  - uid: 17
     components:
     - type: Transform
-      parent: 16
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: FoodSnackNutribrick
-  entities:
-  - uid: 22
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 16
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: FoodTinMRE
-  entities:
-  - uid: 19
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 16
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 20
+      pos: -4.5806994,-2.5397594
+      parent: 1
 - proto: GasMixer
   entities:
-  - uid: 400
-    mapInit: true
-    paused: true
+  - uid: 242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: GasMixer
       inletTwoConcentration: 0.75
       inletOneConcentration: 0.25
       targetPressure: 4500
 - proto: GasOutletInjector
   entities:
-  - uid: 401
-    mapInit: true
-    paused: true
+  - uid: 243
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPassiveVent
   entities:
-  - uid: 402
-    mapInit: true
-    paused: true
+  - uid: 244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-0.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 403
-    mapInit: true
-    paused: true
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,1.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 404
-    mapInit: true
-    paused: true
+  - uid: 246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,5.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 405
-    mapInit: true
-    paused: true
+  - uid: 247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,3.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 406
-    mapInit: true
-    paused: true
+  - uid: 248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 407
-    mapInit: true
-    paused: true
+  - uid: 249
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,0.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 408
-    mapInit: true
-    paused: true
+  - uid: 250
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 409
-    mapInit: true
-    paused: true
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 410
-    mapInit: true
-    paused: true
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 411
-    mapInit: true
-    paused: true
+  - uid: 254
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,1.5
+      pos: 6.5,-2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 412
-    mapInit: true
-    paused: true
+  - uid: 255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 413
-    mapInit: true
-    paused: true
+  - uid: 272
     components:
     - type: Transform
-      pos: 6.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: 11.5,1.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 414
-    mapInit: true
-    paused: true
+  - uid: 256
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 415
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 416
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 417
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 418
-    mapInit: true
-    paused: true
+  - uid: 260
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 419
-    mapInit: true
-    paused: true
+  - uid: 261
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 420
-    mapInit: true
-    paused: true
+  - uid: 257
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,0.5
+      pos: 1.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 421
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 422
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 423
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 424
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 425
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 426
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 427
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 428
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 429
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 430
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 431
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 432
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,4.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 433
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,4.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 434
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,4.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 435
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 436
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,1.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 437
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 438
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 439
-    mapInit: true
-    paused: true
+  - uid: 258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 440
-    mapInit: true
-    paused: true
+  - uid: 262
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 441
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 442
-    mapInit: true
-    paused: true
+  - uid: 418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,3.5
+      pos: 0.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 443
-    mapInit: true
-    paused: true
+  - uid: 419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,3.5
+      pos: 12.5,0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 444
-    mapInit: true
-    paused: true
+  - uid: 420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 445
-    mapInit: true
-    paused: true
+  - uid: 421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
+      pos: -3.5,3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 446
-    mapInit: true
-    paused: true
+  - uid: 422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
+      pos: -0.5,3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 447
-    mapInit: true
-    paused: true
+      color: '#990000FF'
+  - uid: 423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,4.5
+      pos: 2.5,4.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 448
-    mapInit: true
-    paused: true
+  - uid: 424
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,4.5
+      pos: 1.5,4.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 449
-    mapInit: true
-    paused: true
+  - uid: 425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,4.5
+      pos: 5.5,4.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+  - uid: 426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 450
-    mapInit: true
-    paused: true
+  - uid: 427
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,5.5
+      pos: 0.5,-2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 451
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,6.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 452
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 453
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 454
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 455
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-4.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 456
-    mapInit: true
-    paused: true
+  - uid: 428
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-3.5
+      pos: 0.5,-1.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 457
-    mapInit: true
-    paused: true
+  - uid: 429
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-3.5
+      pos: 0.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 458
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 459
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 460
-    mapInit: true
-    paused: true
+  - uid: 430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 461
-    mapInit: true
-    paused: true
+  - uid: 431
     components:
     - type: Transform
-      pos: 0.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 462
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 463
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 464
-    mapInit: true
-    paused: true
+  - uid: 432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 465
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 466
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 467
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 468
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 469
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 470
-    mapInit: true
-    paused: true
+      color: '#0055CCFF'
+  - uid: 433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-2.5
+      pos: -0.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 471
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 472
-    mapInit: true
-    paused: true
+      color: '#0055CCFF'
+  - uid: 435
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
+      pos: -1.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 473
-    mapInit: true
-    paused: true
+      color: '#0055CCFF'
+  - uid: 436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
+      pos: -2.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 439
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 440
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 474
-    mapInit: true
-    paused: true
+  - uid: 441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,0.5
+      pos: -3.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 475
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 476
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 477
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 478
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 479
-    mapInit: true
-    paused: true
+  - uid: 442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-0.5
+      pos: -2.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 480
-    mapInit: true
-    paused: true
+  - uid: 443
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 481
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 482
-    mapInit: true
-    paused: true
+  - uid: 444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-0.5
+      pos: -1.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 483
-    mapInit: true
-    paused: true
+  - uid: 445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-4.5
+      pos: -0.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 484
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 485
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 486
-    mapInit: true
-    paused: true
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 448
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 449
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 451
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 452
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 456
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 458
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 462
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 463
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 464
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 466
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 467
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 473
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 474
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 475
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 476
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 477
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 481
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 483
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 487
-    mapInit: true
-    paused: true
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 488
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 489
-    mapInit: true
-    paused: true
+  - uid: 265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 490
-    mapInit: true
-    paused: true
+  - uid: 266
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 491
-    mapInit: true
-    paused: true
+  - uid: 267
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 492
-    mapInit: true
-    paused: true
+  - uid: 268
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 493
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,0.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 494
-    mapInit: true
-    paused: true
+  - uid: 269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 495
-    mapInit: true
-    paused: true
+  - uid: 270
     components:
     - type: Transform
-      pos: 3.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: 11.5,0.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 496
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 497
-    mapInit: true
-    paused: true
+  - uid: 273
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 480
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 498
-    mapInit: true
-    paused: true
+  - uid: 274
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 499
-    mapInit: true
-    paused: true
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
 - proto: GasPressurePump
   entities:
-  - uid: 500
-    mapInit: true
-    paused: true
+  - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: GasPressurePump
       targetPressure: 200
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 501
-    mapInit: true
-    paused: true
+  - uid: 277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: GasPressurePump
       targetPressure: 4500
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 502
-    mapInit: true
-    paused: true
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: GasPressurePump
       targetPressure: 4500
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentPump
   entities:
-  - uid: 503
-    mapInit: true
-    paused: true
+  - uid: 290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 209
-      address: VNT-7C6F-D201
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-1543-FA39
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 504
-    mapInit: true
-    paused: true
+  - uid: 291
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 210
-      address: VNT-4453-3379
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-6854-6C99
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 505
-    mapInit: true
-    paused: true
+  - uid: 292
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 211
-      address: VNT-6CF6-DD42
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5FC4-03C5
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 506
-    mapInit: true
-    paused: true
+  - uid: 293
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      address: VNT-6F9E-3534
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5C4B-AD68
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 507
-    mapInit: true
-    paused: true
+  - uid: 294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 213
-      address: VNT-5372-5173
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-7BDF-C6C3
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 508
-    mapInit: true
-    paused: true
+  - uid: 295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-    - type: DeviceNetwork
-      address: VNT-02BF-2D47
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-7BDF-C6C3
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 509
-    mapInit: true
-    paused: true
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      address: VNT-3F57-0F6B
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5C4B-AD68
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 510
-    mapInit: true
-    paused: true
+  - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-0.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      address: VNT-01F7-A8C3
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5C4B-AD68
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 511
-    mapInit: true
-    paused: true
+  - uid: 298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 215
-      address: VNT-42C8-155E
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-1C53-8E40
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 512
-    mapInit: true
-    paused: true
+  - uid: 299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 214
-      address: VNT-4EC5-A165
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-03D5-60D7
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 513
-    mapInit: true
-    paused: true
+  - uid: 300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 214
-      address: VNT-7BA4-0115
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 514
-    mapInit: true
-    paused: true
+  - uid: 7
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 210
-      address: SCR-4E38-24CD
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-6854-6C99
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 515
-    mapInit: true
-    paused: true
+  - uid: 96
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      address: SCR-791D-D15A
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5C4B-AD68
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 516
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,3.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 211
-      address: SCR-16EE-6053
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5FC4-03C5
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 517
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,3.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 209
-      address: SCR-30DB-6F67
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-1543-FA39
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 518
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-3.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 213
-      address: SCR-2884-CD93
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-7BDF-C6C3
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 519
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-3.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 213
-      address: SCR-69CE-9968
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-7BDF-C6C3
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 520
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-4.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      address: SCR-2E1C-9AB7
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5C4B-AD68
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 521
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 212
-      address: SCR-45BE-F182
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-5C4B-AD68
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 522
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 215
-      address: SCR-3379-8819
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-1C53-8E40
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 523
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 214
-      address: SCR-41ED-ADF4
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      registeredDevices:
-      - AIR-03D5-60D7
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 524
-    mapInit: true
-    paused: true
+  - uid: 504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-3.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 214
-      address: SCR-040A-1DE7
-      transmitFrequency: 1621
-      receiveFrequency: 1621
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: AtmosMonitor
-      gasThresholds:
-        Oxygen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0.8
-            enabled: True
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0.3
-            enabled: True
-          ignore: False
-        Nitrogen:
-          lowerWarnAround:
-            threshold: 1.5
-            enabled: True
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0.1
-            enabled: True
-          upperBound:
-            threshold: 0
-            enabled: False
-          ignore: False
-        CarbonDioxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.006
-            enabled: True
-          ignore: False
-        Plasma:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.005
-            enabled: True
-          ignore: False
-        Tritium:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.004
-            enabled: True
-          ignore: False
-        WaterVapor:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 1.5
-            enabled: True
-          ignore: False
-        Ammonia:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.05
-            enabled: True
-          ignore: False
-        NitrousOxide:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0.5
-            enabled: True
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.01
-            enabled: True
-          ignore: False
-        Frezon:
-          lowerWarnAround:
-            threshold: 0
-            enabled: False
-          upperWarnAround:
-            threshold: 0
-            enabled: False
-          lowerBound:
-            threshold: 0
-            enabled: False
-          upperBound:
-            threshold: 0.0001
-            enabled: True
-          ignore: False
-      pressureThreshold:
-        lowerWarnAround:
-          threshold: 1.05
-          enabled: True
-        upperWarnAround:
-          threshold: 0.7
-          enabled: True
-        lowerBound:
-          threshold: 85
-          enabled: True
-        upperBound:
-          threshold: 550
-          enabled: True
-        ignore: False
-      temperatureThreshold:
-        lowerWarnAround:
-          threshold: 1.1
-          enabled: True
-        upperWarnAround:
-          threshold: 0.8
-          enabled: True
-        lowerBound:
-          threshold: 193.15
-          enabled: True
-        upperBound:
-          threshold: 393.15
-          enabled: True
-        ignore: False
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 508
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 525
-    mapInit: true
-    paused: true
+  - uid: 301
     components:
     - type: Transform
       pos: 8.5,5.5
@@ -10679,10 +3420,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 526
-  - uid: 527
-    mapInit: true
-    paused: true
+          - 302
+  - uid: 303
     components:
     - type: Transform
       pos: 8.5,4.5
@@ -10695,10 +3434,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 528
-  - uid: 529
-    mapInit: true
-    paused: true
+          - 304
+  - uid: 305
     components:
     - type: Transform
       pos: 8.5,3.5
@@ -10711,953 +3448,424 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 530
+          - 306
 - proto: Grille
   entities:
-  - uid: 531
-    mapInit: true
-    paused: true
+  - uid: 307
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 532
-    mapInit: true
-    paused: true
+  - uid: 308
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 533
-    mapInit: true
-    paused: true
+  - uid: 309
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 534
-    mapInit: true
-    paused: true
+  - uid: 310
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 535
-    mapInit: true
-    paused: true
+  - uid: 311
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 1
-  - uid: 536
-    mapInit: true
-    paused: true
+  - uid: 312
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 537
-    mapInit: true
-    paused: true
+  - uid: 313
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 538
-    mapInit: true
-    paused: true
+  - uid: 314
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 539
-    mapInit: true
-    paused: true
+  - uid: 315
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 540
-    mapInit: true
-    paused: true
+  - uid: 316
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 541
-    mapInit: true
-    paused: true
+  - uid: 317
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 542
-    mapInit: true
-    paused: true
+  - uid: 318
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 543
-    mapInit: true
-    paused: true
+  - uid: 319
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 544
-    mapInit: true
-    paused: true
+  - uid: 320
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 545
-    mapInit: true
-    paused: true
+  - uid: 321
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 546
-    mapInit: true
-    paused: true
+  - uid: 322
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 547
-    mapInit: true
-    paused: true
+  - uid: 323
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 548
-    mapInit: true
-    paused: true
+  - uid: 324
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 1
-  - uid: 549
-    mapInit: true
-    paused: true
+  - uid: 325
     components:
     - type: Transform
       pos: 11.5,6.5
       parent: 1
-  - uid: 550
-    mapInit: true
-    paused: true
+  - uid: 326
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 1
-  - uid: 551
-    mapInit: true
-    paused: true
+  - uid: 327
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 552
-    mapInit: true
-    paused: true
+  - uid: 328
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 553
-    mapInit: true
-    paused: true
+  - uid: 329
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 1
-  - uid: 554
-    mapInit: true
-    paused: true
+  - uid: 330
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 555
-    mapInit: true
-    paused: true
+  - uid: 331
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 1
-  - uid: 556
-    mapInit: true
-    paused: true
+  - uid: 332
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
 - proto: GrilleBroken
   entities:
-  - uid: 557
-    mapInit: true
-    paused: true
+  - uid: 333
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 1
-  - uid: 558
-    mapInit: true
-    paused: true
+  - uid: 334
     components:
     - type: Transform
       pos: 12.5,6.5
       parent: 1
-  - uid: 559
-    mapInit: true
-    paused: true
+  - uid: 335
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-- proto: HandheldGPSBasic
-  entities:
-  - uid: 95
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 122
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: HeatExchanger
   entities:
-  - uid: 560
-    mapInit: true
-    paused: true
+  - uid: 336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 561
-    mapInit: true
-    paused: true
+  - uid: 337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,3.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 562
-    mapInit: true
-    paused: true
+  - uid: 338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,5.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 563
-    mapInit: true
-    paused: true
+  - uid: 339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 564
-    mapInit: true
-    paused: true
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,3.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-  - uid: 565
-    mapInit: true
-    paused: true
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,4.5
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-- proto: HeavyWrench
-  entities:
-  - uid: 84
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 80
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 566
-    mapInit: true
-    paused: true
+  - uid: 342
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 567
-    mapInit: true
-    paused: true
+  - uid: 343
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 568
-    mapInit: true
-    paused: true
+  - uid: 344
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 569
-    mapInit: true
-    paused: true
+  - uid: 345
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 570
-    mapInit: true
-    paused: true
+  - uid: 346
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-- proto: JetpackMiniFilled
-  entities:
-  - uid: 90
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: Jetpack
-      toggleActionEntity: 91
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 91
-  - uid: 92
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: Jetpack
-      toggleActionEntity: 93
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 93
-  - uid: 117
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: Jetpack
-      toggleActionEntity: 118
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 118
-  - uid: 119
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: Jetpack
-      toggleActionEntity: 120
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 120
-- proto: LightBulb
-  entities:
-  - uid: 572
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 571
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 574
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 573
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 576
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 575
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 578
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 577
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 580
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 579
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 582
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 581
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 584
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 583
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 586
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 585
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 588
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 587
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 590
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 589
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: LockerMedicineFilled
   entities:
-  - uid: 60
-    mapInit: true
-    paused: true
+  - uid: 27
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 63
-          - 68
-          - 71
-          - 67
-          - 69
-          - 70
-          - 66
-          - 65
-          - 61
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
+    - type: Lock
+      locked: False
     - type: EntityStorage
       air:
         volume: 200
         immutable: False
-        temperature: 293.14673
+        temperature: 293.14645
         moles:
-          Oxygen: 1.8546295
-          Nitrogen: 6.9769397
-    - type: Lock
-      locked: False
+          Oxygen: 1.7062591
+          Nitrogen: 6.4187846
 - proto: LockerSalvageSpecialistFilled
   entities:
-  - uid: 72
-    mapInit: true
-    paused: true
+  - uid: 28
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 96
-          - 97
-          - 100
-          - 73
-          - 78
-          - 90
-          - 80
-          - 99
-          - 95
-          - 98
-          - 94
-          - 92
-          - 88
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-  - uid: 101
-    mapInit: true
-    paused: true
+  - uid: 29
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 123
-          - 124
-          - 127
-          - 102
-          - 107
-          - 117
-          - 109
-          - 126
-          - 122
-          - 125
-          - 121
-          - 119
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: LogicGateAnd
   entities:
-  - uid: 366
+  - uid: 216
     components:
     - type: Transform
-      parent: 364
+      parent: 214
     - type: Physics
       canCollide: False
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        368:
+        215:
         - - Output
           - Input
     - type: InsideEntityStorage
-      storage: 364
+      storage: 214
 - proto: LogicGateNor
   entities:
-  - uid: 367
+  - uid: 217
     components:
     - type: Transform
-      parent: 364
+      parent: 214
     - type: Physics
       canCollide: False
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        366:
+        216:
         - - Output
           - InputB
     - type: InsideEntityStorage
-      storage: 364
+      storage: 214
 - proto: MatterBinStockPart
   entities:
-  - uid: 136
-    mapInit: true
-    paused: true
+  - uid: 38
     components:
     - type: Transform
-      parent: 132
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 34
     - type: Physics
       canCollide: False
 - proto: MedicalBed
   entities:
-  - uid: 205
-    mapInit: true
-    paused: true
+  - uid: 60
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
     - type: HealOnBuckle
-      sleepAction: 206
-      nextHealTime: -6051.3877489
+      sleepAction: 61
     - type: ActionsContainer
     - type: ContainerContainer
       containers:
         actions: !type:Container
           ents:
-          - 206
-- proto: MiningShuttleConsoleCircuitboard
-  entities:
-  - uid: 363
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 362
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
+          - 61
 - proto: MiningWindow
   entities:
-  - uid: 591
-    mapInit: true
-    paused: true
+  - uid: 357
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 592
-    mapInit: true
-    paused: true
+  - uid: 358
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 1
-  - uid: 593
-    mapInit: true
-    paused: true
+  - uid: 359
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 594
-    mapInit: true
-    paused: true
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 1
-  - uid: 595
-    mapInit: true
-    paused: true
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-0.5
       parent: 1
-  - uid: 596
-    mapInit: true
-    paused: true
+  - uid: 362
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 597
-    mapInit: true
-    paused: true
+  - uid: 363
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 598
-    mapInit: true
-    paused: true
+  - uid: 364
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 599
-    mapInit: true
-    paused: true
+  - uid: 365
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 600
-    mapInit: true
-    paused: true
+  - uid: 366
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 601
-    mapInit: true
-    paused: true
+  - uid: 367
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 602
-    mapInit: true
-    paused: true
+  - uid: 368
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 603
-    mapInit: true
-    paused: true
+  - uid: 369
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 604
-    mapInit: true
-    paused: true
+  - uid: 370
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 605
-    mapInit: true
-    paused: true
+  - uid: 371
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 606
-    mapInit: true
-    paused: true
+  - uid: 372
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 607
-    mapInit: true
-    paused: true
+  - uid: 373
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 608
-    mapInit: true
-    paused: true
+  - uid: 374
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 609
-    mapInit: true
-    paused: true
+  - uid: 375
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 610
-    mapInit: true
-    paused: true
+  - uid: 376
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 611
-    mapInit: true
-    paused: true
+  - uid: 377
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 612
-    mapInit: true
-    paused: true
+  - uid: 378
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 1
-- proto: NetworkConfigurator
-  entities:
-  - uid: 85
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 80
-    - type: NetworkConfigurator
-      lastUseAttempt: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 113
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 109
-    - type: NetworkConfigurator
-      lastUseAttempt: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: NitrogenCanister
   entities:
-  - uid: 613
-    mapInit: true
-    paused: true
+  - uid: 379
     components:
     - type: Transform
       anchored: True
@@ -11672,102 +3880,28 @@ entities:
           Nitrogen: 1977.1729
     - type: Physics
       bodyType: Static
-  - uid: 614
-    mapInit: true
-    paused: true
+  - uid: 380
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
 - proto: Ointment
   entities:
-  - uid: 70
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
-  - uid: 71
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 60
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 60
-  - uid: 615
-    mapInit: true
-    paused: true
+  - uid: 9
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.488419,-3.5935512
+      pos: 7.3106174,-3.550837
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: OreBag
   entities:
-  - uid: 96
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: MagnetPickup
-      nextScan: 6051.7874697
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
-  - uid: 123
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: MagnetPickup
-      nextScan: 6051.7874697
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
-  - uid: 616
-    mapInit: true
-    paused: true
+  - uid: 382
     components:
     - type: Transform
       pos: -3.4424195,3.5869615
       parent: 1
     - type: MagnetPickup
       nextScan: 6051.7874697
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: UseDelay
@@ -11777,17 +3911,13 @@ entities:
         quickInsert:
           length: 0.5
         storage: {}
-  - uid: 617
-    mapInit: true
-    paused: true
+  - uid: 383
     components:
     - type: Transform
       pos: -2.5830445,3.5713365
       parent: 1
     - type: MagnetPickup
       nextScan: 6051.7874697
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: UseDelay
@@ -11799,9 +3929,7 @@ entities:
         storage: {}
 - proto: OxygenCanister
   entities:
-  - uid: 618
-    mapInit: true
-    paused: true
+  - uid: 384
     components:
     - type: Transform
       anchored: True
@@ -11816,93 +3944,19 @@ entities:
           Oxygen: 2185.1868
     - type: Physics
       bodyType: Static
-  - uid: 619
-    mapInit: true
-    paused: true
+  - uid: 385
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-- proto: OxygenTankFilled
-  entities:
-  - uid: 157
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 147
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 168
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 158
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 179
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 169
-    - type: UseDelay
-      delays:
-        gasTank:
-          endTime: 0
-          startTime: 0
-          length: 1
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: Paper
   entities:
-  - uid: 128
-    mapInit: true
-    paused: true
+  - uid: 30
     components:
     - type: Transform
       rot: 0.0015335821080952883 rad
       pos: 3.985269,5.483892
       parent: 1
-    - type: Flammable
-      nextUpdate: -1261.8838261
     - type: SolutionContainerManager
       solutions:
         food:
@@ -11913,8 +3967,6 @@ entities:
           reagents: []
       containers:
       - food
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Fixtures
       fixtures:
         fix1:
@@ -11954,13 +4006,13 @@ entities:
     - type: ContainerContainer
       containers:
         solution@food: !type:ContainerSlot
-          ent: 129
+          ent: 31
 - proto: PaperNanoTaskItem
   entities:
-  - uid: 365
+  - uid: 218
     components:
     - type: Transform
-      parent: 364
+      parent: 214
     - type: Paper
       content: >-
         From what I can tell, these gates were designed by some techy Salvager to ensure that the vacuum switch will open the signal valve (draining the chamberlock of hot air), but that the valve will close if the inner door is open, ensuring the whole outpost is not spaced.
@@ -11971,9 +4023,7 @@ entities:
       canCollide: False
 - proto: PartRodMetal
   entities:
-  - uid: 130
-    mapInit: true
-    paused: true
+  - uid: 32
     components:
     - type: Transform
       pos: -5.4569616,3.5658166
@@ -11982,685 +4032,221 @@ entities:
       solutions: null
       containers:
       - rod
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@rod: !type:ContainerSlot
-          ent: 131
+          ent: 33
 - proto: Pickaxe
   entities:
-  - uid: 97
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 124
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 620
-    mapInit: true
-    paused: true
+  - uid: 386
     components:
     - type: Transform
       pos: -3.5517945,5.6963367
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
     - type: UseDelay
       delays:
         default:
           endTime: 0
           startTime: 0
           length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-  - uid: 621
-    mapInit: true
-    paused: true
+  - uid: 387
     components:
     - type: Transform
       pos: -3.3486695,5.4619617
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
     - type: UseDelay
       delays:
         default:
           endTime: 0
           startTime: 0
           length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-  - uid: 622
-    mapInit: true
-    paused: true
+  - uid: 388
     components:
     - type: Transform
       pos: -2.6767945,5.6807117
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
     - type: UseDelay
       delays:
         default:
           endTime: 0
           startTime: 0
           length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-  - uid: 623
-    mapInit: true
-    paused: true
+  - uid: 389
     components:
     - type: Transform
       pos: -2.3486695,5.4932117
       parent: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
     - type: UseDelay
       delays:
         default:
           endTime: 0
           startTime: 0
           length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-- proto: PipeWrench
-  entities:
-  - uid: 197
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 182
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: PowerCellMedium
-  entities:
-  - uid: 32
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 30
-    - type: Battery
-      lastCharge: 720
-      lastUpdate: -81.6002792
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 33
-  - uid: 44
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 43
-    - type: Battery
-      lastCharge: 720
-      lastUpdate: -81.627052
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 45
-  - uid: 74
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 73
-    - type: Battery
-      lastCharge: 720
-      lastUpdate: -81.6002792
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 75
-  - uid: 103
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 102
-    - type: Battery
-      lastCharge: 720
-      lastUpdate: -81.6002792
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 104
-  - uid: 186
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 185
-    - type: Battery
-      lastCharge: 720
-      lastUpdate: -81.6002792
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 187
-  - uid: 192
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 190
-    - type: Battery
-      lastCharge: 720
-      lastUpdate: -81.6002792
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 193
 - proto: PowerCellSmall
   entities:
-  - uid: 143
-    mapInit: true
-    paused: true
+  - uid: 45
     components:
     - type: Transform
-      parent: 138
+      parent: 40
     - type: Battery
       lastCharge: 360
-      lastUpdate: -81.6002792
     - type: SolutionContainerManager
       solutions: null
       containers:
       - battery
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@battery: !type:ContainerSlot
-          ent: 144
+          ent: 46
 - proto: PoweredSmallLight
   entities:
-  - uid: 571
-    mapInit: true
-    paused: true
+  - uid: 347
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 572
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 693C-10B0
-      receiveFrequency: 1173
-  - uid: 573
-    mapInit: true
-    paused: true
+  - uid: 348
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 574
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 5290-D9CF
-      receiveFrequency: 1173
-  - uid: 575
-    mapInit: true
-    paused: true
+  - uid: 349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 576
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 1917-D96F
-      receiveFrequency: 1173
-  - uid: 577
-    mapInit: true
-    paused: true
+  - uid: 350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 578
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 04DE-E23E
-      receiveFrequency: 1173
-  - uid: 579
-    mapInit: true
-    paused: true
+  - uid: 351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 580
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 0C00-CBD7
-      receiveFrequency: 1173
-  - uid: 581
-    mapInit: true
-    paused: true
+  - uid: 352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-2.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 582
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 4531-F8FD
-      receiveFrequency: 1173
-  - uid: 583
-    mapInit: true
-    paused: true
+  - uid: 353
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7606969
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 584
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 56A2-C640
-      receiveFrequency: 1173
-  - uid: 585
-    mapInit: true
-    paused: true
+  - uid: 354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7940302
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 586
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 00B9-471D
-      receiveFrequency: 1173
-  - uid: 587
-    mapInit: true
-    paused: true
+  - uid: 355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,4.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7940302
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 588
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 27E9-DD41
-      receiveFrequency: 1173
-  - uid: 589
-    mapInit: true
-    paused: true
+  - uid: 356
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-    - type: PointLight
-      color: '#FFD1A3FF'
-    - type: PoweredLight
-      lastThunk: 5969.7940302
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 590
-    - type: ApcPowerReceiver
-      powerLoad: 60
-    - type: DeviceNetwork
-      address: 6A3B-A849
-      receiveFrequency: 1173
 - proto: Rack
   entities:
-  - uid: 624
-    mapInit: true
-    paused: true
+  - uid: 390
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 625
-    mapInit: true
-    paused: true
+  - uid: 391
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 626
-    mapInit: true
-    paused: true
+  - uid: 392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,5.5
       parent: 1
-  - uid: 627
-    mapInit: true
-    paused: true
+  - uid: 393
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
 - proto: RadioHandheld
   entities:
-  - uid: 98
-    mapInit: true
-    paused: true
+  - uid: 233
     components:
     - type: Transform
-      parent: 72
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 125
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 628
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -3.0124002,-2.4114635
+      pos: -2.8758144,-2.4194028
       parent: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: RCD
   entities:
-  - uid: 629
-    mapInit: true
-    paused: true
+  - uid: 62
     components:
     - type: Transform
-      pos: 3.5018163,5.616694
+      pos: 3.5947742,5.621424
       parent: 1
-    - type: RCD
-      protoId: WallSolid
-    - type: LimitedCharges
-      lastUpdate: -81.6002792
-      lastCharges: 30
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: ReinforcedGirder
   entities:
-  - uid: 630
-    mapInit: true
-    paused: true
+  - uid: 396
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,6.5
       parent: 1
-- proto: Screwdriver
-  entities:
-  - uid: 86
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 80
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: RandomSprite
-      selected:
-        enum.DamageStateVisualLayers.Base:
-        - screwdriver
-        - '#18A2D5FF'
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 114
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 109
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: RandomSprite
-      selected:
-        enum.DamageStateVisualLayers.Base:
-        - screwdriver
-        - '#A05212FF'
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: SheetSteel1
   entities:
-  - uid: 53
-    mapInit: true
-    paused: true
+  - uid: 20
     components:
     - type: Transform
-      parent: 52
+      parent: 19
     - type: SolutionContainerManager
       solutions: null
       containers:
       - steel
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
     - type: ContainerContainer
       containers:
         solution@steel: !type:ContainerSlot
-          ent: 54
+          ent: 21
 - proto: SignalControlledValve
   entities:
-  - uid: 631
+  - uid: 397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
     - type: GasValve
       open: False
     - type: DeviceLinkSink
       invokeCounter: 2
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 632
+  - uid: 398
     components:
     - type: MetaData
       name: vacuum switch
@@ -12670,14 +4256,12 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        366:
+        216:
         - - Status
           - InputA
 - proto: SignDirectionalDorms
   entities:
-  - uid: 633
-    mapInit: true
-    paused: true
+  - uid: 399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12685,9 +4269,7 @@ entities:
       parent: 1
 - proto: SignDirectionalEng
   entities:
-  - uid: 634
-    mapInit: true
-    paused: true
+  - uid: 400
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12695,9 +4277,7 @@ entities:
       parent: 1
 - proto: SignDirectionalEvac
   entities:
-  - uid: 635
-    mapInit: true
-    paused: true
+  - uid: 401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12705,9 +4285,7 @@ entities:
       parent: 1
 - proto: SignDirectionalMed
   entities:
-  - uid: 636
-    mapInit: true
-    paused: true
+  - uid: 402
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12715,9 +4293,7 @@ entities:
       parent: 1
 - proto: SignDirectionalSupply
   entities:
-  - uid: 637
-    mapInit: true
-    paused: true
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12725,18 +4301,14 @@ entities:
       parent: 1
 - proto: SignEVA
   entities:
-  - uid: 638
-    mapInit: true
-    paused: true
+  - uid: 404
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
 - proto: SignFlammableMed
   entities:
-  - uid: 639
-    mapInit: true
-    paused: true
+  - uid: 405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12744,9 +4316,7 @@ entities:
       parent: 1
 - proto: SpaceHeaterEnabled
   entities:
-  - uid: 132
-    mapInit: true
-    paused: true
+  - uid: 34
     components:
     - type: Transform
       pos: 5.5,-0.5
@@ -12757,14 +4327,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 137
+          - 39
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 136
-          - 135
-          - 133
+          - 38
+          - 37
+          - 35
     - type: SpaceHeater
       mode: Cool
     - type: GasThermoMachine
@@ -12772,21 +4342,15 @@ entities:
       heatCapacity: 3500
 - proto: SpaceHeaterMachineCircuitBoard
   entities:
-  - uid: 137
-    mapInit: true
-    paused: true
+  - uid: 39
     components:
     - type: Transform
-      parent: 132
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 34
     - type: Physics
       canCollide: False
 - proto: SubstationBasic
   entities:
-  - uid: 138
-    mapInit: true
-    paused: true
+  - uid: 40
     components:
     - type: MetaData
       name: Mining Outpost substation
@@ -12795,7 +4359,6 @@ entities:
       parent: 1
     - type: Battery
       lastCharge: 2500000
-      lastUpdate: -77.3270563
     - type: PowerNetworkBattery
       loadingNetworkDemand: 4731.919
       currentReceiving: 4732.5044
@@ -12806,223 +4369,95 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 146
+          - 48
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 145
-          - 139
-          - 141
-          - 143
+          - 47
+          - 41
+          - 43
+          - 45
 - proto: SubstationMachineCircuitboard
   entities:
-  - uid: 146
-    mapInit: true
-    paused: true
+  - uid: 48
     components:
     - type: Transform
-      parent: 138
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 40
     - type: Physics
       canCollide: False
 - proto: SuitStorageSalv
   entities:
-  - uid: 147
-    mapInit: true
-    paused: true
+  - uid: 49
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 157
-          - 148
-          - 151
-          - 156
-  - uid: 158
-    mapInit: true
-    paused: true
+  - uid: 50
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 168
-          - 159
-          - 162
-          - 167
-  - uid: 169
-    mapInit: true
-    paused: true
+  - uid: 51
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.147
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 179
-          - 170
-          - 173
-          - 178
-- proto: SurvivalKnife
-  entities:
-  - uid: 99
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 126
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 - proto: SyringeBicaridine
   entities:
-  - uid: 180
-    mapInit: true
-    paused: true
+  - uid: 160
     components:
-    - type: MetaData
-      name: syringe (bicaridine)
     - type: Transform
-      pos: 4.4849324,-2.411089
+      pos: 4.4668674,-2.315175
       parent: 1
-    - type: Label
-      currentLabel: bicaridine
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - injector
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: NameModifier
-      baseName: syringe
-    - type: ContainerContainer
-      containers:
-        solution@injector: !type:ContainerSlot
-          ent: 181
 - proto: TableCounterMetal
   entities:
-  - uid: 640
-    mapInit: true
-    paused: true
+  - uid: 406
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 641
-    mapInit: true
-    paused: true
+  - uid: 407
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
 - proto: TableGlass
   entities:
-  - uid: 642
-    mapInit: true
-    paused: true
+  - uid: 408
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 643
-    mapInit: true
-    paused: true
+  - uid: 409
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 644
-    mapInit: true
-    paused: true
+  - uid: 410
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 645
-    mapInit: true
-    paused: true
+  - uid: 411
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 646
-    mapInit: true
-    paused: true
+  - uid: 412
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 647
-    mapInit: true
-    paused: true
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 648
-    mapInit: true
-    paused: true
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13030,32 +4465,24 @@ entities:
       parent: 1
 - proto: TableWood
   entities:
-  - uid: 649
-    mapInit: true
-    paused: true
+  - uid: 415
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 650
-    mapInit: true
-    paused: true
+  - uid: 416
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 651
-    mapInit: true
-    paused: true
+  - uid: 417
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
 - proto: TelecomServer
   entities:
-  - uid: 52
-    mapInit: true
-    paused: true
+  - uid: 19
     components:
     - type: Transform
       pos: 3.5,3.5
@@ -13068,859 +4495,583 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 57
-          - 58
+          - 24
+          - 25
         machine_board: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 59
+          - 26
         machine_parts: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 53
-          - 55
+          - 20
+          - 22
 - proto: TelecomServerCircuitboard
   entities:
-  - uid: 59
-    mapInit: true
-    paused: true
+  - uid: 26
     components:
     - type: Transform
-      parent: 52
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 19
     - type: Physics
       canCollide: False
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 182
-    mapInit: true
-    paused: true
+  - uid: 53
     components:
     - type: Transform
-      pos: 4.475717,5.574835
+      pos: 4.4072742,5.621424
       parent: 1
-    - type: Storage
-      storedItems:
-        196:
-          position: 0,0
-          _rotation: South
-        197:
-          position: 1,0
-          _rotation: South
-        183:
-          position: 2,0
-          _rotation: South
-        198:
-          position: 3,0
-          _rotation: South
-        185:
-          position: 4,0
-          _rotation: South
-        190:
-          position: 5,0
-          _rotation: South
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 196
-          - 197
-          - 183
-          - 198
-          - 185
-          - 190
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 207
-    mapInit: true
-    paused: true
+  - uid: 241
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-    - type: VendingMachine
-      inventory:
-        OxygenTankFilled:
-          amount: 10
-          iD: OxygenTankFilled
-          type: Regular
-        NitrogenTankFilled:
-          amount: 10
-          iD: NitrogenTankFilled
-          type: Regular
-      nextEmpEject: -6051.3877489
-    - type: ActionGrant
-      actionEntities:
-      - 208
-    - type: Vocalizer
-      nextVocalizeInterval: 506.9314028
-    - type: PointLight
-      enabled: True
-    - type: Actions
-      actions:
-      - 208
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 208
 - proto: WallMining
   entities:
-  - uid: 652
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: 14.5,-1.5
-      parent: 1
-  - uid: 653
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-3.5
-      parent: 1
-  - uid: 654
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-2.5
-      parent: 1
-  - uid: 655
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-3.5
-      parent: 1
-  - uid: 656
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -7.5,3.5
-      parent: 1
-  - uid: 657
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,2.5
-      parent: 1
-  - uid: 658
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,2.5
-      parent: 1
-  - uid: 659
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 1
-  - uid: 660
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
-      parent: 1
-  - uid: 661
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 662
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,2.5
-      parent: 1
-  - uid: 663
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 664
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,5.5
-      parent: 1
-  - uid: 665
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,5.5
-      parent: 1
-  - uid: 666
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,6.5
-      parent: 1
-  - uid: 667
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 668
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 669
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 670
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 671
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 672
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,6.5
-      parent: 1
-  - uid: 673
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,7.5
-      parent: 1
-  - uid: 674
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,6.5
-      parent: 1
-  - uid: 675
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-  - uid: 676
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-  - uid: 677
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 678
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-2.5
-      parent: 1
-  - uid: 679
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,6.5
-      parent: 1
-  - uid: 680
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,6.5
-      parent: 1
-  - uid: 681
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,7.5
-      parent: 1
-  - uid: 682
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 683
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 684
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-  - uid: 685
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-1.5
-      parent: 1
-  - uid: 686
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-1.5
-      parent: 1
-  - uid: 687
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-  - uid: 688
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-  - uid: 689
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -7.5,4.5
-      parent: 1
-  - uid: 690
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -8.5,4.5
-      parent: 1
-  - uid: 691
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -9.5,4.5
-      parent: 1
-  - uid: 692
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -10.5,4.5
-      parent: 1
-  - uid: 693
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -11.5,4.5
-      parent: 1
-  - uid: 694
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -12.5,4.5
-      parent: 1
-  - uid: 695
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,4.5
-      parent: 1
-  - uid: 696
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,3.5
-      parent: 1
-  - uid: 697
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,2.5
-      parent: 1
-  - uid: 698
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,1.5
-      parent: 1
-  - uid: 699
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,0.5
-      parent: 1
-  - uid: 700
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,-0.5
-      parent: 1
-  - uid: 701
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 1
-  - uid: 702
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,-2.5
-      parent: 1
-  - uid: 703
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      pos: -13.5,-3.5
-      parent: 1
-  - uid: 704
-    mapInit: true
-    paused: true
+  - uid: 104
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 1
-  - uid: 705
-    mapInit: true
-    paused: true
+  - uid: 114
     components:
     - type: Transform
-      pos: -11.5,-3.5
+      pos: -13.5,-0.5
       parent: 1
-  - uid: 706
-    mapInit: true
-    paused: true
+  - uid: 115
     components:
     - type: Transform
-      pos: -10.5,-3.5
+      pos: -13.5,0.5
       parent: 1
-  - uid: 707
-    mapInit: true
-    paused: true
+  - uid: 116
     components:
     - type: Transform
-      pos: -9.5,-3.5
+      pos: -13.5,1.5
       parent: 1
-  - uid: 708
-    mapInit: true
-    paused: true
+  - uid: 117
     components:
     - type: Transform
-      pos: -8.5,-3.5
+      pos: -13.5,2.5
       parent: 1
-  - uid: 709
-    mapInit: true
-    paused: true
+  - uid: 118
     components:
     - type: Transform
-      pos: -7.5,-3.5
+      pos: -13.5,3.5
       parent: 1
-  - uid: 710
-    mapInit: true
-    paused: true
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 126
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 711
-    mapInit: true
-    paused: true
+  - uid: 127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 712
-    mapInit: true
-    paused: true
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 14.5,-1.5
+      parent: 1
+  - uid: 563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 713
-    mapInit: true
-    paused: true
+  - uid: 564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 714
-    mapInit: true
-    paused: true
+  - uid: 565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-  - uid: 715
-    mapInit: true
-    paused: true
+  - uid: 566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 716
-    mapInit: true
-    paused: true
+  - uid: 567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 1
-  - uid: 717
-    mapInit: true
-    paused: true
+  - uid: 568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 718
-    mapInit: true
-    paused: true
+  - uid: 569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 719
-    mapInit: true
-    paused: true
+  - uid: 570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 720
-    mapInit: true
-    paused: true
+  - uid: 571
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 721
-    mapInit: true
-    paused: true
+  - uid: 572
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 1
-  - uid: 722
-    mapInit: true
-    paused: true
+  - uid: 573
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 1
-  - uid: 723
-    mapInit: true
-    paused: true
+  - uid: 574
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 724
-    mapInit: true
-    paused: true
+  - uid: 575
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 725
-    mapInit: true
-    paused: true
+  - uid: 576
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 726
-    mapInit: true
-    paused: true
+  - uid: 577
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 727
-    mapInit: true
-    paused: true
+  - uid: 578
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 728
-    mapInit: true
-    paused: true
+  - uid: 579
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 729
-    mapInit: true
-    paused: true
+  - uid: 580
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 730
-    mapInit: true
-    paused: true
+  - uid: 581
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 731
-    mapInit: true
-    paused: true
+  - uid: 582
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 732
-    mapInit: true
-    paused: true
+  - uid: 583
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 733
-    mapInit: true
-    paused: true
+  - uid: 584
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 734
-    mapInit: true
-    paused: true
+  - uid: 585
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 735
-    mapInit: true
-    paused: true
+  - uid: 586
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 736
-    mapInit: true
-    paused: true
+  - uid: 587
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 737
-    mapInit: true
-    paused: true
+  - uid: 588
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 738
-    mapInit: true
-    paused: true
+  - uid: 589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 739
-    mapInit: true
-    paused: true
+  - uid: 590
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 740
-    mapInit: true
-    paused: true
+  - uid: 591
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,2.5
       parent: 1
-  - uid: 741
-    mapInit: true
-    paused: true
+  - uid: 592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,2.5
       parent: 1
-  - uid: 742
-    mapInit: true
-    paused: true
+  - uid: 593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,2.5
       parent: 1
-  - uid: 743
-    mapInit: true
-    paused: true
+  - uid: 594
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,2.5
       parent: 1
-  - uid: 744
-    mapInit: true
-    paused: true
+  - uid: 595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,2.5
       parent: 1
-  - uid: 745
-    mapInit: true
-    paused: true
+  - uid: 596
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 1
-  - uid: 746
-    mapInit: true
-    paused: true
+  - uid: 597
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-1.5
       parent: 1
-  - uid: 747
-    mapInit: true
-    paused: true
+  - uid: 598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
       parent: 1
-  - uid: 748
-    mapInit: true
-    paused: true
+  - uid: 599
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 749
-    mapInit: true
-    paused: true
+  - uid: 600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13928,78 +5079,58 @@ entities:
       parent: 1
 - proto: WallMiningDiagonal
   entities:
-  - uid: 750
-    mapInit: true
-    paused: true
+  - uid: 484
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 751
-    mapInit: true
-    paused: true
+  - uid: 485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 1
-  - uid: 752
-    mapInit: true
-    paused: true
+  - uid: 486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 753
-    mapInit: true
-    paused: true
+  - uid: 487
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 754
-    mapInit: true
-    paused: true
+  - uid: 488
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 1
-  - uid: 755
-    mapInit: true
-    paused: true
+  - uid: 489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 756
-    mapInit: true
-    paused: true
+  - uid: 490
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 757
-    mapInit: true
-    paused: true
+  - uid: 491
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 758
-    mapInit: true
-    paused: true
+  - uid: 492
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 1
-  - uid: 759
-    mapInit: true
-    paused: true
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14007,41 +5138,27 @@ entities:
       parent: 1
 - proto: WallmountGeneratorAPUElectronics
   entities:
-  - uid: 526
-    mapInit: true
-    paused: true
+  - uid: 302
     components:
     - type: Transform
-      parent: 525
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 301
     - type: Physics
       canCollide: False
-  - uid: 528
-    mapInit: true
-    paused: true
+  - uid: 304
     components:
     - type: Transform
-      parent: 527
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 303
     - type: Physics
       canCollide: False
-  - uid: 530
-    mapInit: true
-    paused: true
+  - uid: 306
     components:
     - type: Transform
-      parent: 529
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
+      parent: 305
     - type: Physics
       canCollide: False
 - proto: WarpPoint
   entities:
-  - uid: 760
-    mapInit: true
-    paused: true
+  - uid: 494
     components:
     - type: Transform
       pos: 0.5,0.5
@@ -14050,158 +5167,24 @@ entities:
       location: Mining Station
 - proto: WeaponProtoKineticAccelerator
   entities:
-  - uid: 100
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 72
-    - type: Gun
-      nextFire: -6051.3877489
-    - type: RechargeBasicEntityAmmo
-      nextCharge: -81.6002792
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 127
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 101
-    - type: Gun
-      nextFire: -6051.3877489
-    - type: RechargeBasicEntityAmmo
-      nextCharge: -81.6002792
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 761
-    mapInit: true
-    paused: true
+  - uid: 495
     components:
     - type: Transform
       pos: -5.4307666,5.5822673
       parent: 1
-    - type: Gun
-      nextFire: -6051.3877489
     - type: RechargeBasicEntityAmmo
-      nextCharge: -81.6002792
+      nextCharge: 0
     - type: UseDelay
       delays:
         default:
           endTime: 0
           startTime: 0
           length: 1
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
     - type: Physics
       canCollide: False
-- proto: Welder
-  entities:
-  - uid: 81
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 80
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - Welder
-    - type: Welder
-      nextUpdate: 0.3997208
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@Welder: !type:ContainerSlot
-          ent: 82
-  - uid: 110
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 109
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - Welder
-    - type: Welder
-      nextUpdate: 0.3997208
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@Welder: !type:ContainerSlot
-          ent: 111
-  - uid: 183
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 182
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - Welder
-    - type: Welder
-      nextUpdate: 0.3997208
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@Welder: !type:ContainerSlot
-          ent: 184
 - proto: Windoor
   entities:
-  - uid: 369
-    mapInit: true
-    paused: true
+  - uid: 219
     components:
     - type: MetaData
       name: Treatment Area
@@ -14218,14 +5201,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 370
+          - 220
     - type: Airlock
       powered: True
     - type: DoorBolt
       powered: True
-  - uid: 371
-    mapInit: true
-    paused: true
+  - uid: 221
     components:
     - type: MetaData
       name: Bunks
@@ -14242,46 +5223,36 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 372
+          - 222
     - type: Airlock
       powered: True
     - type: DoorBolt
       powered: True
 - proto: WindowDirectional
   entities:
-  - uid: 762
-    mapInit: true
-    paused: true
+  - uid: 496
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 763
-    mapInit: true
-    paused: true
+  - uid: 497
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 764
-    mapInit: true
-    paused: true
+  - uid: 498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 765
-    mapInit: true
-    paused: true
+  - uid: 499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-  - uid: 766
-    mapInit: true
-    paused: true
+  - uid: 500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14289,87 +5260,16 @@ entities:
       parent: 1
 - proto: WindowFrostedDirectional
   entities:
-  - uid: 767
-    mapInit: true
-    paused: true
+  - uid: 501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 768
-    mapInit: true
-    paused: true
+  - uid: 502
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-4.5
       parent: 1
-- proto: Wirecutter
-  entities:
-  - uid: 87
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 80
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: RandomSprite
-      selected:
-        enum.DamageStateVisualLayers.Base:
-        - cutters
-        - '#D58C18FF'
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 115
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 109
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: RandomSprite
-      selected:
-        enum.DamageStateVisualLayers.Base:
-        - cutters
-        - '#1861D5FF'
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-  - uid: 198
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 182
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: RandomSprite
-      selected:
-        enum.DamageStateVisualLayers.Base:
-        - cutters
-        - '#18A2D5FF'
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
-- proto: Wrench
-  entities:
-  - uid: 116
-    mapInit: true
-    paused: true
-    components:
-    - type: Transform
-      parent: 109
-    - type: MeleeWeapon
-      nextAttack: -6051.3877489
-    - type: EmitSoundOnCollide
-      nextSound: -6051.3877489
-    - type: Physics
-      canCollide: False
 ...

--- a/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
+++ b/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
@@ -795,13 +795,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 73
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -818,13 +811,6 @@ entities:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 75
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -839,13 +825,6 @@ entities:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 77
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -860,13 +839,6 @@ entities:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 79
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -879,13 +851,6 @@ entities:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 81
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -902,13 +867,6 @@ entities:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 83
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -1676,31 +1634,15 @@ entities:
     - type: Transform
       pos: -0.09953964,-5.4144
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - smokable
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@smokable: !type:ContainerSlot
-          ent: 11
   - uid: 12
     components:
     - type: Transform
       pos: -0.25578964,-5.555025
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - smokable
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@smokable: !type:ContainerSlot
-          ent: 13
 - proto: ClosetFireFilled
   entities:
   - uid: 14
@@ -1742,62 +1684,6 @@ entities:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-- proto: DoorElectronics
-  entities:
-  - uid: 75
-    components:
-    - type: Transform
-      parent: 74
-    - type: Physics
-      canCollide: False
-  - uid: 77
-    components:
-    - type: Transform
-      parent: 76
-    - type: Physics
-      canCollide: False
-  - uid: 79
-    components:
-    - type: Transform
-      parent: 78
-    - type: AccessReader
-      accessListsOriginal: []
-    - type: Physics
-      canCollide: False
-  - uid: 81
-    components:
-    - type: Transform
-      parent: 80
-    - type: Physics
-      canCollide: False
-  - uid: 220
-    components:
-    - type: Transform
-      parent: 219
-    - type: Physics
-      canCollide: False
-  - uid: 222
-    components:
-    - type: Transform
-      parent: 221
-    - type: Physics
-      canCollide: False
-- proto: DoorElectronicsExternal
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      parent: 72
-    - type: Physics
-      canCollide: False
-- proto: DoorElectronicsSalvage
-  entities:
-  - uid: 83
-    components:
-    - type: Transform
-      parent: 82
-    - type: Physics
-      canCollide: False
 - proto: DrinkBeerBottleFull
   entities:
   - uid: 18
@@ -2953,43 +2839,16 @@ entities:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-    - type: PowerSupplier
-      supplyRampPosition: 1577.5016
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 302
   - uid: 303
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-    - type: PowerSupplier
-      supplyRampPosition: 1577.5016
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 304
   - uid: 305
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-    - type: PowerSupplier
-      supplyRampPosition: 1577.5016
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 306
 - proto: Grille
   entities:
   - uid: 307
@@ -3404,13 +3263,6 @@ entities:
       anchored: True
       pos: 7.5,5.5
       parent: 1
-    - type: GasCanister
-      gasMixture:
-        volume: 1500
-        immutable: False
-        temperature: 293.15
-        moles:
-          Nitrogen: 1977.1729
     - type: Physics
       bodyType: Static
   - uid: 380
@@ -3433,33 +3285,15 @@ entities:
     - type: Transform
       pos: -3.4424195,3.5869615
       parent: 1
-    - type: MagnetPickup
-      nextScan: 6051.7874697
     - type: Physics
       canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
   - uid: 383
     components:
     - type: Transform
       pos: -2.5830445,3.5713365
       parent: 1
-    - type: MagnetPickup
-      nextScan: 6051.7874697
     - type: Physics
       canCollide: False
-    - type: UseDelay
-      delays:
-        default:
-          length: 1
-        quickInsert:
-          length: 0.5
-        storage: {}
 - proto: OxygenCanister
   entities:
   - uid: 384
@@ -3468,13 +3302,6 @@ entities:
       anchored: True
       pos: 7.5,4.5
       parent: 1
-    - type: GasCanister
-      gasMixture:
-        volume: 1500
-        immutable: False
-        temperature: 293.15
-        moles:
-          Oxygen: 2185.1868
     - type: Physics
       bodyType: Static
   - uid: 385
@@ -3490,56 +3317,8 @@ entities:
       rot: 0.0015335821080952883 rad
       pos: 3.985269,5.483892
       parent: 1
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape: !type:PolygonShape
-            radius: 0.01
-            vertices:
-            - -0.25,-0.25
-            - 0.25,-0.25
-            - 0.25,0.25
-            - -0.25,0.25
-          mask:
-          - Impassable
-          - HighImpassable
-          layer: []
-          density: 20
-          hard: True
-          restitution: 0.3
-          friction: 0.2
-        flammable:
-          shape: !type:PhysShapeCircle
-            radius: 0.35
-            position: 0,0
-          mask:
-          - TableLayer
-          - HighImpassable
-          - LowImpassable
-          - BulletImpassable
-          - InteractImpassable
-          - Opaque
-          layer: []
-          density: 0
-          hard: False
-          restitution: 0
-          friction: 0.4
     - type: Paper
       content: '            [bold][color=red]BREAK IN CASE OF ATMOSPHERIC EMERGENCY[/color][/bold]'
-    - type: ContainerContainer
-      containers:
-        solution@food: !type:ContainerSlot
-          ent: 31
 - proto: PaperNanoTaskItem
   entities:
   - uid: 218
@@ -3561,16 +3340,8 @@ entities:
     - type: Transform
       pos: -5.4569616,3.5658166
       parent: 1
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - rod
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@rod: !type:ContainerSlot
-          ent: 33
 - proto: Pickaxe
   entities:
   - uid: 386
@@ -3578,12 +3349,6 @@ entities:
     - type: Transform
       pos: -3.5517945,5.6963367
       parent: 1
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
     - type: Physics
       canCollide: False
   - uid: 387
@@ -3591,12 +3356,6 @@ entities:
     - type: Transform
       pos: -3.3486695,5.4619617
       parent: 1
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
     - type: Physics
       canCollide: False
   - uid: 388
@@ -3604,12 +3363,6 @@ entities:
     - type: Transform
       pos: -2.6767945,5.6807117
       parent: 1
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
     - type: Physics
       canCollide: False
   - uid: 389
@@ -3617,32 +3370,8 @@ entities:
     - type: Transform
       pos: -2.3486695,5.4932117
       parent: 1
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 0
-          startTime: 0
-          length: 1
     - type: Physics
       canCollide: False
-- proto: PowerCellSmall
-  entities:
-  - uid: 45
-    components:
-    - type: Transform
-      parent: 40
-    - type: Battery
-      lastCharge: 360
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - battery
-    - type: Physics
-      canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@battery: !type:ContainerSlot
-          ent: 46
 - proto: PoweredSmallLight
   entities:
   - uid: 347
@@ -3753,16 +3482,8 @@ entities:
     components:
     - type: Transform
       parent: 19
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - steel
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        solution@steel: !type:ContainerSlot
-          ent: 21
 - proto: SignalControlledValve
   entities:
   - uid: 397
@@ -3964,14 +3685,6 @@ entities:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-- proto: TelecomServerCircuitboard
-  entities:
-  - uid: 26
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
 - proto: ToolboxMechanicalFilled
   entities:
   - uid: 53
@@ -4631,13 +4344,6 @@ entities:
     - type: DeviceNetwork
       address: 5BBA-9254
       receiveFrequency: 1280
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 220
     - type: Airlock
       powered: True
     - type: DoorBolt
@@ -4653,13 +4359,6 @@ entities:
     - type: DeviceNetwork
       address: 6001-209D
       receiveFrequency: 1280
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 222
     - type: Airlock
       powered: True
     - type: DoorBolt

--- a/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
+++ b/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
@@ -1737,22 +1737,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 1
-- proto: EncryptionKeyCargo
-  entities:
-  - uid: 24
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
-- proto: EncryptionKeyCommon
-  entities:
-  - uid: 25
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
 - proto: FaxMachineBase
   entities:
   - uid: 225
@@ -3126,14 +3110,6 @@ entities:
           - InputB
     - type: InsideEntityStorage
       storage: 214
-- proto: MatterBinStockPart
-  entities:
-  - uid: 38
-    components:
-    - type: Transform
-      parent: 34
-    - type: Physics
-      canCollide: False
 - proto: MedicalBed
   entities:
   - uid: 60
@@ -3476,14 +3452,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 13.5,6.5
       parent: 1
-- proto: SheetSteel1
-  entities:
-  - uid: 20
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
 - proto: SignalControlledValve
   entities:
   - uid: 397

--- a/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
+++ b/Resources/Maps/_DV/Nonstations/lavaland_mining_base.yml
@@ -4862,16 +4862,10 @@ entities:
 - proto: FaxMachineBase
   entities:
   - uid: 375
-    mapInit: true
-    paused: true
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-    - type: DeviceNetwork
-      address: 322E-6013
-      transmitFrequency: 2640
-      receiveFrequency: 2640
     - type: FaxMachine
       name: Mining Base
 - proto: FireExtinguisher


### PR DESCRIPTION
We've been experiencing a tenacious bug lately that "haunts" prototypes--partially initializes them during mapping for unknown reasons, rendering containers full of air and network devices that don't work right and causing containers to double their contents.

This caused the fax machine and air alarms on Lavaland to break.

I really don't understand what happened to the map saving systems, but, well, it all works again.

**Changelog**
:cl:
- fix: Fixed initialization issues with Lavaland's fax machine, air alarms, and containers.