### PR TITLE
tweak: slime character water damage

### DIFF
--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -185,7 +185,7 @@
       - !type:HealthChange
         damage:
           types:
-            Caustic: 0.05 # starcup: changed damage type from heat
+            Caustic: 0.15 # starcup: changed damage type from heat, raised from 0.05 to 0.15
       - !type:PopupMessage
         type: Local
         visualType: Large


### PR DESCRIPTION
Raised damage dealt by water to slime characters.

## Why / Balance
We felt that water was more of an inconvenience than a danger to slime characters.

## Technical details
- Raised caustic damage dealt by water from 0.05 to 0.15.

**Changelog**
:cl:
- tweak: Water deals more damage to slimes. Stay out of the mist!
