### PR TITLE
feat: adds Medical Needs and Security Flags record lines

### DIFF
--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml
@@ -76,6 +76,8 @@
                             <records:RecordLongItemDisplay Name="RecordContainerAllergies" Title="{Loc 'humanoid-profile-editor-cd-records-allergies'}"/>
                             <records:RecordLongItemDisplay Name="RecordContainerDrugAllergies" Title="{Loc 'humanoid-profile-editor-cd-records-drug-allergies'}"/>
                             <records:RecordLongItemDisplay Name="RecordContainerPostmortem" Title="{Loc 'humanoid-profile-editor-cd-records-postmortem'}"/>
+                            <!-- starcup Medical Needs -->
+                            <records:RecordLongItemDisplay Name="RecordContainerMedicalNeeds" Title="{Loc 'humanoid-profile-editor-cd-records-medical-needs'}"/>
                             <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                                 <Label Text="{Loc 'cd-character-records-viewer-record-med-sex'}"/>
                                 <Control HorizontalExpand="True" />
@@ -85,6 +87,8 @@
                         <!-- Security -->
                         <BoxContainer Name="RecordContainerSecurity" Orientation="Vertical" HorizontalExpand="True" Visible="False" >
                             <records:RecordLongItemDisplay Name="RecordContainerIdentFeatures" Title="{Loc 'humanoid-profile-editor-cd-records-identifying-features'}"/>
+                            <!-- starcup Security Flags -->
+                            <records:RecordLongItemDisplay Name="RecordContainerSecurityFlags" Title="{Loc 'humanoid-profile-editor-cd-records-security-flags'}"/>
                             <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                                 <Label Text="{Loc 'cd-character-records-viewer-record-sec-fingerprint'}"/>
                                 <Control HorizontalExpand="True" />

--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -398,6 +398,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         RecordContainerAllergies.SetValue(cr.Allergies);
         RecordContainerDrugAllergies.SetValue(cr.DrugAllergies);
         RecordContainerPostmortem.SetValue(cr.PostmortemInstructions);
+        RecordContainerMedicalNeeds.SetValue(cr.MedicalNeeds); // starcup
         RecordContainerSex.Text = record.Sex.ToString();
     }
 
@@ -405,6 +406,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
     {
         RecordContainerSecurity.Visible = true;
         RecordContainerIdentFeatures.SetValue(record.PRecords.IdentifyingFeatures);
+        RecordContainerIdentFeatures.SetValue(record.PRecords.SecurityFlags); // starcup
         RecordContainerFingerprint.Text = record.Fingerprint ?? Loc.GetString("cd-character-records-viewer-unknown");
         RecordContainerDNA.Text = record.DNA ?? Loc.GetString("cd-character-records-viewer-unknown");
 

--- a/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
+++ b/Content.Client/_CD/Records/UI/RecordEditorGui.xaml
@@ -44,6 +44,12 @@
                      <Control HorizontalExpand="True" />
                      <LineEdit Name="IdentifyingFeaturesEdit" HorizontalAlignment="Right" MinSize="350 0"/>
                  </BoxContainer>
+                    <!-- starcup Security Flags -->
+                 <BoxContainer Orientation="Horizontal">
+                     <Label Text="{Loc 'humanoid-profile-editor-cd-records-security-flags'}" />
+                     <Control HorizontalExpand="True" />
+                     <LineEdit Name="SecurityFlagsEdit" HorizontalAlignment="Right" MinSize="350 0"/>
+                 </BoxContainer>
                  <Control MinSize="0 20"/>
                  <!-- Medical stuff -->
                  <BoxContainer Orientation="Horizontal">
@@ -60,6 +66,12 @@
                      <Label Text="{Loc 'humanoid-profile-editor-cd-records-postmortem'}" />
                      <Control HorizontalExpand="True" />
                      <LineEdit Name="PostmortemEdit" HorizontalAlignment="Right" MinSize="350 0"/>
+                 </BoxContainer>
+                 <!-- starcup Medical Needs -->
+                 <BoxContainer Orientation="Horizontal">
+                     <Label Text="{Loc 'humanoid-profile-editor-cd-records-medical-needs'}" />
+                     <Control HorizontalExpand="True" />
+                     <LineEdit Name="MedicalNeedsEdit" HorizontalAlignment="Right" MinSize="350 0"/>
                  </BoxContainer>
                  <Control MinSize="0 20"/>
                  <!-- Entry editor -->

--- a/Content.Client/_CD/Records/UI/RecordEditorGui.xaml.cs
+++ b/Content.Client/_CD/Records/UI/RecordEditorGui.xaml.cs
@@ -69,6 +69,11 @@ public sealed partial class RecordEditorGui : Control
             UpdateRecords(_records.WithIdentifyingFeatures(args.Text));
         };
 
+        SecurityFlagsEdit.OnTextChanged += args => // starcup
+        {
+            UpdateRecords(_records.WithSecurityFlags(args.Text));
+        };
+
         #endregion
 
         #region Medical
@@ -86,6 +91,11 @@ public sealed partial class RecordEditorGui : Control
         PostmortemEdit.OnTextChanged += args =>
         {
             UpdateRecords(_records.WithPostmortemInstructions(args.Text));
+        };
+
+        MedicalNeedsEdit.OnTextChanged += args => // starcup
+        {
+            UpdateRecords(_records.WithMedicalNeeds(args.Text));
         };
 
         #endregion
@@ -150,10 +160,12 @@ public sealed partial class RecordEditorGui : Control
         WorkAuthCheckBox.Pressed = _records.HasWorkAuthorization;
 
         IdentifyingFeaturesEdit.SetText(_records.IdentifyingFeatures);
+        SecurityFlagsEdit.SetText(_records.SecurityFlags); // starcup
 
         AllergiesEdit.SetText(_records.Allergies);
         DrugAllergiesEdit.SetText(_records.DrugAllergies);
         PostmortemEdit.SetText(_records.PostmortemInstructions);
+        MedicalNeedsEdit.SetText(_records.MedicalNeeds); // starcup
     }
 
     private void UpdateImperialHeight(int newHeight)

--- a/Content.Server/_CD/Records/RecordsSerialization.cs
+++ b/Content.Server/_CD/Records/RecordsSerialization.cs
@@ -69,9 +69,11 @@ public static class RecordsSerialization
             emergencyContactName: DeserializeString(e, nameof(def.EmergencyContactName), def.EmergencyContactName),
             hasWorkAuthorization: DeserializeBool(e, nameof(def.HasWorkAuthorization), def.HasWorkAuthorization),
             identifyingFeatures: DeserializeString(e, nameof(def.IdentifyingFeatures), def.IdentifyingFeatures),
+            securityFlags: DeserializeString(e, nameof(def.SecurityFlags), def.SecurityFlags), // starcup
             allergies: DeserializeString(e, nameof(def.Allergies), def.Allergies),
             drugAllergies: DeserializeString(e, nameof(def.DrugAllergies), def.DrugAllergies),
             postmortemInstructions: DeserializeString(e, nameof(def.PostmortemInstructions), def.PostmortemInstructions),
+            medicalNeeds: DeserializeString(e, nameof(def.MedicalNeeds), def.MedicalNeeds), // starcup
             medicalEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Medical),
             securityEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Security),
             employmentEntries: DeserializeEntries(entries, CDModel.DbRecordEntryType.Employment),

--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -41,6 +41,9 @@ public sealed partial class PlayerProvidedCharacterRecords
     [DataField]
     public string IdentifyingFeatures { get; private set; }
 
+    [DataField] // starcup
+    public string SecurityFlags { get; private set; } = "N/A";
+
     // Medical
     [DataField]
     public string Allergies { get; private set; }
@@ -49,6 +52,8 @@ public sealed partial class PlayerProvidedCharacterRecords
     [DataField]
     public string PostmortemInstructions { get; private set; }
     // history, prescriptions, etc. would be a record below
+    [DataField] // starcup
+    public string MedicalNeeds { get; private set; } = "N/A";
 
     // "incidents"
     [DataField, JsonIgnore]
@@ -104,8 +109,10 @@ public sealed partial class PlayerProvidedCharacterRecords
         string birthday, // TheDen
         string emergencyContactName,
         string identifyingFeatures,
+        string securityFlags, // starcup
         string allergies, string drugAllergies,
         string postmortemInstructions,
+        string medicalNeeds, // starcup
         List<RecordEntry> medicalEntries,
         List<RecordEntry> securityEntries,
         List<RecordEntry> employmentEntries,
@@ -117,9 +124,11 @@ public sealed partial class PlayerProvidedCharacterRecords
         Birthday = birthday; // TheDen
         EmergencyContactName = emergencyContactName;
         IdentifyingFeatures = identifyingFeatures;
+        SecurityFlags = securityFlags; // starcup
         Allergies = allergies;
         DrugAllergies = drugAllergies;
         PostmortemInstructions = postmortemInstructions;
+        MedicalNeeds = medicalNeeds; // starcup
         MedicalEntries = medicalEntries;
         SecurityEntries = securityEntries;
         EmploymentEntries = employmentEntries;
@@ -134,9 +143,11 @@ public sealed partial class PlayerProvidedCharacterRecords
         EmergencyContactName = other.EmergencyContactName;
         HasWorkAuthorization = other.HasWorkAuthorization;
         IdentifyingFeatures = other.IdentifyingFeatures;
+        SecurityFlags = other.SecurityFlags; // starcup
         Allergies = other.Allergies;
         DrugAllergies = other.DrugAllergies;
         PostmortemInstructions = other.PostmortemInstructions;
+        MedicalNeeds = other.MedicalNeeds; // starcup
         MedicalEntries = other.MedicalEntries.Select(x => new RecordEntry(x)).ToList();
         SecurityEntries = other.SecurityEntries.Select(x => new RecordEntry(x)).ToList();
         EmploymentEntries = other.EmploymentEntries.Select(x => new RecordEntry(x)).ToList();
@@ -151,9 +162,11 @@ public sealed partial class PlayerProvidedCharacterRecords
             birthday: "N/A", // TheDen
             emergencyContactName: "",
             identifyingFeatures: "",
+            securityFlags: "", // starcup
             allergies: "None",
             drugAllergies: "None",
             postmortemInstructions: "Return home",
+            medicalNeeds: "", // starcup
             medicalEntries: new List<RecordEntry>(),
             securityEntries: new List<RecordEntry>(),
             employmentEntries: new List<RecordEntry>(),
@@ -170,9 +183,11 @@ public sealed partial class PlayerProvidedCharacterRecords
                    && Birthday == other.Birthday // TheDen
                    && HasWorkAuthorization == other.HasWorkAuthorization
                    && IdentifyingFeatures == other.IdentifyingFeatures
+                   && SecurityFlags == other.SecurityFlags // starcup
                    && Allergies == other.Allergies
                    && DrugAllergies == other.DrugAllergies
-                   && PostmortemInstructions == other.PostmortemInstructions;
+                   && PostmortemInstructions == other.PostmortemInstructions
+                   && MedicalNeeds == other.MedicalNeeds; // starcup
         if (!test)
             return false;
         if (MedicalEntries.Count != other.MedicalEntries.Count)
@@ -232,9 +247,11 @@ public sealed partial class PlayerProvidedCharacterRecords
         EmergencyContactName =
             ClampString(EmergencyContactName, TextMedLen);
         IdentifyingFeatures = ClampString(IdentifyingFeatures, TextMedLen);
+        SecurityFlags = ClampString(SecurityFlags, TextMedLen); // starcup
         Allergies = ClampString(Allergies, TextMedLen);
         DrugAllergies = ClampString(DrugAllergies, TextMedLen);
         PostmortemInstructions = ClampString(PostmortemInstructions, TextMedLen);
+        MedicalNeeds = ClampString(MedicalNeeds, TextMedLen); // starcup
 
         EnsureValidEntries(EmploymentEntries);
         EnsureValidEntries(MedicalEntries);
@@ -266,6 +283,12 @@ public sealed partial class PlayerProvidedCharacterRecords
     {
         return new(this) { IdentifyingFeatures = feat};
     }
+
+    public PlayerProvidedCharacterRecords WithSecurityFlags(string flags) // starcup
+    {
+        return new(this) { SecurityFlags = flags};
+    }
+
     public PlayerProvidedCharacterRecords WithAllergies(string s)
     {
         return new(this) { Allergies = s };
@@ -274,10 +297,17 @@ public sealed partial class PlayerProvidedCharacterRecords
     {
         return new(this) { DrugAllergies = s };
     }
+
     public PlayerProvidedCharacterRecords WithPostmortemInstructions(string s)
     {
         return new(this) { PostmortemInstructions = s};
     }
+
+    public PlayerProvidedCharacterRecords WithMedicalNeeds(string needs) // starcup
+    {
+        return new(this) { MedicalNeeds = needs};
+    }
+
     public PlayerProvidedCharacterRecords WithEmploymentEntries(List<RecordEntry> entries)
     {
         return new(this) { EmploymentEntries = entries};

--- a/Resources/Locale/en-US/_CD/records/editor.ftl
+++ b/Resources/Locale/en-US/_CD/records/editor.ftl
@@ -14,11 +14,15 @@ humanoid-profile-editor-cd-records-work-authorization = Work Authorization:
 
 # Security
 humanoid-profile-editor-cd-records-identifying-features = Identifying Features:
+# starcup - added Security Flags
+humanoid-profile-editor-cd-records-security-flags = Security Flags:
 
 # Medical
 humanoid-profile-editor-cd-records-allergies = Allergies:
 humanoid-profile-editor-cd-records-drug-allergies = Drug Allergies:
 humanoid-profile-editor-cd-records-postmortem = Postmortem Instructions:
+# starcup - added Medical Needs
+humanoid-profile-editor-cd-records-medical-needs = Medical Needs:
 
 # Admin
 # starcup: change name from admin to ooc


### PR DESCRIPTION
This PR adds two new lines to the basic Records tab: Medical Needs, aimed toward accommodations and prescriptions, and Security Flags, aimed toward important things for Security to know.

## Why / Balance
Security, Medical, and Command are still expected to review their crewmates' full record entries, of course! The intention of these lines is purely to provide quick summaries for easier browsing, giving some idea of what to look for when they do open the record entries.

I'd love a better records system in general--being able to pin or tag records, standardized built-in templates, etc--but for now, I think this would be a significant boost.

## Technical details
Adds two new sections to the Records tab.

## Media
<img width="1539" height="393" alt="image" src="https://github.com/user-attachments/assets/8b5e3ef1-55e3-4354-bacc-44325e3815a7" />

**Changelog**
:cl:
- add: Added two new fillable lines to the Records tab: Security Flags and Medical Needs!