### PR TITLE
fix: tomato killer vent horde misparenting

### DIFF
--- a/Resources/Prototypes/_starcup/GameRules/critters.yml
+++ b/Resources/Prototypes/_starcup/GameRules/critters.yml
@@ -816,7 +816,7 @@
 
 - type: entity
   id: TomatoKillerSpawnHordeLowPop
-  parent: LeechSpawnHorde
+  parent: TomatoKillerSpawnHorde
   components:
   - type: StationEvent
     minimumPlayers: 7


### PR DESCRIPTION
Tiny PR, just fixing a single line from https://github.com/teamstarcup/starcup/pull/899.

## Technical details
- Parented the low pop tomato killer vent horde event to its regular counterpart, not the charonic leech one.

**Changelog**
Not player facing
