### PR TITLE
fix: deconstructable vent dens

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -130,7 +130,7 @@
   parent: GasVentPumpInfested
   id: GasVentPumpPulsating
   name: pulsating vent
-  description: Twinging tendons are creeping out of it...
+  description: Twinging tendons are creeping out of it.
   components:
   - type: SubFloorHide
     visibleLayers:
@@ -231,6 +231,9 @@
         loop: true
     positional: true
     predicted: true
+  - type: Construction
+    graph: GasUnaryBroken
+    node: ventpumpden
 
 - type: entity
   parent: GasVentPumpInfested
@@ -277,6 +280,9 @@
         loop: true
     positional: true
     predicted: true
+  - type: Construction
+    graph: GasUnaryBroken
+    node: ventpumphivewasp
 
 - type: entity
   parent: GasVentPumpHiveWasp
@@ -306,3 +312,6 @@
     prototypes:
     - MobGiantSandwasp
     chance: 0.05
+  - type: Construction
+    graph: GasUnaryBroken
+    node: ventpumphivesandwasp

--- a/Resources/Prototypes/_starcup/Recipes/Construction/Graphs/utilities/atmos_unary.yml
+++ b/Resources/Prototypes/_starcup/Recipes/Construction/Graphs/utilities/atmos_unary.yml
@@ -20,3 +20,51 @@
       steps:
       - tool: Welding
         doAfter: 1
+
+  - node: ventpumpden
+    entity: GasVentPumpDen
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 1
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: ventpumphivewasp
+    entity: GasVentPumpHiveWasp
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 1
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: ventpumphivesandwasp
+    entity: GasVentPumpHiveSandwasp
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 1
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1


### PR DESCRIPTION
A few of the special vents introduced in https://github.com/teamstarcup/starcup/pull/899 were meant to be deconstructable but I forgot to add the nodes. Whoops!

## Why / Balance
Vent dens and hives are supposed to be deconstructable. Infested and pulsating vents are messed up beyond all repair and must be smashed.

## Technical details
- Added two graph nodes.

**Changelog**
:cl:
- fix: The broken vents, dens and hives left behind by intrusive vent fauna can now be deconstructed for repairs. Exomorph goop and aberrant flesh messes vents up beyond repair though, and the only recourse then is smashing.
