### PR TITLE
fix: remove "anomalyhreshold" typo

### DIFF
--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -70,7 +70,7 @@ public sealed partial class AnomalyComponent : Component
     /// If the <see cref="Stability"/> of the anomaly exceeds this value, it
     /// becomes too unstable to support itself and starts decreasing in <see cref="Health"/>.
     /// </summary>
-    [DataField("decayhreshold"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("decayThreshold"), ViewVariables(VVAccess.ReadWrite)]
     public float DecayThreshold = 0.15f;
 
     /// <summary>

--- a/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-shadow-valley-13x12.yml
+++ b/Resources/Maps/_starcup/Events/SilentMoonGrids/T3-shadow-valley-13x12.yml
@@ -113,7 +113,7 @@ entities:
       pos: 0.5010822,-2.1641045
       parent: 1
     - type: Anomaly
-      decayhreshold: 0.05
+      decayThreshold: 0.05
       cannotRandomPulse: True
       cannotSupercrit: True
     - type: ScaleVisuals

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
@@ -144,7 +144,7 @@
     maxPointsPerSecond: 10
     corePrototype: AnomaliteCore
     healthChangePerSecond: 0.0
-    decayhreshold: 9999.0
+    decayThreshold: 9999.0
     growthThreshold: 9999.0
   # apid-type always weightless movement
   - type: MovementAlwaysTouching


### PR DESCRIPTION
Fixes the "anomalyhreshold" datafield to be "anomalyThreshold", as intended. Fixes a map that invokes the datafield.

## Why / Balance
Obvious typo.

**Changelog**
No player-facing changes.