### PR TITLE
fix: restore no-spawn vent

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -1,4 +1,12 @@
 - type: entity
+  parent: GasVentPump
+  id: GasVentPumpNoSpawns
+  suffix: Pests Only
+  components:
+  - type: VentCritterSpawnLocation
+    canSpawn: false
+
+- type: entity
   parent: GasUnaryBase
   id: GasVentPumpBroken
   name: broken vent


### PR DESCRIPTION
At some point when making https://github.com/teamstarcup/starcup/pull/899 I misguidedly decided this wasn't necessary for some reason and removed it. It is now back.

## Technical details
- Restores a removed prototype.