### PR TITLE
fix: endless beetle apocalypse

### DIFF
--- a/Resources/Prototypes/_starcup/GameRules/critters.yml
+++ b/Resources/Prototypes/_starcup/GameRules/critters.yml
@@ -83,9 +83,13 @@
   - type: VentCrittersRule
     entries:
     - id: MobBeetleStag
+      prob: 0.02
     - id: MobBeetleRhino
+      prob: 0.02
     - id: MobBeetleJune
+      prob: 0.02
     - id: MobLadybug
+      prob: 0.02
 
 - type: entity
   id: MothroachMigration # starcup: renamed from MothroachSpawn


### PR DESCRIPTION
Beetle migration events were garanteed to spawn beetles on every vent. We had two in a single round. The beetlepocalypse was real.

Hotfix for https://github.com/teamstarcup/starcup/pull/899.