### PR TITLE
tweak: remove spider footsteps

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2948,7 +2948,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
-    - FootstepSound
+    #- FootstepSound # starcup: the new spider walking sounds made some of our players uncomfortable
     - CreatureEmotes # starcup
     - IgnoreTallGrass # starcup
   - type: Prying # Open door from xeno.yml.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2948,7 +2948,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
-    #- FootstepSound # starcup: the new spider walking sounds made some of our players uncomfortable
+    #- FootstepSound # starcup
     - CreatureEmotes # starcup
     - IgnoreTallGrass # starcup
   - type: Prying # Open door from xeno.yml.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -807,7 +807,7 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
-    #- FootstepSound # starcup: some players were uncomfortable with the footstep noise
+    #- FootstepSound # starcup
     - CreatureEmotes # starcup
   - type: StealTarget
     stealGroup: AnimalShiva

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -760,6 +760,10 @@
   - type: NpcFactionMember
     factions:
       - PetsNT
+      # begin starcup: bug politics real
+      - BugHunter
+      - GiantBugHunter
+      # end starcup
   - type: Sprite
     drawdepth: Mobs
     layers:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -760,10 +760,6 @@
   - type: NpcFactionMember
     factions:
       - PetsNT
-      # begin starcup: bug politics real
-      - BugHunter
-      - GiantBugHunter
-      # end starcup
   - type: Sprite
     drawdepth: Mobs
     layers:
@@ -811,7 +807,7 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
-    - FootstepSound
+    #- FootstepSound # starcup: some players were uncomfortable with the footstep noise
     - CreatureEmotes # starcup
   - type: StealTarget
     stealGroup: AnimalShiva


### PR DESCRIPTION
Makes spider walking be silent.

## Why / Balance
Some of our players were uncomfortable with the new spider footsteps sounds, so they were commented out in preparation for a future PR that expands the number of spiders (and situations they'll have to deal with them).

## Technical details
- Commented the footstep tag out of the base spider prototype as well as Shiva.

**Changelog**
:cl:
- tweak: Spiders will no longer make noises when they walk.
