### PR TITLE
fix: SyndComm flippo now defines its own access level

### DIFF
--- a/Resources/Prototypes/_starcup/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Tools/lighters.yml
@@ -9,3 +9,6 @@
     sprite: _starcup/Objects/Tools/Lighters/syndcomm.rsi
   - type: Item
     sprite: _starcup/Objects/Tools/Lighters/syndcomm.rsi
+  - type: Lock
+  - type: AccessReader
+    access: [["SyndicateCommunications"]]

--- a/Resources/Prototypes/_starcup/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Machines/vending_machines.yml
@@ -26,4 +26,4 @@
     energy: 1.6
     color: "#D9A336"
   - type: AccessReader
-    access: [["CentralCommand"]]
+    access: [["SyndicateCommunications"]]


### PR DESCRIPTION

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<!-- Delete this section if it isn't relevant. -->
Syndcomm flippo was parenting off the Centcomm flippo with no other changes besides changing which RSI it uses, and would inherit the Centcomm access level (despite being for Syndcomm), which is a problem.
## Technical details
<!-- Summary of code changes for easier review. -->
<!-- Delete this section if there aren't significant technical details. -->
Adds a couple lines (two or three, I think?) to the Syndcomm flippo's yml file to make it define its' own access level.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<!-- Delete this section if there's nothing to be shown. -->
[Before change](https://cdn.discordapp.com/attachments/1361214606592446645/1527917573419831358/Screenshot_2026-07-18_015841.png?ex=6a5c67a0&is=6a5b1620&hm=ba9646f2799a26d082ce763487cd9871d2d4b44ca36bb6466a592057b26f9797)
[After change](https://cdn.discordapp.com/attachments/1361214606592446645/1527919628653695077/Screenshot_2026-07-18_020657.png?ex=6a5c698a&is=6a5b180a&hm=57cc17c179a1e737668aa31d05db5095d08a8a3216b5fecccaa4d57e1c907ac1)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: SyndComm flippo lighters now use the correct access level.
