### PR TITLE
feat: adds alt-interact options for MKCs draining APCs and batteries

### DIFF
--- a/Content.Shared/Body/BodySystem.Relay.cs
+++ b/Content.Shared/Body/BodySystem.Relay.cs
@@ -24,6 +24,7 @@ public sealed partial class BodySystem
 
         // begin starcup
         SubscribeLocalEvent<BodyComponent, GetVerbsEvent<InnateVerb>>(RelayBodyEvent);
+        SubscribeLocalEvent<BodyComponent, GetVerbsEvent<AlternativeVerb>>(RelayBodyEvent);
         SubscribeLocalEvent<BodyComponent, LocalPlayerAttachedEvent>(RelayBodyEvent);
         SubscribeLocalEvent<BodyComponent, LocalPlayerDetachedEvent>(RelayBodyEvent);
         SubscribeLocalEvent<BodyComponent, RefreshMovementSpeedModifiersEvent>(RelayBodyEvent);

--- a/Content.Shared/_starcup/MKC/PowerDrinkableComponent.cs
+++ b/Content.Shared/_starcup/MKC/PowerDrinkableComponent.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._starcup.MKC;
+
+/// <summary>
+/// starcup: Indicates an entity which can be drained of electricity to refill a power core.
+/// </summary>
+/// <remarks>
+/// This is created to work around complexity with SharedInteractionSystem and event subscriptions.
+/// </remarks>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PowerDrinkableComponent : Component
+{
+
+}

--- a/Content.Shared/_starcup/MKC/PowerDrinkableComponent.cs
+++ b/Content.Shared/_starcup/MKC/PowerDrinkableComponent.cs
@@ -3,13 +3,12 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._starcup.MKC;
 
 /// <summary>
-/// starcup: Indicates an entity which can be drained of electricity to refill a power core.
+/// starcup: Put this component on an entity (that also has BatteryComponent) to give MKCs smooth interactions for
+/// draining power from it.
 /// </summary>
 /// <remarks>
-/// This is created to work around complexity with SharedInteractionSystem and event subscriptions.
+/// This was created to work around complexity with SharedInteractionSystem and event subscriptions. Entities that lack
+/// this component, but still have BatteryComponent, are still drainable with an "innate" verb.
 /// </remarks>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class PowerDrinkableComponent : Component
-{
-
-}
+public sealed partial class PowerDrinkableComponent : Component;

--- a/Content.Shared/_starcup/MKC/SharedPowerCoreSystem.cs
+++ b/Content.Shared/_starcup/MKC/SharedPowerCoreSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Body;
 using Content.Shared.DoAfter;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Power;
@@ -30,7 +31,6 @@ public abstract class SharedPowerCoreSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    private const float MaxEnergyDrainDistance = 32.0f;
     private readonly SoundSpecifier? _drainSounds = new SoundCollectionSpecifier("sparks");
 
     public override void Initialize()
@@ -39,6 +39,8 @@ public abstract class SharedPowerCoreSystem : EntitySystem
 
         SubscribeLocalEvent<PowerCoreComponent, MapInitEvent>(OnMapInit);
 
+        SubscribeLocalEvent<PowerDrinkableComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternativeVerbs);
+        SubscribeLocalEvent<PowerDrinkableComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<PowerCoreComponent, BodyRelayedEvent<GetVerbsEvent<InnateVerb>>>(AddEnergyDrainVerb);
         SubscribeLocalEvent<PowerCoreComponent, PowerCoreDoAfterEvent>(OnDoAfter);
 
@@ -104,6 +106,34 @@ public abstract class SharedPowerCoreSystem : EntitySystem
         return true;
     }
 
+    /// <summary>
+    /// Attempts to find the power core organ inside a mob.
+    /// </summary>
+    /// <param name="character">mob to search</param>
+    /// <param name="powerCore">power core organ</param>
+    /// <returns></returns>
+    private bool TryGetPowerCore(EntityUid character, [NotNullWhen(true)] out Entity<PowerCoreComponent>? powerCore)
+    {
+        powerCore = null;
+
+        if (!TryComp<BodyComponent>(character, out var body))
+            return false;
+
+        if (body.Organs == null)
+            return false;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!TryComp<PowerCoreComponent>(organ, out var comp))
+                continue;
+
+            powerCore = (organ, comp);
+            return true;
+        }
+
+        return false;
+    }
+
     private void UpdateMoveSpeedModifier(Entity<PowerCoreComponent> powerCore, ref BodyRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
         Entity<BatteryComponent?> battery = (powerCore.Owner, null);
@@ -129,11 +159,14 @@ public abstract class SharedPowerCoreSystem : EntitySystem
         if (!HasComp<BatteryComponent>(args.Args.Target))
             return;
 
+        if (HasComp<PowerDrinkableComponent>(args.Args.Target))
+            return;
+
         var target = args.Args.Target;
 
         InnateVerb verb = new()
         {
-            Act = () => StartDraining(powerCore, target),
+            Act = () => TryStartDraining(powerCore, target),
             Text = Loc.GetString("power-core-verb"),
             IconEntity = GetNetEntity(powerCore),
             Priority = 2,
@@ -141,18 +174,65 @@ public abstract class SharedPowerCoreSystem : EntitySystem
         args.Args.Verbs.Add(verb);
     }
 
-    private void StartDraining(Entity<PowerCoreComponent> powerCore, EntityUid target)
+    /// <summary>
+    /// Allows MKCs to use alt-E to drain from APCs and power cells.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="drinkable"></param>
+    /// <param name="args"></param>
+    private void OnAlternativeVerbs(EntityUid uid, PowerDrinkableComponent drinkable, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        if (!HasComp<BatteryComponent>(args.Target))
+            return;
+
+        if (!TryGetPowerCore(args.User, out var powerCore))
+            return;
+
+        var verb = new AlternativeVerb
+        {
+            Act = () => TryStartDraining(powerCore.Value, args.Target),
+            Text = Loc.GetString("power-core-verb"),
+            IconEntity = GetNetEntity(powerCore),
+            Priority = 3,
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    /// <summary>
+    /// Allows MKCs to hit Z or left-click on a handheld power cell to drain from it.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="args"></param>
+    private void OnUseInHand(Entity<PowerDrinkableComponent> entity, ref UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!HasComp<BatteryComponent>(entity))
+            return;
+
+        if (!TryGetPowerCore(args.User, out var powerCore))
+            return;
+
+        args.Handled = TryStartDraining(powerCore.Value, entity);
+    }
+
+    private bool TryStartDraining(Entity<PowerCoreComponent> powerCore, EntityUid target)
     {
         if (!TryGetContainingBody(powerCore, out var bodyUid))
-            return;
+            return false;
 
         Entity<BatteryComponent?> powerCoreBattery = (powerCore.Owner, null);
         if (!Resolve(powerCoreBattery, ref powerCoreBattery.Comp))
-            return;
+            return false;
 
         Entity<BatteryComponent?> targetBattery = (target, null);
         if (!Resolve(targetBattery, ref targetBattery.Comp))
-            return;
+            return false;
 
         if (_battery.IsFull(powerCoreBattery))
         {
@@ -161,7 +241,7 @@ public abstract class SharedPowerCoreSystem : EntitySystem
                 bodyUid.Value,
                 bodyUid.Value
                 );
-            return;
+            return false;
         }
 
         if (MathHelper.CloseToPercent(_battery.GetCharge(targetBattery), 0) && targetBattery.Comp.NetSyncEnabled)
@@ -171,18 +251,17 @@ public abstract class SharedPowerCoreSystem : EntitySystem
                 bodyUid.Value,
                 bodyUid.Value
                 );
-            return;
+            return false;
         }
 
         _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, bodyUid.Value, powerCore.Comp.Delay, new PowerCoreDoAfterEvent(), powerCore, target: target, used: powerCore)
         {
             DuplicateCondition = DuplicateConditions.SameEvent,
-            BreakOnMove = true,
+            BreakOnMove = false,
             BreakOnHandChange = false,
             BreakOnDamage = true,
-            MovementThreshold = 0.01f,
-            DistanceThreshold = MaxEnergyDrainDistance,
         });
+        return true;
     }
 
     private void OnDoAfter(Entity<PowerCoreComponent> powerCore, ref PowerCoreDoAfterEvent args)

--- a/Content.Shared/_starcup/MKC/SharedPowerCoreSystem.cs
+++ b/Content.Shared/_starcup/MKC/SharedPowerCoreSystem.cs
@@ -109,14 +109,14 @@ public abstract class SharedPowerCoreSystem : EntitySystem
     /// <summary>
     /// Attempts to find the power core organ inside a mob.
     /// </summary>
-    /// <param name="character">mob to search</param>
+    /// <param name="mob">mob to search</param>
     /// <param name="powerCore">power core organ</param>
     /// <returns></returns>
-    private bool TryGetPowerCore(EntityUid character, [NotNullWhen(true)] out Entity<PowerCoreComponent>? powerCore)
+    private bool TryGetPowerCore(EntityUid mob, [NotNullWhen(true)] out Entity<PowerCoreComponent>? powerCore)
     {
         powerCore = null;
 
-        if (!TryComp<BodyComponent>(character, out var body))
+        if (!TryComp<BodyComponent>(mob, out var body))
             return false;
 
         if (body.Organs == null)
@@ -175,7 +175,7 @@ public abstract class SharedPowerCoreSystem : EntitySystem
     }
 
     /// <summary>
-    /// Allows MKCs to use alt-E to drain from APCs and power cells.
+    /// Allows MKCs to use alt-E to drain from entities in the world.
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="drinkable"></param>
@@ -203,7 +203,7 @@ public abstract class SharedPowerCoreSystem : EntitySystem
     }
 
     /// <summary>
-    /// Allows MKCs to hit Z or left-click on a handheld power cell to drain from it.
+    /// Allows MKCs to hit Z or left-click on a held entity to drain from it.
     /// </summary>
     /// <param name="entity"></param>
     /// <param name="args"></param>

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -40,6 +40,7 @@
           Full: {visible: true, state: o2}
           Neither: {visible: true, state: o1}
           Empty: {visible: false}
+  - type: PowerDrinkable # starcup - MKC drainable
 
 - type: entity
   name: potato battery

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -160,6 +160,7 @@
     guides:
     - VoltageNetworks
     - Power
+  - type: PowerDrinkable # starcup - MKC drainable
 
 # APC under construction
 - type: entity


### PR DESCRIPTION
Thanks to @little-meow-meow for handling most of this task and guiding me through the rest!

This PR makes it so MKCs can now drain APCs and power cells by using Alt-E (for using a nearby target) or left-click/Z (for a handheld target).

MKCs can also move while draining now, although if they move too far away, they'll lose the doafer.

## Why / Balance
This was a nice feature IPCs had that we weren't able to include in the original MKC refactor.

## Technical details
- Added the new PowerDrinkable component to BaseAPC and BasePowerCell.
- Cleaned up SharedPowerCoreSystem and added OnUseInHand and OnAlternativeVerb interaction events that allow different interaction options when targeting entities with the above component. Entities which lack the component but have BatteryComponent should still work as before.
- Set BreakOnMove to False and removed the specified distance limits so they're set to the 1.5f default.

## Media
https://github.com/user-attachments/assets/19bd29e7-190a-4718-a1b2-55cb4f295b43

**Changelog**
:cl:
- add: MKCs can now drain power by using Alt-E on APCs and Alt-E, Z, and Left-Click on power cells.
- tweak: MKCs can now walk freely while they drain power cells.