### PR TITLE
fix: rat meat inhands hotfix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -486,6 +486,7 @@
     slice: FoodMeatCutlet
   - type: Item
     storedOffset: -2,1
+    sprite: Objects/Consumable/Food/meat.rsi
     inhandVisuals:
       left:
       - state: plain-inhand-left


### PR DESCRIPTION
Forgot to point the inhand sprites to the correct directory.