### PR TITLE
tweak: standardized and expanded winter wear

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -30,6 +30,8 @@
         color: "#9C0DE1"
   - type: Fiber
     fiberColor: fibers-purple
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Red Gloves
 - type: entity
@@ -59,6 +61,8 @@
         color: "#940000"
   - type: Fiber
     fiberColor: fibers-red
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Blue Gloves
 - type: entity
@@ -88,6 +92,8 @@
         color: "#0089EF"
   - type: Fiber
     fiberColor: fibers-blue
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Teal Gloves
 - type: entity
@@ -117,6 +123,8 @@
         color: "#3CB57C"
   - type: Fiber
     fiberColor: fibers-teal
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Brown Gloves
 - type: entity
@@ -146,6 +154,8 @@
         color: "#723A02"
   - type: Fiber
     fiberColor: fibers-brown
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Grey Gloves
 - type: entity
@@ -175,6 +185,8 @@
         color: "#999999"
   - type: Fiber
     fiberColor: fibers-grey
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Green Gloves
 - type: entity
@@ -204,6 +216,8 @@
         color: "#5ABF2F"
   - type: Fiber
     fiberColor: fibers-green
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Light Brown Gloves
 - type: entity
@@ -233,6 +247,8 @@
         color: "#C09F72"
   - type: Fiber
     fiberColor: fibers-light-brown
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Orange Gloves
 - type: entity
@@ -262,6 +278,8 @@
         color: "#EF8100"
   - type: Fiber
     fiberColor: fibers-orange
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # White Gloves
 - type: entity
@@ -291,6 +309,8 @@
         color: "#EAE8E8"
   - type: Fiber
     fiberColor: fibers-white
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Black Gloves
 # TECHNICALLY, if you ported the worn state to the RSI, this could be greyscaled, but I do not really feel like doing that.
@@ -316,6 +336,8 @@
     - id: ClothingHandsGlovesFingerless
   - type: Fiber
     fiberColor: fibers-black
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8
 
 # Insulated Gloves (Yellow Gloves)
 # Currently can not be greyscaled without looking like shit.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -645,6 +645,8 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: TemperatureProtection  # starcup: not quite as good as a scarf, but doesn't overheat you
+    coolingCoefficient: 0.8
 
 - type: entity
   parent: ClothingMaskNeckGaiter

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -115,6 +115,9 @@
     sprite: Clothing/OuterClothing/Coats/jensencoat.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodChaplainHood
+  - type: TemperatureProtection # starcup
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterCoatJensen
@@ -137,8 +140,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/trenchcoat.rsi
   - type: TemperatureProtection
-    heatingCoefficient: 0.1
-    coolingCoefficient: 0.1
+    heatingCoefficient: 1.1 # starcup - nerfed from 0.1 (why would it keep you cool?)
+    coolingCoefficient: 0.6  # starcup: nerf cold protection on winter coats (0.1 -> 0.6)
   - type: Armor
     modifiers:
       coefficients:
@@ -395,6 +398,9 @@
     sprite: Clothing/OuterClothing/Coats/windbreaker_paramedic.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/windbreaker_paramedic.rsi
+  - type: TemperatureProtection # starcup
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterStorageBase # starcup: remove syndicate contraband label
@@ -498,6 +504,9 @@
     sprite: Clothing/OuterClothing/Coats/expensive_coat.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/expensive_coat.rsi
+  - type: TemperatureProtection # starcup
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.6
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatExpensive]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -82,6 +82,9 @@
     sprite: Clothing/OuterClothing/Misc/black_hoodie.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/black_hoodie.rsi
+  - type: TemperatureProtection # starcup - hoodies warm you a little
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterBase
@@ -93,6 +96,9 @@
     sprite: Clothing/OuterClothing/Misc/grey_hoodie.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/grey_hoodie.rsi
+  - type: TemperatureProtection # starcup - hoodies warm you a little
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterBase
@@ -122,6 +128,9 @@
     sprite: Clothing/OuterClothing/Misc/chaplain_hoodie.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodChaplainHood
+  - type: TemperatureProtection # starcup - hoodies warm you a little
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.7
 
 - type: entity
   parent: ClothingOuterBase
@@ -135,6 +144,9 @@
     sprite: Clothing/OuterClothing/Misc/classicponcho.rsi
 #  - type: AddAccentClothing # DeltaV - remove clothing-forced accents
 #    accent: SpanishAccent
+  - type: TemperatureProtection # starcup - full ponchos warm you like coats
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.6
 
 - type: entity
   parent: ClothingOuterBase
@@ -170,6 +182,9 @@
     sprite: Clothing/OuterClothing/Misc/poncho.rsi
 #  - type: AddAccentClothing # DeltaV - remove clothing-forced accents
 #    accent: SpanishAccent
+  - type: TemperatureProtection # starcup - full ponchos warm you like coats
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.6
 
 - type: entity
   parent: ClothingOuterBase
@@ -181,6 +196,9 @@
     sprite: Clothing/OuterClothing/Misc/santa.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/santa.rsi
+  - type: TemperatureProtection # starcup - this is just a winter coat
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.6
 
 - type: entity
   abstract: true
@@ -325,8 +343,9 @@
         color: "#670a09"
       - state: equipped-OUTERCLOTHING-lines
         color: "#000000"
-  - type: TemperatureProtection
-    coolingCoefficient: 0.3
+  - type: TemperatureProtection # starcup - nerfed to be more like a coat
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.65
 
 - type: entity
   parent: ClothingOuterBase
@@ -361,8 +380,9 @@
         color: "#3232a6"
       - state: equipped-OUTERCLOTHING-lines
         color: "#000000"
-  - type: TemperatureProtection
-    coolingCoefficient: 0.3
+  - type: TemperatureProtection # starcup - nerfed to be more like a coat
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.65
 
 - type: entity
   parent: ClothingOuterBase
@@ -397,8 +417,9 @@
         color: "#164d0f"
       - state: equipped-OUTERCLOTHING-lines
         color: "#000000"
-  - type: TemperatureProtection
-    coolingCoefficient: 0.3
+  - type: TemperatureProtection # starcup - nerfed to be more like a coat
+    heatingCoefficient: 1.05
+    coolingCoefficient: 0.65
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
@@ -16,7 +16,7 @@
       default: ClothingOuterVest
     - type: TemperatureProtection # Same as a basic winter coat.
       heatingCoefficient: 1.1
-      coolingCoefficient: 0.1
+      coolingCoefficient: 0.6  # starcup: nerf cold protection on winter coats (0.1 -> 0.6)
     - type: Armor
       modifiers:
         coefficients:

--- a/Resources/Prototypes/_DEN/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_DEN/Entities/Clothing/Hands/gloves.yml
@@ -8,3 +8,5 @@
     sprite: _DEN/Clothing/Hands/Gloves/evening_gloves.rsi
   - type: Clothing
     sprite: _DEN/Clothing/Hands/Gloves/evening_gloves.rsi
+  - type: TemperatureProtection # starcup - cloth gloves keep you slightly warm
+    coolingCoefficient: 0.8

--- a/Resources/Prototypes/_DEN/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_DEN/Entities/Clothing/OuterClothing/coats.yml
@@ -8,6 +8,9 @@
     sprite: _DEN/Clothing/OuterClothing/Coats/victorian_coat.rsi
   - type: Clothing
     sprite: _DEN/Clothing/OuterClothing/Coats/victorian_coat.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.05 # starcup - not quite a winter coat
+    coolingCoefficient: 0.7 # starcup - but better than nothing
 
 - type: entity
   parent: ClothingOuterBase
@@ -19,3 +22,6 @@
     sprite: _DEN/Clothing/OuterClothing/Coats/victorian_coat_red.rsi
   - type: Clothing
     sprite: _DEN/Clothing/OuterClothing/Coats/victorian_coat_red.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.05 # starcup - not quite a winter coat
+    coolingCoefficient: 0.7 # starcup - but better than nothing

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/misc.yml
@@ -12,7 +12,7 @@
     size: Normal
   - type: TemperatureProtection
     heatingCoefficient: 1.1
-    coolingCoefficient: 0.1
+    coolingCoefficient: 0.65 # starcup - nerf to slightly better than a scarf, since it overheats you more
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/Longcoats/security.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/Longcoats/security.yml
@@ -26,6 +26,13 @@
   # begin starcup: examinable clothing
   - type: ExaminableClothing
     examineText: clothing-security-longcoat
+  - type: Armor # should be as good as an armored coat
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.85 # DeltaV - not as resistant as pre-rebase, but still better than nothing
+        Heat: 0.75
   # end starcup
 
 - type: entity
@@ -38,3 +45,11 @@
     sprite: _Floof/Clothing/OuterClothing/Longcoats/corpsman.rsi
   - type: Clothing
     sprite: _Floof/Clothing/OuterClothing/Longcoats/corpsman.rsi
+  - type: Armor # starcup - bring to parity with their armored medical gown
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.85
+        Piercing: 0.65
+        Heat: 0.85
+        Caustic: 0.75

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/misc.yml
@@ -10,8 +10,9 @@
     sprite: _DV/Clothing/Misc/hoodie_white.rsi
   - type: Clothing
     sprite: _DV/Clothing/Misc/hoodie_white.rsi
-  #- type: TemperatureProtection # starcup
-  #  coolingCoefficient: 0.4
+  - type: TemperatureProtection
+    heatingCoefficient: 1.05 # starcup
+    coolingCoefficient: 0.7 # starcup - 0.4 -> 0.7
 
 - type: entity
   parent: ClothingOuterWinterCoat # starcup: was ClothingOuterStorageBase
@@ -23,8 +24,9 @@
     sprite: _DV/Clothing/Misc/black_top_coat.rsi
   - type: Clothing
     sprite: _DV/Clothing/Misc/black_top_coat.rsi
-  #- type: TemperatureProtection # starcup
-  #  coolingCoefficient: 0.4
+  - type: TemperatureProtection
+    heatingCoefficient: 1.05 # starcup
+    coolingCoefficient: 0.7 # starcup - 0.4 -> 0.7
 
 - type: entity
   parent: ClothingOuterWinterCoat # starcup: was ClothingOuterStorageBase
@@ -36,5 +38,6 @@
     sprite: _DV/Clothing/Misc/black_jacket.rsi
   - type: Clothing
     sprite: _DV/Clothing/Misc/black_jacket.rsi
-  #- type: TemperatureProtection # starcup
-  #  coolingCoefficient: 0.4
+  - type: TemperatureProtection
+    heatingCoefficient: 1.05 # starcup
+    coolingCoefficient: 0.7 # starcup - 0.4 -> 0.7

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -5,7 +5,7 @@
   components:
   - type: TemperatureProtection
     heatingCoefficient: 1.1
-    coolingCoefficient: 0.1
+    coolingCoefficient: 0.6  # starcup: nerf cold protection on winter coats (0.1 -> 0.6)
   - type: Item
     size: Normal
   - type: Armor


### PR DESCRIPTION
This PR is a mix of fixes, nerfs, and buffs.
- Fixed Detective/Combat Medic longcoats having the wrong armor levels
- Nerfed various winter wear to be roughly equivalent to winter coats, including neck ponchos and armored winter coats.
- Trench coats no longer protect you from heat. (??)
- Gave lots of clothes cold resistance, including neck gaiters, old-fashioned coats, jensen coats, colored gloves, ponchos, santa suits, hoodies, windbreakers, and expensive coats.

## Why / Balance
These are mostly fixes; when we nerfed winter coats and boots, we missed a few items, and we've added more clothes since then that don't exactly follow starcup standards.

I would rather have proper mittens than just cold resistance to all colored gloves, but this feels fine for now. The other items just make sense to provide some protection, and it expands player options when assembling an ensemble for Glacier or Ptarmigan.

**Changelog**
:cl:
- fix: Standardized cold protection levels on various overpowered winterwear, including trench coats and armored coats.
- tweak: Gaiters, colored gloves, and various coats now provide some cold protection!
- fix: Fixed some Security personnel's winterwear not providing the proper armored protection!