### PR TITLE
map(ptarmigan): remove Ptarmigan from map pool

### DIFF
--- a/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
+++ b/Resources/Prototypes/_starcup/FeedbackPopup/feedbackpopups.yml
@@ -78,7 +78,7 @@
     If you have any thoughts on this map or noticed something wrong, let us know on our forum!
   responseType: "Forum Thread"
   responseLink: "https://forum.starcup.cc/t/ptarmigan-station-feedback-thread/455"
-  showRoundEnd: true
+  showRoundEnd: false
 
 - type: feedbackPopup
   id: FeedbackPopupMapReach

--- a/Resources/Prototypes/_starcup/Maps/ptarmigan.yml
+++ b/Resources/Prototypes/_starcup/Maps/ptarmigan.yml
@@ -4,8 +4,8 @@
   mapPath: /Maps/_starcup/ptarmigan.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 0
-  maxPlayers: 15
+  minPlayers: 50 # starcup: 0->50, too buggy for regular use at the moment, fine for events.
+  maxPlayers: 51 # starcup: 15-51, changed to prevent errors
   stations:
     Ptarmigan:
       stationProto: StandardTerrestrialStationTradingSnowy


### PR DESCRIPTION
Ptarmigan's minimum player count has been increased to 50, ensuring it will be impossible for starcup players, at least, to vote for it in a typical round. GMs will still be able to force the map manually, same as Loop.

## Why / Balance
Ptarmigan has buggy ore generation, cluttered evac landing sites, and unwanted warm weather. It is completely unable to run all but a handful of odd events, making it useless for any non-curated gamemodes except Empty and possibly Calm. Tiles can't be placed back down, frustrating players who want to decorate, rebuild, or construct paths to important destinations. Shuttles cause massive errorspam if you try to view the docking UI while on the planet surface.

Ptarmigan is unsuitable for play except when GMs can be involved to address these myriad issues. It will serve fine as an event-only map, I hope. I am very sad about this, but it's a matter of our basic standard of quality. Ptarmigan simply doesn't meet them. The terrestrial station experiment is, for the time being, a failure.

**Changelog**
:cl:
- remove: Ptarmigan Outpost has been removed for the foreseeable future from all shift rotations due to safety concerns.