### PR TITLE
fix: reinforced steel wood wall rust replacement

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Walls/walls.yml
@@ -80,7 +80,6 @@
         node: reinforcedWall
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: ReinforcedWallReplacementMarker
   - type: StaticPrice
     price: 250
   - type: RadiationBlocker


### PR DESCRIPTION
Reinforced steel wood walls were errantly replaced by rusted steel walls during a roundstart variation pass rule. This corrects that.

References impstation/imp-station-14#4535

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Reinforced steel wood walls are no longer replaced by rusted reinforced steel walls at round start.
