### PR TITLE
tweak: boost evac vote time, expedition time, and lobby time

### DIFF
--- a/Resources/ConfigPresets/starcup/starcup.toml
+++ b/Resources/ConfigPresets/starcup/starcup.toml
@@ -16,8 +16,8 @@ defaultpreset = "Calm"
 # time after docking at syndcomm before returning to lobby
 round_restart_time = 1200
 
-# time in lobby before the next game starts
-lobbyduration = 300
+# time in lobby before the next game starts (changed from 300 to an 11-minute timer)
+lobbyduration = 660
 
 [server]
 id = "starcup"
@@ -46,8 +46,8 @@ space_wind = true
 arrivals = false
 emergency_early_launch_allowed = true
 
-# the percentage of time passed from the initial call to when the shuttle can no longer be recalled
-recall_turning_point = 0.2
+# the percentage of time passed from the initial call to when the shuttle can no longer be recalled (decreased from 0.5)
+recall_turning_point = 0.01
 
 # time before the evac shuttle leaves after docking
 emergency_dock_time = 300
@@ -57,6 +57,10 @@ auto_call_time = 120
 
 # how big a shuttle can be before it can't FTL (increased from 300 for Reach)
 mass_limit = 1000
+
+[salvage]
+# letting expeditions last longer (increased from 660)
+expedition_duration = 960
 
 [admin]
 see_own_notes   = true


### PR DESCRIPTION
This PR makes the following CVar changes:
- **Lobby time** (the time between rounds) increased from 5 minutes -> **11 minutes**
- **Expedition time** increased from 11 minutes -> **16 minutes**
- **Evac shuttle recall cutoff time** decreased from 2 minutes to **6 seconds**.

This means players will have more time to spend between rounds, on salvage expeditions, and before voting to recall the evac shuttle.

Expedition countdown music should trigger at the same time, and the cooldown is unchanged.

## Why / Balance
Our players are chatty after rounds, and the "recovery period" after a particularly intense shift really takes longer than five minutes for us. Admins are always delaying the next round anyways, so this just makes it easier.

Expeditions being rushed for Salvagers doesn't really encourage them to take along friends or chat along the way, which isn't ideal for a prosocial RP experience.

The cutoff for evac doesn't serve much purpose for us aside from putting pressure on Command (and GMs). Ideally, there would be a warning at the 2-minute mark or so that the shuttle will be arriving soon, but that's out of scope here.

## Technical details
- `lobbyduration = 660` (from 300)
- `recall_turning_point = 0.01` (from 0.2)
- `expedition_duration = 960` (from 660)

## Test plan
No tests seem necessary to me, these are all known mechanics and the changes are minor. Expeditions are particularly tedious to test, too. If someone wants to double-check, just run an expedition, make sure the announcements/countdown music are at the correct times, and see if the disk-printing cooldown not being changed causes any issues.


## Changelog
:cl:
- tweak: Lobby times, expedition durations, and evac recall cutoffs modified by x2, x1.5, and *0.005, respectively!