### PR TITLE
fix: update outdated solution containers

### DIFF
--- a/Resources/Maps/_starcup/Events/event-glacier-vacation.yml
+++ b/Resources/Maps/_starcup/Events/event-glacier-vacation.yml
@@ -21132,17 +21132,15 @@ entities:
       rot: -6.283185307179586 rad
       pos: -0.35275316,-9.408485
       parent: 2
-    - type: SolutionContainerManager
+    - type: Solution
       solutions:
-        beaker:
-          temperature: 293.15
-          canReact: True
-          maxVol: 50
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Cryoxadone
-            Quantity: 50
+        temperature: 293.15
+        canReact: True
+        maxVol: 50
+        name: null
+        reagents:
+        - ReagentId: Cryoxadone
+          Quantity: 50
 - proto: Bed
   entities:
   - uid: 1355
@@ -87502,17 +87500,15 @@ entities:
       rot: -6.283185307179586 rad
       pos: -0.5884385,-9.248528
       parent: 2
-    - type: SolutionContainerManager
+    - type: Solution
       solutions:
-        beaker:
-          temperature: 293.15
-          canReact: True
-          maxVol: 100
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Cryoxadone
-            Quantity: 100
+        temperature: 293.15
+        canReact: True
+        maxVol: 100
+        name: null
+        reagents:
+        - ReagentId: Cryoxadone
+          Quantity: 100
 - proto: LeftArmHuman
   entities:
   - uid: 12656

--- a/Resources/Maps/_starcup/Events/event-glacier-vacation.yml
+++ b/Resources/Maps/_starcup/Events/event-glacier-vacation.yml
@@ -21133,7 +21133,7 @@ entities:
       pos: -0.35275316,-9.408485
       parent: 2
     - type: Solution
-      solutions:
+      solution:
         temperature: 293.15
         canReact: True
         maxVol: 50
@@ -87501,7 +87501,7 @@ entities:
       pos: -0.5884385,-9.248528
       parent: 2
     - type: Solution
-      solutions:
+      solution:
         temperature: 293.15
         canReact: True
         maxVol: 100

--- a/Resources/Maps/_starcup/freighter.yml
+++ b/Resources/Maps/_starcup/freighter.yml
@@ -61634,18 +61634,6 @@ entities:
 
 
         And for the rest... all the shredded walls should do a nice job of protecting everything, but there should be plenty of surplus materials. Whole area is going to be a huge radiation hazard but just let everyone know and it'll be alright!
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
-    - type: EmitSoundOnCollide
-      nextSound: -3522.4964775
     - type: Fixtures
       fixtures:
         fix1:

--- a/Resources/Maps/_starcup/glacier.yml
+++ b/Resources/Maps/_starcup/glacier.yml
@@ -23072,17 +23072,12 @@ entities:
     - type: Transform
       pos: -0.344872,-9.4933405
       parent: 2
-    - type: SolutionContainerManager
-      solutions:
-        beaker:
-          temperature: 293.15
-          canReact: True
-          maxVol: 50
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Cryoxadone
-            Quantity: 50
+    - type: Solution
+      solution:
+        maxVol: 50
+        reagents:
+        - ReagentId: Cryoxadone
+          Quantity: 50
   - uid: 17529
     components:
     - type: Transform
@@ -97889,7 +97884,7 @@ entities:
       pos: -0.6750982,-9.144404
       parent: 2
     - type: Solution
-      solutions:
+      solution:
         maxVol: 100
         reagents:
         - ReagentId: Cryoxadone

--- a/Resources/Maps/_starcup/glacier.yml
+++ b/Resources/Maps/_starcup/glacier.yml
@@ -71292,10 +71292,7 @@ entities:
     - type: Transform
       pos: -33.657883,12.666442
       parent: 2
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - food
+    - type: Solution
     - type: EmitSoundOnCollide
       nextSound: -3000.4971662
     - type: ContainerContainer
@@ -71503,16 +71500,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71536,16 +71524,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71569,16 +71548,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - white
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71602,16 +71572,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - white
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71635,16 +71596,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71668,16 +71620,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71701,16 +71644,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - white
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71734,16 +71668,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71767,16 +71692,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - white
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71800,16 +71716,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71833,16 +71740,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - icon
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -71866,16 +71764,7 @@ entities:
         enum.DamageStateVisualLayers.Base:
         - white
         - null
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: TemperatureDamage
       lastUpdate: -0.4668329
     - type: InternalTemperature
@@ -97999,17 +97888,12 @@ entities:
     - type: Transform
       pos: -0.6750982,-9.144404
       parent: 2
-    - type: SolutionContainerManager
+    - type: Solution
       solutions:
-        beaker:
-          temperature: 293.15
-          canReact: True
-          maxVol: 100
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Cryoxadone
-            Quantity: 100
+        maxVol: 100
+        reagents:
+        - ReagentId: Cryoxadone
+          Quantity: 100
 - proto: LightBulb
   entities:
   - uid: 12915
@@ -99871,16 +99755,7 @@ entities:
     components:
     - type: Transform
       parent: 8162
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: EmitSoundOnCollide
       nextSound: -3000.4971662
     - type: Physics
@@ -108226,16 +108101,7 @@ entities:
         Sorgy. N e ed them. Important.
 
          - Honkers[/color]
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 0
-          name: food
-          reagents: []
-      containers:
-      - food
+    - type: Solution
     - type: EmitSoundOnCollide
       nextSound: -725.2962767
     - type: Fixtures
@@ -116979,10 +116845,7 @@ entities:
     components:
     - type: Transform
       parent: 20921
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - food
+    - type: Solution
     - type: MeleeWeapon
       nextAttack: -44.8667875
     - type: EmitSoundOnCollide

--- a/Resources/Maps/_starcup/ptarmigan.yml
+++ b/Resources/Maps/_starcup/ptarmigan.yml
@@ -38433,12 +38433,16 @@ entities:
     components:
     - type: Transform
       parent: 6634
+    - type: Physics
+      canCollide: False
     - type: InsideEntityStorage
       storage: 6634
   - uid: 6637
     components:
     - type: Transform
       parent: 6636
+    - type: Physics
+      canCollide: False
     - type: InsideEntityStorage
       storage: 6636
 - proto: ClothingOuterHardsuitEngineering
@@ -52488,6 +52492,16 @@ entities:
       pos: 14.5,18.5
       parent: 2
     - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: AccessReader
+      accessListsOriginal:
+      - - Detective
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -52495,12 +52509,23 @@ entities:
           occludes: True
           ents:
           - 6635
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
   - uid: 6636
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 2
     - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -52508,6 +52533,10 @@ entities:
           occludes: True
           ents:
           - 6637
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: LockerEngineerFilledHardsuit
   entities:
   - uid: 8623

--- a/Resources/Maps/_starcup/ptarmigan.yml
+++ b/Resources/Maps/_starcup/ptarmigan.yml
@@ -38427,20 +38427,20 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
       storage: 4902
-#- proto: ClothingOuterCoatStasecDet
-#  entities:
-#  - uid: 6635
-#    components:
-#    - type: Transform
-#      parent: 6634
-#    - type: InsideEntityStorage
-#      storage: 6634
-#  - uid: 6637
-#    components:
-#    - type: Transform
-#      parent: 6636
-#    - type: InsideEntityStorage
-#      storage: 6636
+- proto: ClothingOuterCoatStasecDet
+  entities:
+  - uid: 6635
+    components:
+    - type: Transform
+      parent: 6634
+    - type: InsideEntityStorage
+      storage: 6634
+  - uid: 6637
+    components:
+    - type: Transform
+      parent: 6636
+    - type: InsideEntityStorage
+      storage: 6636
 - proto: ClothingOuterHardsuitEngineering
   entities:
   - uid: 6595
@@ -52487,27 +52487,27 @@ entities:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
-#    - type: EntityStorage
-#    - type: ContainerContainer
-#      containers:
-#        entity_storage: !type:Container
-#          showEnts: False
-#          occludes: True
-#          ents:
-#          - 6635
+    - type: EntityStorage
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 6635
   - uid: 6636
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 2
-#    - type: EntityStorage
-#    - type: ContainerContainer
-#      containers:
-#        entity_storage: !type:Container
-#          showEnts: False
-#          occludes: True
-#          ents:
-#          - 6637
+    - type: EntityStorage
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 6637
 - proto: LockerEngineerFilledHardsuit
   entities:
   - uid: 8623

--- a/Resources/Maps/_starcup/ptarmigan.yml
+++ b/Resources/Maps/_starcup/ptarmigan.yml
@@ -38427,20 +38427,20 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
       storage: 4902
-- proto: ClothingOuterCoatStasecDet
-  entities:
-  - uid: 6635
-    components:
-    - type: Transform
-      parent: 6634
-    - type: InsideEntityStorage
-      storage: 6634
-  - uid: 6637
-    components:
-    - type: Transform
-      parent: 6636
-    - type: InsideEntityStorage
-      storage: 6636
+#- proto: ClothingOuterCoatStasecDet
+#  entities:
+#  - uid: 6635
+#    components:
+#    - type: Transform
+#      parent: 6634
+#    - type: InsideEntityStorage
+#      storage: 6634
+#  - uid: 6637
+#    components:
+#    - type: Transform
+#      parent: 6636
+#    - type: InsideEntityStorage
+#      storage: 6636
 - proto: ClothingOuterHardsuitEngineering
   entities:
   - uid: 6595
@@ -52487,27 +52487,27 @@ entities:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
-    - type: EntityStorage
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 6635
+#    - type: EntityStorage
+#    - type: ContainerContainer
+#      containers:
+#        entity_storage: !type:Container
+#          showEnts: False
+#          occludes: True
+#          ents:
+#          - 6635
   - uid: 6636
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 2
-    - type: EntityStorage
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 6637
+#    - type: EntityStorage
+#    - type: ContainerContainer
+#      containers:
+#        entity_storage: !type:Container
+#          showEnts: False
+#          occludes: True
+#          ents:
+#          - 6637
 - proto: LockerEngineerFilledHardsuit
   entities:
   - uid: 8623

--- a/Resources/Maps/_starcup/ptarmigan.yml
+++ b/Resources/Maps/_starcup/ptarmigan.yml
@@ -38433,16 +38433,12 @@ entities:
     components:
     - type: Transform
       parent: 6634
-    - type: Physics
-      canCollide: False
     - type: InsideEntityStorage
       storage: 6634
   - uid: 6637
     components:
     - type: Transform
       parent: 6636
-    - type: Physics
-      canCollide: False
     - type: InsideEntityStorage
       storage: 6636
 - proto: ClothingOuterHardsuitEngineering
@@ -52492,16 +52488,6 @@ entities:
       pos: 14.5,18.5
       parent: 2
     - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
-    - type: AccessReader
-      accessListsOriginal:
-      - - Detective
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -52509,23 +52495,12 @@ entities:
           occludes: True
           ents:
           - 6635
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 6636
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 2
     - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -52533,10 +52508,6 @@ entities:
           occludes: True
           ents:
           - 6637
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: LockerEngineerFilledHardsuit
   entities:
   - uid: 8623

--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -8483,16 +8483,12 @@ entities:
     - type: Transform
       pos: 7.7243433,-13.122412
       parent: 2
-  - type: Solution
-    solution:
-      temperature: 293.15
-      canReact: True
-      maxVol: 50
-      name: null
-      reagents:
-      - data: null
-        ReagentId: Leporazine
-        Quantity: 40
+    - type: Solution
+      solution:
+        maxVol: 50
+        reagents:
+        - ReagentId: Leporazine
+          Quantity: 40
   - uid: 533
     components:
     - type: Transform

--- a/Resources/Maps/_starcup/saltern.yml
+++ b/Resources/Maps/_starcup/saltern.yml
@@ -8483,17 +8483,16 @@ entities:
     - type: Transform
       pos: 7.7243433,-13.122412
       parent: 2
-    - type: SolutionContainerManager
-      solutions:
-        beaker:
-          temperature: 293.15
-          canReact: True
-          maxVol: 50
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Leporazine
-            Quantity: 40
+  - type: Solution
+    solution:
+      temperature: 293.15
+      canReact: True
+      maxVol: 50
+      name: null
+      reagents:
+      - data: null
+        ReagentId: Leporazine
+        Quantity: 40
   - uid: 533
     components:
     - type: Transform

--- a/Resources/Maps/_starcup/shoukou.yml
+++ b/Resources/Maps/_starcup/shoukou.yml
@@ -9074,17 +9074,16 @@ entities:
     - type: Transform
       pos: -7.3135357,-4.6884913
       parent: 2
-    - type: SolutionContainerManager
-      solutions:
-        beaker:
-          temperature: 293.15
-          canReact: True
-          maxVol: 50
-          name: null
-          reagents:
-          - data: null
-            ReagentId: TableSalt
-            Quantity: 25
+    - type: Solution
+      solution:
+        temperature: 293.15
+        canReact: True
+        maxVol: 50
+        name: null
+        reagents:
+        - data: null
+          ReagentId: TableSalt
+          Quantity: 25
   - uid: 606
     components:
     - type: Transform

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -143,13 +143,12 @@
         Slash: 0.95
   - type: Edible
     requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 20
+  - type: Solution
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Fiber
+        Quantity: 20
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -143,12 +143,13 @@
         Slash: 0.95
   - type: Edible
     requiresSpecialDigestion: true
-  - type: Solution
-    solution:
-      maxVol: 20
-      reagents:
-      - ReagentId: Fiber
-        Quantity: 20
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 20
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -127,7 +127,7 @@
         id: SyndieHandyFlag
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, TemperatureProtection ] # starcup: temp protection
+  parent: [ ClothingOuterJacketBase, TemperatureProtection ] # starcup: temp protection
   id: ClothingOuterCoatTrench
   name: trench coat
   description: A comfy trench coat.
@@ -141,15 +141,6 @@
     modifiers:
       coefficients:
         Slash: 0.95
-  - type: Edible
-    requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 20
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -171,11 +171,10 @@
   - type: Sprite
     state: COOKIE!!!
   # begin starcup: add theobromine
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 6
-        reagents:
+  - type: Solution
+    solution:
+      maxVol: 15
+      reagents:
         - ReagentId: Nutriment
           Quantity: 5
         - ReagentId: Theobromine

--- a/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -3,13 +3,12 @@
   id: DrinkJaegermisterGlass
   suffix: jaegermister
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Jaegermister
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Jaegermister
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/jaegermister.rsi
     state: icon
@@ -19,13 +18,12 @@
   id: DrinkJaegerbombGlass
   suffix: jaegerbomb
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Jaegerbomb
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Jaegerbomb
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/jaegerbomb.rsi
     state: icon
@@ -35,13 +33,12 @@
   id: DrinkJaegeritaGlass
   suffix: jaegerita
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Jaegerita
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Jaegerita
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/jaegerita.rsi
     state: icon
@@ -51,13 +48,12 @@
   id: DrinkSurferGlass
   suffix: surfer
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Surfer
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Surfer
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/surfer.rsi
     state: icon
@@ -67,13 +63,12 @@
   id: DrinkSurferOnAcidGlass
   suffix: surfer on acid
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: SurferOnAcid
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: SurferOnAcid
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/surferonacid.rsi
     state: icon
@@ -83,13 +78,12 @@
   id: DrinkFizzballGlass
   suffix: fizzball
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Fizzball
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Fizzball
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/fizzball.rsi
     state: icon
@@ -99,13 +93,12 @@
   id: DrinkTuxedoSunsetGlass
   suffix: tuxedo sunset
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: TuxedoSunset
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: TuxedoSunset
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/tuxedosunset.rsi
     state: icon
@@ -115,13 +108,12 @@
   id: DrinkInsideScoopGlass
   suffix: inside scoop
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: InsideScoop
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: InsideScoop
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/insidescoop.rsi
     state: icon
@@ -131,13 +123,12 @@
   id: DrinkFizzballFloatGlass
   suffix: fizzball float
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: FizzballFloat
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: FizzballFloat
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/fizzballfloat.rsi
     state: icon
@@ -147,13 +138,12 @@
   id: DrinkChartruseGlass
   suffix: chartruse
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Chartruse
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Chartruse
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/chartruse.rsi
     state: icon
@@ -163,13 +153,12 @@
   id: DrinkDeathFlipGlass
   suffix: death flip
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: DeathFlip
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: DeathFlip
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/deathflip.rsi
     state: icon
@@ -179,13 +168,12 @@
   id: DrinkBloodyJaegerGlass
   suffix: bloody jaeger
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BloodyJaeger
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BloodyJaeger
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/bloodyjaeger.rsi
     state: icon
@@ -195,13 +183,12 @@
   id: DrinkPopQuizGlass
   suffix: pop quiz
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: PopQuiz
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: PopQuiz
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/popquiz.rsi
     state: icon
@@ -211,13 +198,12 @@
   id: DrinkNaughtyBartenderGlass
   suffix: naughty bartender
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: NaughtyBartender
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: NaughtyBartender
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/naughtybartender.rsi
     state: icon
@@ -227,29 +213,27 @@
   id: DrinkAtlanticOceanGlass
   suffix: atlantic ocean
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: AtlanticOcean
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: AtlanticOcean
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/atlanticocean.rsi
     state: icon
-    
+
 - type: entity
   parent: DrinkGlass
   id: DrinkCafeCocktailGlass
   suffix: cafe cocktail
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CafeCocktail
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CafeCocktail
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/cafecocktail.rsi
     state: icon
@@ -259,13 +243,12 @@
   id: DrinkCinnamonCookieGlass
   suffix: cinnamon cookie
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CinnamonCookie
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CinnamonCookie
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/cinnamoncookie.rsi
     state: icon
@@ -275,13 +258,12 @@
   id: DrinkBloodRedLicoriceGlass
   suffix: blood-red-licorice
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BloodRedLicorice
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BloodRedLicorice
+        Quantity: 30
   - type: Icon
     sprite: _DEN/Objects/Consumable/Drinks/blood-redlicorice.rsi
     state: icon

--- a/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -4,12 +4,12 @@
   name: jaegermister bottle
   description: A bittersweet alcohol that hasn't changed its recipe in nearly a thousand years.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Jaegermister
-          Quantity: 100
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 100
+      reagents:
+      - ReagentId: Jaegermister
+        Quantity: 100
   - type: Label
     localizedLabel: reagent-name-jaegermister
   - type: Sprite

--- a/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -6,7 +6,6 @@
   components:
   - type: Solution # starcup - remove SolutionContainerManager
     solution:
-      maxVol: 100
       reagents:
       - ReagentId: Jaegermister
         Quantity: 100

--- a/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Consumable/Food/candy.yml
@@ -15,15 +15,14 @@
     tags:
     - FoodSnack
     - Candy
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
-        - ReagentId: Sugar
-          Quantity: 3
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 2
+      - ReagentId: Sugar
+        Quantity: 3
   - type: RandomSprite
     available:
     - enum.DamageStateVisualLayers.Base:
@@ -46,15 +45,14 @@
     state: worm
   - type: Item
     size: Normal
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-        - ReagentId: Sugar
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 10
+      - ReagentId: Sugar
+        Quantity: 10
 
 ## Larj bar
 
@@ -86,19 +84,18 @@
     state: unwrapped
   - type: Item
     size: Normal
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 30
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 9
-        - ReagentId: Sugar
-          Quantity: 6
-        - ReagentId: Theobromine
-          Quantity: 6
-        - ReagentId: CocoaPowder
-          Quantity: 3
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 9
+      - ReagentId: Sugar
+        Quantity: 6
+      - ReagentId: Theobromine
+        Quantity: 6
+      - ReagentId: CocoaPowder
+        Quantity: 3
   - type: ToolRefinable
     refineResult:
     - id: FoodSnackChocolateBarLarjChunk
@@ -115,19 +112,18 @@
     state: chunk
   - type: Item
     size: Small
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 10
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 3
-        - ReagentId: Sugar
-          Quantity: 2
-        - ReagentId: Theobromine
-          Quantity: 2
-        - ReagentId: CocoaPowder
-          Quantity: 1
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 10
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 3
+      - ReagentId: Sugar
+        Quantity: 2
+      - ReagentId: Theobromine
+        Quantity: 2
+      - ReagentId: CocoaPowder
+        Quantity: 1
   - type: ToolRefinable
     refineResult:
     - id: FoodSnackChocolateBarLarjPiece
@@ -144,19 +140,18 @@
     state: chunk_small
   - type: Item
     size: Tiny
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 3
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 0.75
-        - ReagentId: Sugar
-          Quantity: 0.5
-        - ReagentId: Theobromine
-          Quantity: 0.5
-        - ReagentId: CocoaPowder
-          Quantity: 0.25
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 3
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 0.75
+      - ReagentId: Sugar
+        Quantity: 0.5
+      - ReagentId: Theobromine
+        Quantity: 0.5
+      - ReagentId: CocoaPowder
+        Quantity: 0.25
 
 ## Hard candies + wrapper
 
@@ -175,15 +170,14 @@
     tags:
     - FoodSnack
     - Candy
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
-        - ReagentId: Sugar
-          Quantity: 3
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 2
+      - ReagentId: Sugar
+        Quantity: 3
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Melee/spear.yml
@@ -58,10 +58,9 @@
     slots:
     - back
     - suitStorage
-  - type: SolutionContainerManager
-    solutions:
-      melee:
-        maxVol: 1
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 1
   - type: MeleeChemicalInjector
     solution: melee
   - type: RefillableSolution

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, TemperatureProtection ] # upstream: temperature protection
+  parent: [ClothingOuterJacketBase, AllowSuitStorageClothing, TemperatureProtection ] # upstream: temperature protection, Jacket parent
   id: ClothingOuterArmoredWinterCoat
   components:
   - type: Item
@@ -102,13 +102,6 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/detcoat.rsi
   - type: Clothing
     sprite: _DV/Clothing/OuterClothing/WinterCoats/detcoat.rsi
-  - type: Solution # starcup - trying to clear some weird errors, no way this works but
-    id: food
-    solution:
-      maxVol: 30
-      reagents:
-      - ReagentId: Fiber
-        Quantity: 30
 
 - type: entity
   parent: ClothingOuterWinterCoatLong

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -14,13 +14,12 @@
         Heat: 0.75
   - type: Edible
     requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 30
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Fiber
+        Quantity: 30
   - type: Tag
     tags:
     - ClothMade

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -12,14 +12,14 @@
         Slash: 0.75
         Piercing: 0.75
         Heat: 0.75
-  - type: Edible
-    requiresSpecialDigestion: true
-  - type: Solution # starcup - remove SolutionContainerManager
-    solution:
-      maxVol: 30
-      reagents:
-      - ReagentId: Fiber
-        Quantity: 30
+#  - type: Edible # starcup - unnecessary with reparenting to Jacket
+#    requiresSpecialDigestion: true
+#  - type: Solution
+#    solution:
+#      maxVol: 30
+#      reagents:
+#      - ReagentId: Fiber
+#        Quantity: 30
   - type: Tag
     tags:
     - ClothMade

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -103,8 +103,8 @@
   - type: Clothing
     sprite: _DV/Clothing/OuterClothing/WinterCoats/detcoat.rsi
   - type: Solution # starcup - trying to clear some weird errors, no way this works but
+    id: food
     solution:
-      id: food
       maxVol: 30
       reagents:
       - ReagentId: Fiber

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -102,6 +102,13 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/detcoat.rsi
   - type: Clothing
     sprite: _DV/Clothing/OuterClothing/WinterCoats/detcoat.rsi
+  - type: Solution # starcup - trying to clear some weird errors, no way this works but
+    solution:
+      id: food
+      maxVol: 30
+      reagents:
+      - ReagentId: Fiber
+        Quantity: 30
 
 - type: entity
   parent: ClothingOuterWinterCoatLong

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -7,10 +7,9 @@
     sound:
       collection: bottleOpenSounds #Could use a new sound someday ¯\_(ツ)_/¯
   - type: Sealable
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 20
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
   - type: Item
     size: Small
   - type: MeleeWeapon
@@ -52,12 +51,11 @@
   name: orange juice box
   description: A great source of vitamins. Stay healthy!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: JuiceOrange
-          Quantity: 20
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: JuiceOrange
+        Quantity: 20
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/juiceboxorange.rsi
 
@@ -67,12 +65,11 @@
   name: pineapple juice box
   description: Everyone's favourite juice.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: JuicePineapple
-          Quantity: 20
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: JuicePineapple
+        Quantity: 20
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/juiceboxpineapple.rsi
 
@@ -82,12 +79,11 @@
   name: apple juice box
   description: Sweet apple juice. Don't be late for school!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: JuiceApple
-          Quantity: 20
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: JuiceApple
+        Quantity: 20
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/juiceboxapple.rsi
 
@@ -97,12 +93,11 @@
   name: grape juice box
   description: Tasty grape juice in a fun little container. Non-alcoholic!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: JuiceGrape
-          Quantity: 20
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: JuiceGrape
+        Quantity: 20
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/juiceboxgrape.rsi
 
@@ -112,13 +107,12 @@
   name: chocolate milk juice box
   description: Tasty chocolate juice and milk in a small box. Contains Theobromine.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: HotCocoa
-          Quantity: 10
-        - ReagentId: Milk # The milk of chocolate milk
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: HotCocoa
+        Quantity: 10
+      - ReagentId: Milk # The milk of chocolate milk
+        Quantity: 10
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/juiceboxchocolate.rsi

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -231,8 +231,8 @@
     solution:
       maxVol: 30
       reagents:
-    - ReagentId: ArsonistsBrew
-      Quantity: 30
+      - ReagentId: ArsonistsBrew
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/arsonist.rsi
     state: icon

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -4,13 +4,12 @@
   suffix: orange creamcicle
   description: Orangy, creamy goodness.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: OrangeCreamice
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: OrangeCreamice
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/orangecreamcicle.rsi
     state: icon
@@ -21,13 +20,12 @@
   suffix: silverjack
   description: Reminds you of family.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Silverjack
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Silverjack
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/silverjack.rsi
     state: icon
@@ -38,13 +36,12 @@
   suffix: brainbomb
   description: Toxic to about anything alive, especially your liver.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Brainbomb
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Brainbomb
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/brainbomb.rsi
     state: icon
@@ -55,13 +52,12 @@
   suffix: clown blood
   description: A mixture invented by a famed clown who wanted a yummier choice for fake blood. # starcup: rewritten for tone
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: ClownBlood
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: ClownBlood
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/clownblood.rsi
     state: icon
@@ -72,13 +68,12 @@
   suffix: circus juice
   description: One day, a clown managed to sneak their way into an Interdyne chemical lab. This was the result. # starcup: rewritten for tone
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CircusJuice
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CircusJuice
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/circusjuice.rsi
     state: icon
@@ -89,13 +84,12 @@
   suffix: sapo picante
   description: Tastes nothing like a toad.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: SapoPicante
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: SapoPicante
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/sapopicante.rsi
     state: icon
@@ -106,13 +100,12 @@
   suffix: graveyard
   description: For those shifts that never seem to end.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Graveyard
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Graveyard
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/graveyard.rsi
     state: icon
@@ -123,13 +116,12 @@
   suffix: atomic punch
   description: Will NOT make you immune to bullets; Isotopes included!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: AtomicPunch
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: AtomicPunch
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/atomicpunch.rsi
     state: icon
@@ -140,13 +132,12 @@
   suffix: pink drink
   description: Entire civilizations have crumbled trying to decide if this drink really tastes like pink...
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: PinkDrink
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: PinkDrink
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/pinkdrink.rsi
     state: icon
@@ -157,13 +148,12 @@
   suffix: bubble tea
   description: Big straw not included.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BubbleTea
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BubbleTea
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/bubbletea.rsi
     state: icon
@@ -173,13 +163,12 @@
   suffix: health code violation
   description: Allegedly it's a cocktail. The warning cone motif seems apt.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: HealthViolation
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: HealthViolation
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/healthcodeviolation.rsi
     state: icon
@@ -190,13 +179,12 @@
   suffix: gunmetal
   description: A cloudy mix of rum, cream, and... is that welding fuel? Probably tasty.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Gunmetal
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Gunmetal
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/gunmetal.rsi
     state: icon
@@ -207,13 +195,12 @@
   suffix: lemon drop
   description: A martini glass filled with a translucent mix of refreshing lemony goodness.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: LemonDrop
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: LemonDrop
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/lemondrop.rsi
     state: icon
@@ -224,13 +211,12 @@
   suffix: green grass
   description: An odd green cocktail, topped with oranges, ice, and a plastic straw. Curious.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: GreenGrass
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: GreenGrass
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/greengrass.rsi
     state: icon
@@ -241,13 +227,12 @@
   suffix: arsonist's brew
   description: It's probably not concerning that it's glowing faintly. Or bubbling. Or smoking. No, not at all.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: ArsonistsBrew
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+    - ReagentId: ArsonistsBrew
+      Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/arsonist.rsi
     state: icon
@@ -258,13 +243,12 @@
   suffix: kvass
   description: A sweet-and-sour grain alcohol, mellow enough to replace cola in some cultures. # starcup: rewritten for tone
   components:
-    - type: SolutionContainerManager
-      solutions:
-        drink:
-          maxVol: 30
-          reagents:
-            - ReagentId: Kvass
-              Quantity: 30
+    - type: Solution # starcup - remove SolutionContainerManager
+      solution:
+        maxVol: 30
+        reagents:
+        - ReagentId: Kvass
+          Quantity: 30
     - type: Icon
       sprite: _DV/Objects/Consumable/Drinks/kvass.rsi
       state: icon
@@ -275,13 +259,12 @@
   suffix: mothamphetamine
   description: A strangely... Fuzzy drink. It has a chaotic aura.
   components:
-    - type: SolutionContainerManager
-      solutions:
-        drink:
-          maxVol: 30
-          reagents:
-            - ReagentId: Mothamphetamine
-              Quantity: 30
+    - type: Solution # starcup - remove SolutionContainerManager
+      solution:
+        maxVol: 30
+        reagents:
+        - ReagentId: Mothamphetamine
+          Quantity: 30
     - type: Icon
       sprite: _DV/Objects/Consumable/Drinks/mothamphetamine.rsi
       state: icon
@@ -291,13 +274,12 @@
   id: DoubleIceCreamGlass
   suffix: double ice cream
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: DoubleIceCream
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: DoubleIceCream
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/doubleicecreamglass.rsi
     state: icon
@@ -307,13 +289,12 @@
   id: LemonLimeBittersGlass
   suffix: lemon lime bitters
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: LemonLimeBitters
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: LemonLimeBitters
+        Quantity: 30
   - type: Icon
     sprite: _DV/Objects/Consumable/Drinks/lemonlimebitters.rsi
     state: icon

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -6,7 +6,6 @@
   components:
   - type: Solution # starcup - remove SolutionContainerManager
     solution:
-      maxVol: 100
       reagents:
       - ReagentId: Soju
         Quantity: 100

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -4,12 +4,12 @@
   name: soju bottle
   description: It's like sake but if you're trying to get FUCKED. UP.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Soju
-          Quantity: 100
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 100
+      reagents:
+      - ReagentId: Soju
+        Quantity: 100
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/sojubottle.rsi
 
@@ -19,13 +19,12 @@
   name: tokkuri
   description: Floral and full of osake!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 100
-        reagents:
-        - ReagentId: Sake
-          Quantity: 100
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 100
+      reagents:
+      - ReagentId: Sake
+        Quantity: 100
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/saketokkuri.rsi
 
@@ -35,12 +34,11 @@
   name: flask of holy water
   description: A flask of holy water.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Holywater
-          Quantity: 100
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: Holywater
+        Quantity: 100
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/flaskholywater.rsi
 - type: entity
@@ -49,12 +47,11 @@
   name: angobitters bottle
   description: Commonly used for mixed drinks, not drunk neat.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Angobitters
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: Angobitters
+        Quantity: 50
   - type: Label
     localizedLabel: reagent-name-angobitters
   - type: Sprite

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -4,12 +4,11 @@
   name: Dr. Gibb Blood Red can
   description:  A drink to quench YOUR bloodthirst.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: DrGibbBloodRed
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: DrGibbBloodRed
+        Quantity: 30
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/drgibbbloodred.rsi

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -4,12 +4,11 @@
   name: sakazuki
   description: A ceremonial white cup for drinking sake.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Sake
-          Quantity: 20
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: Sake
+        Quantity: 20
   - type: Sprite
     sprite: _DV/Objects/Consumable/Drinks/sakecup.rsi
     state: icon

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/powdered_drinks.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/powdered_drinks.yml
@@ -278,13 +278,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#A9536C"
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceCherry
-          Quantity: 50
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceCherry
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -299,13 +298,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFA06B"
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceCarrot
-          Quantity: 50
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceCarrot
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -320,10 +318,9 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#D85553"
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceTomato
-          Quantity: 50
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceTomato
+        Quantity: 50

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/powdered_drinks.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/powdered_drinks.yml
@@ -279,7 +279,7 @@
     - state: overlay-container
       color: "#A9536C"
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 50
       reagents:
       - ReagentId: PowderedJuiceCherry
@@ -299,7 +299,7 @@
     - state: overlay-container
       color: "#FFA06B"
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 50
       reagents:
       - ReagentId: PowderedJuiceCarrot
@@ -319,7 +319,7 @@
     - state: overlay-container
       color: "#D85553"
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 50
       reagents:
       - ReagentId: PowderedJuiceTomato

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/powdered_drinks.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Drinks/powdered_drinks.yml
@@ -58,13 +58,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFC420"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceOrange
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceOrange
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -79,11 +78,10 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FAFAFA"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
         - ReagentId: PowderedMilk
           Quantity: 50
 
@@ -100,11 +98,10 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFFCE3"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
         - ReagentId: PowderedMilkSoy
           Quantity: 50
 
@@ -121,11 +118,10 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#B4FF64"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
         - ReagentId: PowderedJuiceLime
           Quantity: 50
 
@@ -142,13 +138,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFFC69"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceLemon
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceLemon
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -163,13 +158,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFD644"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuicePineapple
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuicePineapple
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -184,13 +178,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFFEBF"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceBanana
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceBanana
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -205,13 +198,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#D366FF"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceBerry
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceBerry
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -226,13 +218,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFBCDB"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceWatermelon
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceWatermelon
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -247,13 +238,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#E57DFF"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceGrape
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceGrape
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase
@@ -268,13 +258,12 @@
       map: ["enum.OpenableVisuals.Layer"]
     - state: overlay-container
       color: "#FFC67E"
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 50
-        reagents:
-        - ReagentId: PowderedJuiceApple
-          Quantity: 50
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: PowderedJuiceApple
+        Quantity: 50
 
 - type: entity
   parent: ReagentTinBase

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Food/meat.yml
@@ -2,11 +2,10 @@
   parent: FoodMeatSnake
   id: FoodMeatSnakeSilvia
   components:
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 8
-        - ReagentId: Omnizine
-          Quantity: 8
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 8
+      - ReagentId: Omnizine
+        Quantity: 8

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Food/ration.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Food/ration.yml
@@ -65,13 +65,12 @@
   - type: Item
   - type: Sprite
     sprite: _DV/Objects/Consumable/Food/ration.rsi
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 15
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 15
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 15
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 15
   - type: Tag
     tags:
     - Fruit # DeltaV - Allow anyone to eat it, hopefully

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -4,15 +4,14 @@
   suffix: olive
   description: A roll of tobacco and nicotine soaked in some chemical, smells like olives.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      smokable:
-        maxVol: 15
-        reagents:
-          - ReagentId: Nicotine
-            Quantity: 10
-          - ReagentId: OilOlive
-            Quantity: 5
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 15
+      reagents:
+      - ReagentId: Nicotine
+        Quantity: 10
+      - ReagentId: OilOlive
+        Quantity: 5
 
 - type: entity
   parent: [Cigarette, FoodBase]
@@ -28,15 +27,9 @@
   - type: FlavorProfile
     flavors:
     - sweet
-  - type: SolutionContainerManager
+  - type: Solution
     solutions:
-      smokable:
-        maxVol: 10
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 10
-      food:
-        maxVol: 10
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 10
+      maxVol: 20
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 20

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -27,9 +27,12 @@
   - type: FlavorProfile
     flavors:
     - sweet
-  - type: SolutionManager # starcup - remove SolutionContainerManager (I tried to figure out splitting food/smoke; didn't work out)
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      maxVol: 20
+      maxVol: 10
       reagents:
       - ReagentId: Sugar
-        Quantity: 20
+        Quantity: 10
+  - type: SolutionManager # starcup
+    solutions:
+    - SolutionCandy

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -27,7 +27,7 @@
   - type: FlavorProfile
     flavors:
     - sweet
-  - type: Solution
+  - type: SolutionManager # starcup - remove SolutionContainerManager (I tried to figure out splitting food/smoke; didn't work out)
     solutions:
       maxVol: 20
       reagents:

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -28,7 +28,7 @@
     flavors:
     - sweet
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 10
       reagents:
       - ReagentId: Sugar

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
@@ -9,13 +9,12 @@
     pillType: 9
   - type: Label
     localizedLabel: pill-label-serenitol-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Serenitol
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Serenitol
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -42,13 +41,12 @@
     pillType: 7
   - type: Label
     localizedLabel: pill-label-neurozenium-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Neurozenium
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Neurozenium
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -75,13 +73,12 @@
     pillType: 1
   - type: Label
     localizedLabel: pill-label-equilibrazine-5u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Equilibrazine
-          Quantity: 5
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Equilibrazine
+        Quantity: 5
 
 - type: entity
   parent: PillCanister
@@ -108,13 +105,12 @@
     pillType: 6
   - type: Label
     localizedLabel: pill-label-blissifylovene-5u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Blissifylovene
-          Quantity: 5
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Blissifylovene
+        Quantity: 5
 
 - type: entity
   parent: PillCanister
@@ -141,13 +137,12 @@
     pillType: 14
   - type: Label
     localizedLabel: pill-label-calmafluxine-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Calmafluxine
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Calmafluxine
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -174,13 +169,12 @@
     pillType: 15
   - type: Label
     localizedLabel: pill-label-tranquinase-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Tranquinase
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Tranquinase
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -207,13 +201,12 @@
     pillType: 2
   - type: Label
     localizedLabel: pill-label-stubantazine-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Stubantazine
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Stubantazine
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -240,13 +233,12 @@
     state: pill15
   - type: Label
     localizedLabel: pill-label-soretizone-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Soretizone
-          Quantity: 10
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Soretizone
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -273,13 +265,12 @@
     pillType: 19
   - type: Label
     localizedLabel: pill-label-agonolexyne-5u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Agonolexyne
-          Quantity: 5
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Agonolexyne
+        Quantity: 5
 
 - type: entity
   parent: PillCanister

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Species/felinid.yml
@@ -8,13 +8,12 @@
     sprite: _DV/Objects/Specific/Species/felinid.rsi
     state: icon
   - type: Hairball
-  - type: SolutionContainerManager
-    solutions:
-      hairball:
-        maxVol: 25
-        reagents:
-        - ReagentId: Protein
-          Quantity: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 25
+      reagents:
+      - ReagentId: Protein
+        Quantity: 2
   - type: Extractable
     grindableSolutionName: hairball
   - type: Tag

--- a/Resources/Prototypes/_DV/Entities/Structures/Storage/Crates/barrel.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Storage/Crates/barrel.yml
@@ -151,7 +151,7 @@
   - type: Label
     localizedLabel: reagent-name-beer
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       reagents:
       - ReagentId: Beer
         Quantity: 500
@@ -165,7 +165,7 @@
   - type: Label
     localizedLabel: reagent-name-wine
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       reagents:
       - ReagentId: Wine
         Quantity: 500

--- a/Resources/Prototypes/_DV/Entities/Structures/Storage/Crates/barrel.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Storage/Crates/barrel.yml
@@ -150,12 +150,11 @@
   components:
   - type: Label
     localizedLabel: reagent-name-beer
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      tank:
-        reagents:
-        - ReagentId: Beer
-          Quantity: 500
+      reagents:
+      - ReagentId: Beer
+        Quantity: 500
 
 - type: entity
   parent: WoodenKeg
@@ -165,9 +164,8 @@
   components:
   - type: Label
     localizedLabel: reagent-name-wine
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      tank:
-        reagents:
-        - ReagentId: Wine
-          Quantity: 500
+      reagents:
+      - ReagentId: Wine
+        Quantity: 500

--- a/Resources/Prototypes/_DV/Entities/Structures/Storage/Crates/barrel.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Storage/Crates/barrel.yml
@@ -77,10 +77,9 @@
   name: wooden keg
   description: A musty old wooden keg, with a tap attached to the front.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      tank:
-        maxVol: 500
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 500
   - type: ExaminableSolution
     solution: tank
   - type: UserInterface
@@ -137,12 +136,11 @@
   components:
   - type: Label
     localizedLabel: reagent-name-root-beer
-  - type: SolutionContainerManager
-    solutions:
-      tank:
-        reagents:
-        - ReagentId: RootBeer
-          Quantity: 500
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: RootBeer
+        Quantity: 500
 
 - type: entity
   parent: WoodenKeg

--- a/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -56,17 +56,16 @@
     node: doubleFrosted
   - type: Sprite
     state: double
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 130
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 72
-        - ReagentId: Sugar
-          Quantity: 36
-        - ReagentId: Vitamin
-          Quantity: 12
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 130
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 72
+      - ReagentId: Sugar
+        Quantity: 36
+      - ReagentId: Vitamin
+        Quantity: 12
   - type: ToolRefinable
     refineResult:
     - id: FoodCakeTieredSlice

--- a/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -94,7 +94,7 @@
   - type: Sprite
     state: triple
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 200
       reagents:
       - ReagentId: Nutriment
@@ -117,7 +117,7 @@
     sprite: _Floof/Objects/Consumable/Food/Baked/cake_tiered.rsi
     state: slice
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 15
       reagents:
       - ReagentId: Nutriment

--- a/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -93,17 +93,16 @@
     node: tripleFrosted
   - type: Sprite
     state: triple
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      food:
-        maxVol: 200
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 108
-        - ReagentId: Sugar
-          Quantity: 54
-        - ReagentId: Vitamin
-          Quantity: 18
+      maxVol: 200
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 108
+      - ReagentId: Sugar
+        Quantity: 54
+      - ReagentId: Vitamin
+        Quantity: 18
   - type: ToolRefinable
     refineResult:
     - id: FoodCakeTieredSlice
@@ -117,14 +116,13 @@
   - type: Sprite
     sprite: _Floof/Objects/Consumable/Food/Baked/cake_tiered.rsi
     state: slice
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      food:
-        maxVol: 15
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: Vitamin
-          Quantity: 1
+      maxVol: 15
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 6
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: Vitamin
+        Quantity: 1

--- a/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Consumable/Food/ingredients.yml
@@ -12,12 +12,11 @@
   - type: Sprite
     sprite: _Floof/Objects/Consumable/Food/ingredients.rsi
     state: frosting-pipe
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 24
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 4
-        - ReagentId: Sugar
-          Quantity: 15
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 24
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 4
+      - ReagentId: Sugar
+        Quantity: 15

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
@@ -500,7 +500,8 @@
       types:
         Radiation: 0
   # end starcup
-  - type: Solution # starcup - remove SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager, add id
+    id: anomaly
     solution:
       maxVol: 1500
   - type: MeleeChemicalInjector

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
@@ -500,10 +500,9 @@
       types:
         Radiation: 0
   # end starcup
-  - type: SolutionContainerManager
-    solutions:
-      anomaly:
-        maxVol: 1500
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 1500
   - type: MeleeChemicalInjector
     solution: anomaly
     transferAmount: 6

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -3,13 +3,12 @@
   id: DrinkLovePotionGlass
   suffix: love potion
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: LovePotion
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: LovePotion
+        Quantity: 30
   - type: Icon
     sprite: _Impstation/Objects/Consumable/Drinks/lovepotion.rsi
     state: icon

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -12,10 +12,9 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: fill-
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 30
   - type: PhysicalComposition
     materialComposition:
       Plastic: 30
@@ -26,12 +25,11 @@
   name: orange Asterade™ bottle
   description: Ostensibly healthy for you. The label says "Outrageous Orange"
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: OrangeAsterade
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: OrangeAsterade
+        Quantity: 30
 
 - type: entity
   parent: DrinkAsteradeBottleFull
@@ -39,12 +37,12 @@
   name: purple Asterade™ bottle
   description: Ostensibly healthy for you. The label says "Boisterous Berry"
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: PurpleAsterade
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 100
+      reagents:
+      - ReagentId: PurpleAsterade
+        Quantity: 30
 
 - type: entity
   parent: DrinkAsteradeBottleFull
@@ -52,12 +50,11 @@
   name: red Asterade™ bottle
   description: Ostensibly healthy for you. The label says "Wild Watermelon"
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: RedAsterade
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: RedAsterade
+        Quantity: 30
 
 - type: entity
   parent: DrinkAsteradeBottleFull
@@ -65,12 +62,11 @@
   name: green Asterade™ bottle
   description: Ostensibly healthy for you. The label says "Lightning Lime"
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: GreenAsterade
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: GreenAsterade
+        Quantity: 30
 
 - type: entity
   parent: DrinkAsteradeBottleFull
@@ -78,12 +74,11 @@
   name: yellow Asterade™ bottle
   description: Ostensibly healthy for you. The label says "Preposterous Pineapple"
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: YellowAsterade
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: YellowAsterade
+        Quantity: 30
 
 - type: entity
   parent: DrinkAsteradeBottleFull
@@ -91,10 +86,9 @@
   name: lemon Asterade™ bottle
   description: Ostensibly healthy for you. The label says "Tesloose Lemon"
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
         - ReagentId: LemonAsterade
           Quantity: 30
 
@@ -104,9 +98,8 @@
   name: brown Asterade™ bottle
   description: Ostensibly healthy for you. The label has been scratched off and "Potato" has been written with a marker in its place.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: BrownAsterade
-          Quantity: 30
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: BrownAsterade
+        Quantity: 30

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -39,7 +39,6 @@
   components:
   - type: Solution # starcup - remove SolutionContainerManager
     solution:
-      maxVol: 100
       reagents:
       - ReagentId: PurpleAsterade
         Quantity: 30

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/candy.yml
@@ -18,13 +18,12 @@
     available:
     - enum.DamageStateVisualLayers.Base:
         chalkheartcolorable: Pastel
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 2 # starcup - allows tiny injections
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 1
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 2 # starcup - allows tiny injections
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 1
   - type: RandomMetadata
     descriptionSegments: [ConversationHeartDescriptions]
   - type: Tag
@@ -64,17 +63,16 @@
     sprite: _Impstation/Objects/Consumable/Food/candy.rsi
     layers:
     - state: chocolateheart
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 2
-        - ReagentId: CocoaPowder
-          Quantity: 2
-        - ReagentId: Theobromine
-          Quantity: 1
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 2
+      - ReagentId: CocoaPowder
+        Quantity: 2
+      - ReagentId: Theobromine
+        Quantity: 1
   - type: Tag
     tags:
     - FoodSnack
@@ -150,17 +148,16 @@
     sprite: _Impstation/Objects/Consumable/Food/candy.rsi
     layers:
     - state: homemadechocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 15 # extra space for poison purposes
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 2
-        - ReagentId: CocoaPowder
-          Quantity: 2
-        - ReagentId: Theobromine
-          Quantity: 1
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 15 # extra space for poison purposes
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 2
+      - ReagentId: CocoaPowder
+        Quantity: 2
+      - ReagentId: Theobromine
+        Quantity: 1
 
 - type: entity
   name: berry macaron
@@ -173,15 +170,14 @@
   - type: Sprite
     sprite: _Impstation/Objects/Consumable/Food/candy.rsi
     state: macaronberry
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 7 # starcup - for pumping in extra flavor
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: JuiceBerry
-          Quantity: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 7 # starcup - for pumping in extra flavor
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: JuiceBerry
+        Quantity: 2
   - type: Tag
     tags:
     - FoodSnack
@@ -195,15 +191,14 @@
   components:
   - type: Sprite
     state: macaroncherry
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 7 # starcup - for pumping in extra flavor
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: JuiceCherry
-          Quantity: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 7 # starcup - for pumping in extra flavor
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: JuiceCherry
+        Quantity: 2
 
 - type: entity
   name: cotton macaron
@@ -215,15 +210,14 @@
     requiresSpecialDigestion: true
   - type: Sprite
     state: macaroncotton
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 7 # starcup - for pumping in extra flavor
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: Fiber
-          Quantity: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 7 # starcup - for pumping in extra flavor
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: Fiber
+        Quantity: 2
   - type: Tag
     tags:
     - FoodSnack
@@ -236,15 +230,14 @@
   components:
   - type: Sprite
     state: macaronlemon
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 7 # starcup - for pumping in extra flavor
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: JuiceLemon
-          Quantity: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 7 # starcup - for pumping in extra flavor
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: JuiceLemon
+        Quantity: 2
 
 - type: entity
   name: mimana macaron
@@ -254,15 +247,14 @@
   components:
   - type: Sprite
     state: macaronmimana
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 7 # starcup - for pumping in extra nothingness
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: MuteToxin
-          Quantity: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 7 # starcup - for pumping in extra nothingness
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: MuteToxin
+        Quantity: 2
 
 - type: entity
   name: box of macarons

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Consumable/Food/meat.yml
@@ -7,17 +7,16 @@
   - type: FlavorProfile
     flavors:
     - meaty
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 1
-        - ReagentId: Fat
-          Quantity: 5
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 5
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 1
+      - ReagentId: Fat
+        Quantity: 5
   - type: Sprite
     sprite: _Impstation/Objects/Consumable/Food/candy.rsi
     state: heartcarpaccio

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseItem
+  parent: [ BaseItem, SolutionFood ] # starcup - SolutionFood
   id: Rose
   name: rose # starcup - lowercase
   description: Smells like love.
@@ -141,7 +141,6 @@
         Piercing: 5
         Slash: 3
   - type: Solution # starcup - remove SolutionContainerManager
-    id: food
     solution:
       maxVol: 5
       reagents:

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
@@ -118,7 +118,7 @@
       types:
         Piercing: 5
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 3
       reagents:
       - ReagentId: SulfuricAcid
@@ -140,12 +140,11 @@
       types:
         Piercing: 5
         Slash: 3
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Tazinide
-          Quantity: 2
-        - ReagentId: PolytrinicAcid
-          Quantity: 3
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Tazinide
+        Quantity: 2
+      - ReagentId: PolytrinicAcid
+        Quantity: 3

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
@@ -44,10 +44,9 @@
   - type: Item
     sprite: _Impstation/Objects/Specific/Hydroponics/rose.rsi
     size: Small
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 2
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 2
   - type: MeleeChemicalInjector
     solution: food
   - type: InjectableSolution

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
@@ -142,6 +142,7 @@
         Slash: 3
   - type: Solution # starcup - remove SolutionContainerManager
     solution:
+      id: food
       maxVol: 5
       reagents:
       - ReagentId: Tazinide

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
@@ -141,8 +141,8 @@
         Piercing: 5
         Slash: 3
   - type: Solution # starcup - remove SolutionContainerManager
+    id: food
     solution:
-      id: food
       maxVol: 5
       reagents:
       - ReagentId: Tazinide

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Throwable/roses.yml
@@ -117,15 +117,14 @@
     damage:
       types:
         Piercing: 5
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      food:
-        maxVol: 3
-        reagents:
-        - ReagentId: SulfuricAcid
-          Quantity: 1
-        - ReagentId: Razorium
-          Quantity: 1
+      maxVol: 3
+      reagents:
+      - ReagentId: SulfuricAcid
+        Quantity: 1
+      - ReagentId: Razorium
+        Quantity: 1
 
 - type: entity
   parent: [ Rose, BaseMajorContraband ] # starcup - Tier3Contraband -> BaseMajorContraband

--- a/Resources/Prototypes/_NF/Mail/Items/misc.yml
+++ b/Resources/Prototypes/_NF/Mail/Items/misc.yml
@@ -5,26 +5,24 @@
   parent: Syringe
   name: cognizine syringe
   components:
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      drink:
-        maxVol: 15
-        reagents:
-        - ReagentId: Cognizine
-          Quantity: 15 # Surely three friends is enough.
+      maxVol: 15
+      reagents:
+      - ReagentId: Cognizine
+        Quantity: 15 # Surely three friends is enough.
 
 - type: entity
   id: SyringeOpporozidone
   parent: Syringe
   name: opporozidone syringe
   components:
-  - type: SolutionContainerManager
+  - type: Solution # starcup - remove SolutionContainerManager
     solutions:
-      drink:
-        maxVol: 15
-        reagents:
-        - ReagentId: Opporozidone
-          Quantity: 15
+      maxVol: 15
+      reagents:
+      - ReagentId: Opporozidone
+        Quantity: 15
 
 # begin starcup: Necrosol was removed upstream
 # - type: entity

--- a/Resources/Prototypes/_NF/Mail/Items/misc.yml
+++ b/Resources/Prototypes/_NF/Mail/Items/misc.yml
@@ -6,7 +6,7 @@
   name: cognizine syringe
   components:
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 15
       reagents:
       - ReagentId: Cognizine
@@ -18,7 +18,7 @@
   name: opporozidone syringe
   components:
   - type: Solution # starcup - remove SolutionContainerManager
-    solutions:
+    solution:
       maxVol: 15
       reagents:
       - ReagentId: Opporozidone

--- a/Resources/Prototypes/_Umbra/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Umbra/Entities/Mobs/NPCs/animals.yml
@@ -69,12 +69,11 @@
       amount: 1
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 3
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:

--- a/Resources/Prototypes/_Umbra/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Umbra/Entities/Mobs/NPCs/animals.yml
@@ -5,6 +5,7 @@
   parent:
   - SimpleMobBase
   - BaseMobAnimal
+  - SolutionVermin # starcup
   id: MobBunny
   description: Tiny, fluffy, and full of attitude.
   components:
@@ -69,11 +70,11 @@
       amount: 1
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution # starcup - remove SolutionContainerManager
-    solution:
-      reagents:
-      - ReagentId: UncookedAnimalProteins
-        Quantity: 3
+#  - type: Solution # starcup - remove this and reparent instead
+#    solution:
+#      reagents:
+#      - ReagentId: UncookedAnimalProteins
+#        Quantity: 3
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:

--- a/Resources/Prototypes/_starcup/Body/Species/mkc.yml
+++ b/Resources/Prototypes/_starcup/Body/Species/mkc.yml
@@ -159,12 +159,11 @@
   abstract: true
   suffix: MKC
   components:
-  - type: SolutionContainerManager
-    solutions:
-      organ:
-        reagents:
-        - ReagentId: Oil
-          Quantity: 10
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: Oil
+        Quantity: 10
 
 - type: entity
   parent: OrganMKC

--- a/Resources/Prototypes/_starcup/Entities/Clothing/OuterClothing/sweaters.yml
+++ b/Resources/Prototypes/_starcup/Entities/Clothing/OuterClothing/sweaters.yml
@@ -7,13 +7,12 @@
     size: Normal
   - type: Edible
     requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 30
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Fiber
+        Quantity: 30
   - type: Tag
     tags:
     - ClothMade

--- a/Resources/Prototypes/_starcup/Entities/Clothing/OuterClothing/sweaters.yml
+++ b/Resources/Prototypes/_starcup/Entities/Clothing/OuterClothing/sweaters.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingOuterBase, TemperatureProtection ]
+  parent: [ SolutionFood, SolutionNormal, ClothingOuterBase, TemperatureProtection ]
   id: ClothingOuterSweaterBase
   abstract: true
   components:

--- a/Resources/Prototypes/_starcup/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/_starcup/Entities/Effects/puddle.yml
@@ -28,7 +28,8 @@
         layer:
         - SlipLayer
         hard: false
-  - type: SolutionContainerManager
+  - type: Solution
+    id: puddle
   - type: Footprint
   - type: Puddle
     affectsMovement: false
@@ -130,39 +131,36 @@
   parent: PuddleTemporary
   suffix: Water (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Water
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Water
+        Quantity: 30
 
 - type: entity
   id: PuddleWaterLarge
   parent: PuddleTemporary
   suffix: Water (100u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Water
-          Quantity: 100
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Water
+        Quantity: 100
 
 - type: entity
   id: PuddleWaterVeryLarge
   parent: PuddleTemporary
   suffix: Water (200u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Water
-          Quantity: 200
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Water
+        Quantity: 200
 
 # Blood
 - type: entity
@@ -170,104 +168,96 @@
   id: PuddleBloodSulfurSmall
   suffix: Sulfur blood (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: SulfurBlood
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: SulfurBlood
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodSulfur
   suffix: Sulfur blood (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: SulfurBlood
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: SulfurBlood
+        Quantity: 30
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodInsectSmall
   suffix: Insect blood (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: InsectBlood
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: InsectBlood
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodInsect
   suffix: Insect blood (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: InsectBlood
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: InsectBlood
+        Quantity: 30
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodAmmoniaSmall
   suffix: Ammonia blood (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: AmmoniaBlood
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: AmmoniaBlood
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodAmmonia
   suffix: Ammonia blood (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: AmmoniaBlood
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: AmmoniaBlood
+        Quantity: 30
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodCopperSmall
   suffix: Copper blood (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: CopperBlood
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: CopperBlood
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleBloodCopper
   suffix: Copper blood (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: CopperBlood
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: CopperBlood
+        Quantity: 30
 
 # Misc
 - type: entity
@@ -275,75 +265,69 @@
   id: PuddleOilSmall
   suffix: Oil (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Oil
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Oil
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleOil
   suffix: Oil (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Oil
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Oil
+        Quantity: 30
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleSapSmall
   suffix: Sap (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Sap
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Sap
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleSap
   suffix: Sap (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Sap
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Sap
+        Quantity: 30
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleSlimeSmall
   suffix: Slime (5u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Slime
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Slime
+        Quantity: 5
 
 - type: entity
   parent: PuddleTemporary
   id: PuddleSlime
   suffix: Slime (30u)
   components:
-  - type: SolutionContainerManager
-    solutions:
-      puddle:
-        maxVol: 1000
-        reagents:
-        - ReagentId: Slime
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 1000
+      reagents:
+      - ReagentId: Slime
+        Quantity: 30

--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/insects.yml
@@ -40,10 +40,9 @@
         Base: dead
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
+  - type: Solution
+    solution:
+      reagents:
         - ReagentId: GroundInsect
           Quantity: 5
   - type: Butcherable
@@ -131,12 +130,11 @@
         Base: dead
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Slime
-          Quantity: 5
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: Slime
+        Quantity: 5
   - type: Tag
     tags:
     - CreatureEmotes
@@ -281,12 +279,11 @@
     damage:
       types:
         Piercing: 2
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: GroundInsect
-          Quantity: 5
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: GroundInsect
+        Quantity: 5
 
 - type: entity
   name: flies
@@ -312,12 +309,11 @@
         - FlyingMobMask
         layer:
         - FlyingMobLayer
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: GroundInsect
-          Quantity: 5
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: GroundInsect
+        Quantity: 5
 
 - type: entity
   name: mosquitoes
@@ -342,12 +338,11 @@
     damage:
       types:
         Piercing: 1
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: GroundInsect
-          Quantity: 5
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: GroundInsect
+        Quantity: 5
 
 - type: entity
   name: fireflies
@@ -630,12 +625,11 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Slime
-          Quantity: 5
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      reagents:
+      - ReagentId: Slime
+        Quantity: 5
   - type: Butcherable
     spawned:
     - id: FoodMeatSlime

--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/insects.yml
@@ -1,3 +1,16 @@
+# Solutions
+- type: entity
+  abstract: true
+  parent: [SolutionFood, SolutionTiny]
+  id: SolutionBug
+  components:
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: GroundInsect
+        Quantity: 5
+
+# Bugs
 - type: entity
   name: flying insect
   parent: [ SimpleMobBase, FlyingMobBase ]
@@ -40,11 +53,6 @@
         Base: dead
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution
-    solution:
-      reagents:
-        - ReagentId: GroundInsect
-          Quantity: 5
   - type: Butcherable
     spawned: [] # Should give nothing when you butcher it so we set the item id it needs to spawn to null
   - type: Item
@@ -81,7 +89,7 @@
 
 - type: entity
   name: giant flying insect
-  parent: [ SimpleMobBase, FlyingMobBase ]
+  parent: [ SimpleMobBase, FlyingMobBase, SolutionFood, SolutionSmall ]
   id: MobGiantFlyingInsect
   description: For those big buggers.
   abstract: true
@@ -134,7 +142,7 @@
     solution:
       reagents:
       - ReagentId: Slime
-        Quantity: 5
+        Quantity: 15
   - type: Tag
     tags:
     - CreatureEmotes
@@ -261,7 +269,7 @@
   suffix: AI
   id: MobWaspSwarm
   description: They don't want any trouble.
-  parent: MobBeeSwarm
+  parent: [ MobBeeSwarm, SolutionBug]
   components:
   - type: Sprite
     layers:
@@ -290,7 +298,7 @@
   suffix: AI
   id: MobFlySwarm
   description: A person's trash is a fly's treasure.
-  parent: MobFlyingInsect
+  parent: [ MobFlyingInsect, SolutionBug ]
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -309,18 +317,13 @@
         - FlyingMobMask
         layer:
         - FlyingMobLayer
-  - type: Solution
-    solution:
-      reagents:
-      - ReagentId: GroundInsect
-        Quantity: 5
 
 - type: entity
   name: mosquitoes
   suffix: AI
   id: MobMosquitoSwarm
   description: That persistent buzzing on your ears...
-  parent: MobBeeSwarm
+  parent: [ MobBeeSwarm, SolutionBug ]
   components:
   - type: NpcFactionMember
     factions:
@@ -338,18 +341,13 @@
     damage:
       types:
         Piercing: 1
-  - type: Solution
-    solution:
-      reagents:
-      - ReagentId: GroundInsect
-        Quantity: 5
 
 - type: entity
   name: fireflies
   suffix: AI
   id: MobFireflySwarm
   description: Beautiful lights in the night.
-  parent: MobFlyingInsect
+  parent: [ MobFlyingInsect, SolutionBug ]
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -403,8 +401,8 @@
   name: dragonfly
   suffix: AI
   id: MobDragonfly
-  description: Its whip-like tail moves with surprising dexteirty.
-  parent: MobFlyingInsect
+  description: Its whip-like tail moves with surprising dexterity.
+  parent: [ MobFlyingInsect, SolutionBug ]
   components:
   - type: NpcFactionMember
     factions:
@@ -562,6 +560,8 @@
   parent:
   - SimpleMobBase
   - BaseMobAnimal
+  - SolutionFood
+  - SolutionTiny
   id: MobBeetle
   description: A little friend with a tough shell and a valiant heart.
   components:
@@ -625,11 +625,11 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution # starcup - remove SolutionContainerManager
+  - type: Solution
     solution:
       reagents:
       - ReagentId: Slime
-        Quantity: 5
+        Quantity: 10
   - type: Butcherable
     spawned:
     - id: FoodMeatSlime

--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/rodents.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/rodents.yml
@@ -188,12 +188,11 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
+  - type: Solution
     solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -348,12 +347,11 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
+  - type: Solution
     solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -513,12 +511,11 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
+  - type: Solution
     solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -655,12 +652,11 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: SolutionContainerManager
+  - type: Solution # starcup
     solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat

--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/rodents.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/rodents.yml
@@ -108,6 +108,7 @@
   parent:
   - SimpleMobBase
   - BaseMobAnimal
+  - SolutionVermin
   id: MobRat
   name: rat
   description: Slightly bigger and braver than your average mouse.
@@ -188,11 +189,6 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution
-    solution:
-      reagents:
-      - ReagentId: UncookedAnimalProteins
-        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -281,6 +277,7 @@
   parent:
   - SimpleMobBase
   - BaseMobAnimal
+  - SolutionVermin
   id: MobRatLarge
   name: large rat
   description: A particularly portly pest.
@@ -347,11 +344,6 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution
-    solution:
-      reagents:
-      - ReagentId: UncookedAnimalProteins
-        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -445,6 +437,7 @@
   parent:
   - SimpleMobBase
   - BaseMobAnimal
+  - SolutionVermin
   id: MobRatDire
   name: dire rat
   description: Aggressive, overgrown vent vermin, with teeth that look like they could shear steel.
@@ -511,11 +504,6 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution
-    solution:
-      reagents:
-      - ReagentId: UncookedAnimalProteins
-        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat
@@ -586,6 +574,7 @@
   parent:
   - SimpleMobBase
   - BaseMobAnimal
+  - SolutionVermin
   id: MobRatBristle
   name: bristle rat
   description: Also known as vent porcupines, they can fire their nasty quills at a distance.
@@ -652,11 +641,6 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution
-    solution:
-      reagents:
-      - ReagentId: UncookedAnimalProteins
-        Quantity: 3
   - type: Butcherable
     spawned:
     - id: FoodMeatRat

--- a/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/rodents.yml
+++ b/Resources/Prototypes/_starcup/Entities/Mobs/NPCs/rodents.yml
@@ -189,7 +189,7 @@
   - type: Extractable
     grindableSolutionName: food
   - type: Solution
-    solutions:
+    solution:
       reagents:
       - ReagentId: UncookedAnimalProteins
         Quantity: 3
@@ -348,7 +348,7 @@
   - type: Extractable
     grindableSolutionName: food
   - type: Solution
-    solutions:
+    solution:
       reagents:
       - ReagentId: UncookedAnimalProteins
         Quantity: 3
@@ -512,7 +512,7 @@
   - type: Extractable
     grindableSolutionName: food
   - type: Solution
-    solutions:
+    solution:
       reagents:
       - ReagentId: UncookedAnimalProteins
         Quantity: 3
@@ -652,8 +652,8 @@
         prototype: MouseThirst
   - type: Extractable
     grindableSolutionName: food
-  - type: Solution # starcup
-    solutions:
+  - type: Solution
+    solution:
       reagents:
       - ReagentId: UncookedAnimalProteins
         Quantity: 3

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -7,10 +7,9 @@
   - type: Sprite
     sprite: _starcup/Objects/Consumable/Drinks/glass_oldfashioned.rsi
   - type: Appearance
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 20
+  - type: Solution
+    solution:
+      maxVol: 20
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: fill-
@@ -26,10 +25,9 @@
   - type: Sprite
     sprite: _starcup/Objects/Consumable/Drinks/glass_cocktail.rsi
   - type: Appearance
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 15
+  - type: Solution
+    solution:
+      maxVol: 15
   - type: SolutionContainerVisuals
     maxFillLevels: 3
     fillBaseName: fill-
@@ -45,10 +43,9 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/glass_clear.rsi
   - type: Appearance
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
+  - type: Solution
+    solution:
+      maxVol: 30
   - type: SolutionContainerVisuals
     maxFillLevels: 9
     fillBaseName: fill-
@@ -70,10 +67,9 @@
       map: [ "enum.SolutionContainerLayers.Fill" ]
       visible: false
   - type: Appearance
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
+  - type: Solution
+    solution:
+      maxVol: 30
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     fillBaseName: fill-
@@ -83,23 +79,21 @@
   id: DrinkChocolateGlassImitation
   suffix: imitation chocolate
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
+  - type: Solution
+    solution:
+      maxVol: 30
 
 - type: entity
   parent: DrinkGlass
   id: DrinkCherryLimeade
   suffix: cherry limeade
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CherryLimeade
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CherryLimeade
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/cherrylimeade.rsi
     state: icon
@@ -109,13 +103,12 @@
   id: DrinkEvilPrincess
   suffix: evil princess
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: EvilPrincess
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: EvilPrincess
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/evilprincess.rsi
     state: icon
@@ -126,13 +119,12 @@
   id: DrinkAdiosMotherfucker
   suffix: adios, motherfucker
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: AdiosMotherfucker
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: AdiosMotherfucker
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/adiosmotherfucker.rsi
     state: icon
@@ -142,13 +134,12 @@
   id: DrinkAfterburner
   suffix: afterburner
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Afterburner
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Afterburner
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/afterburner.rsi
     state: icon
@@ -158,13 +149,12 @@
   id: DrinkAmbrosia
   suffix: ambrosia
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Ambrosia
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Ambrosia
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/ambrosia.rsi
     state: icon
@@ -174,13 +164,12 @@
   id: DrinkAppletini
   suffix: appletini
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Appletini
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Appletini
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/appletini.rsi
     state: icon
@@ -190,13 +179,12 @@
   id: DrinkAviation
   suffix: aviation
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Aviation
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Aviation
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/aviation.rsi
     state: icon
@@ -206,13 +194,12 @@
   id: DrinkBlackVelvet
   suffix: black velvet
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BlackVelvet
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BlackVelvet
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/blackvelvet.rsi
     state: icon
@@ -222,13 +209,12 @@
   id: DrinkBlueLagoon
   suffix: Blue Lagoon
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BlueLagoon
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BlueLagoon
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/bluelagoon.rsi
     state: icon
@@ -238,13 +224,12 @@
   id: DrinkBrainScrambler
   suffix: brain scrambler
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BrainScrambler
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BrainScrambler
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/brainscrambler.rsi
     state: icon
@@ -254,13 +239,12 @@
   id: DrinkBramble
   suffix: bramble
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Bramble
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Bramble
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/bramble.rsi
     state: icon
@@ -270,13 +254,12 @@
   id: DrinkBuzzedBunny
   suffix: buzzed bunny
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: BuzzedBunny
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: BuzzedBunny
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/buzzedbunny.rsi
     state: icon
@@ -286,13 +269,12 @@
   id: DrinkCactus
   suffix: cactus
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Cactus
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Cactus
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/cactus.rsi
     state: icon
@@ -302,13 +284,12 @@
   id: DrinkCherryBomb
   suffix: cherry bomb
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CherryBomb
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CherryBomb
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/cherrybomb.rsi
     state: icon
@@ -318,13 +299,12 @@
   id: DrinkCorpseReviver
   suffix: corpse reviver
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CorpseReviver
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CorpseReviver
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/corpsereviver.rsi
     state: icon
@@ -334,13 +314,12 @@
   id: DrinkCryptid
   suffix: cryptid
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Cryptid
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Cryptid
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/cryptid.rsi
     state: icon
@@ -350,13 +329,12 @@
   id: DrinkEarthquake
   suffix: earthquake
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Earthquake
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Earthquake
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/earthquake.rsi
     state: icon
@@ -366,13 +344,12 @@
   id: DrinkEclipse
   suffix: eclipse
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Eclipse
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Eclipse
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/eclipse.rsi
     state: icon
@@ -382,13 +359,12 @@
   id: DrinkEmeraldBreeze
   suffix: emerald breeze
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: EmeraldBreeze
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: EmeraldBreeze
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/emeraldbreeze.rsi
     state: icon
@@ -398,13 +374,12 @@
   id: DrinkFaeriesCheer
   suffix: faerie's cheer
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: FaeriesCheer
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: FaeriesCheer
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/faeriescheer.rsi
     state: icon
@@ -414,13 +389,12 @@
   id: DrinkGoblinsBrew
   suffix: goblin's brew
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: GoblinsBrew
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: GoblinsBrew
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/goblinsbrew.rsi
     state: icon
@@ -430,13 +404,12 @@
   id: DrinkMoonMist
   suffix: moon mist
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: MoonMist
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: MoonMist
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/moonmist.rsi
     state: icon
@@ -446,13 +419,12 @@
   id: DrinkMushburger
   suffix: mushburger
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Mushburger
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Mushburger
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/mushburger.rsi
     state: icon
@@ -462,13 +434,12 @@
   id: DrinkNecropolitan
   suffix: necropolitan
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Necropolitan
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Necropolitan
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/necropolitan.rsi
     state: icon
@@ -478,13 +449,12 @@
   id: DrinkParadiseLost
   suffix: paradise lost
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: ParadiseLost
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: ParadiseLost
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/paradiselost.rsi
     state: icon
@@ -494,13 +464,12 @@
   id: DrinkRainbowShooter
   suffix: rainbow shooter
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: RainbowShooter
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: RainbowShooter
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/rainbowshooter.rsi
     state: icon
@@ -510,13 +479,12 @@
   id: DrinkRedDog
   suffix: red dog
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: RedDog
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: RedDog
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/reddog.rsi
     state: icon
@@ -526,13 +494,12 @@
   id: DrinkRedEye
   suffix: red eye
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: RedEye
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: RedEye
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/redeye.rsi
     state: icon
@@ -542,13 +509,12 @@
   id: DrinkSakuraMartini
   suffix: sakura martini
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: SakuraMartini
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: SakuraMartini
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/sakuramartini.rsi
     state: icon
@@ -558,13 +524,12 @@
   id: DrinkSnakebite
   suffix: snakebite
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Snakebite
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Snakebite
+        Quantity: 30
   - type: Icon
     sprite: _starcup/Objects/Consumable/Drinks/snakebite.rsi
     state: icon

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -4,13 +4,12 @@
   name: decaf coffee jug
   description: Wake up juice, of the heated kind.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 300
-        reagents:
-        - ReagentId: CoffeeDecaf
-          Quantity: 300
+  - type: Solution
+    solution:
+      maxVol: 300
+      reagents:
+      - ReagentId: CoffeeDecaf
+        Quantity: 300
   - type: Label
     localizedLabel: reagent-name-coffee-decaf
 
@@ -20,12 +19,11 @@
   name: Sol Dry bottle
   description: Sweet ginger soda from outer space!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: SolDry
-          Quantity: 100
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: SolDry
+        Quantity: 100
   - type: Label
     localizedLabel: reagent-name-sol-dry
   - type: Sprite

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -4,12 +4,11 @@
   name: decaf coffee
   description: The process of decaffeination was a collaborative achivement across many species throughout the galaxy. Now, thanks to their efforts, everyone can enjoy the taste of a hellish morning at work!
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: CoffeeDecaf
-          Quantity: 20
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: CoffeeDecaf
+        Quantity: 20
   - type: Icon
     sprite: Objects/Consumable/Drinks/mug_red.rsi
     state: icon
@@ -28,12 +27,11 @@
   name: imitation hot chocolate
   description: Smells like fond memories of caroling catgirls.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: HotCocoaImitation
-          Quantity: 20
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: HotCocoaImitation
+        Quantity: 20
   - type: Icon
     sprite: Objects/Consumable/Drinks/mug_blue.rsi
     state: icon

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/juiceboxes.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Drinks/juiceboxes.yml
@@ -5,11 +5,10 @@
   name: milk juice box
   description: Bone-building milk in a juice box.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Milk
-          Quantity: 20
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: Milk
+        Quantity: 20
   - type: Sprite
     sprite: _starcup/Objects/Consumable/Drinks/juicebox_milk.rsi

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -8,27 +8,25 @@
     refineResult:
     - id: FoodCakeChocolateSliceImitation
       amount: 8
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 55
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 40
-        - ReagentId: Vitamin
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 55
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 40
+      - ReagentId: Vitamin
+        Quantity: 5
 
 - type: entity
   name: slice of imitation chocolate cake
   parent: FoodCakeChocolateSlice
   id: FoodCakeChocolateSliceImitation
   components:
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 15
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 8
-        - ReagentId: Vitamin
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 15
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 8
+      - ReagentId: Vitamin
+        Quantity: 2

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -6,17 +6,16 @@
   id: FoodBakedMuffinChocolateImitation
   description: A delicious and spongy imitation chocolate muffin.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 14
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: Vitamin
-          Quantity: 2
-        - ReagentId: CocoaPowderImitation
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 14
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 6
+      - ReagentId: Vitamin
+        Quantity: 2
+      - ReagentId: CocoaPowderImitation
+        Quantity: 2
 
 # Cookies
 
@@ -28,13 +27,12 @@
   - type: FlavorProfile
     flavors:
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 6
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 6
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 5
 
 # Waffles/Pancakes
 
@@ -47,13 +45,12 @@
   - type: FlavorProfile
     flavors:
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 5
 
 # Misc
 
@@ -67,13 +64,12 @@
     flavors:
       - sweet
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 78
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 78
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 30
   - type: ToolRefinable
     refineResult:
     - id: FoodBakedBrownieImitation
@@ -89,13 +85,12 @@
     flavors:
       - sweet
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 13
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
+  - type: Solution
+    solution:
+      maxVol: 13
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 5
 
 - type: entity
   name: imitation chocolate special brownies
@@ -107,15 +102,14 @@
       - sweet
       - magical
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 228
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 30
-        - ReagentId: THC
-          Quantity: 150
+  - type: Solution
+    solution:
+      maxVol: 228
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 30
+      - ReagentId: THC
+        Quantity: 150
   - type: ToolRefinable
     refineResult:
     - id: FoodBakedCannabisBrownieImitation
@@ -131,15 +125,14 @@
       - sweet
       - magical
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 38
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 5
-        - ReagentId: THC
-          Quantity: 25
+  - type: Solution # starcup - remove SolutionContainerManager
+    solution:
+      maxVol: 38
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 5
+      - ReagentId: THC
+        Quantity: 25
 
 # Empanadas
 - type: entity
@@ -150,15 +143,14 @@
   components:
   - type: Sprite
     state: dumplings
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 8
-        - ReagentId: Protein
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 8
+      - ReagentId: Protein
+        Quantity: 2
   - type: FlavorProfile
     flavors:
     - meaty

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -7,10 +7,9 @@
   - type: FlavorProfile
     flavors:
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 35
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 25
+  - type: Solution
+    solution:
+      maxVol: 35
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 25

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/candy.yml
@@ -420,3 +420,17 @@
         Quantity: 2
       - ReagentId: Nutriment
         Quantity: 1
+
+# Solutions
+- type: entity
+  parent: SolutionFood
+  id: SolutionCandy
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Solution
+    id: food
+    solution:
+      maxVol: 10
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 10

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/candy.yml
@@ -6,15 +6,14 @@
   name: lollipop
   description: Little stick candies in a dizzyingly wide variety of flavors.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: Nutriment
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: Nutriment
+        Quantity: 2
   - type: Sprite
     sprite: _DV/Objects/Consumable/Food/candy.rsi
     layers:
@@ -38,15 +37,14 @@
   name: gumball
   description: A perennial favorite of standoffish cartoon characters.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 3
-        - ReagentId: Nutriment
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 3
+      - ReagentId: Nutriment
+        Quantity: 2
   - type: Sprite
     sprite: _DV/Objects/Consumable/Food/candy.rsi
     layers:
@@ -391,17 +389,16 @@
   - type: FlavorProfile
     flavors:
     - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 2
-        - ReagentId: CocoaPowderImitation
-          Quantity: 2
-        - ReagentId: Nutriment
-          Quantity: 1
+  - type: Solution
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 2
+      - ReagentId: CocoaPowderImitation
+        Quantity: 2
+      - ReagentId: Nutriment
+        Quantity: 1
 
 - type: entity
   name: homemade imitation chocolate heart
@@ -413,14 +410,13 @@
     sprite: _Impstation/Objects/Consumable/Food/candy.rsi
     layers:
     - state: homemadechocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 15 # extra space for poison purposes
-        reagents:
-        - ReagentId: Sugar
-          Quantity: 2
-        - ReagentId: CocoaPowderImitation
-          Quantity: 2
-        - ReagentId: Nutriment
-          Quantity: 1
+  - type: Solution
+    solution:
+      maxVol: 15 # extra space for poison purposes
+      reagents:
+      - ReagentId: Sugar
+        Quantity: 2
+      - ReagentId: CocoaPowderImitation
+        Quantity: 2
+      - ReagentId: Nutriment
+        Quantity: 1

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/honey.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/honey.yml
@@ -4,13 +4,12 @@
   name: honey jar
   description: Golden treasure of bee and bear.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
-        reagents:
-        - ReagentId: Honey
-          Quantity: 50
+  - type: Solution
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: Honey
+        Quantity: 50
   - type: Label
     localizedLabel: reagent-name-honey
   - type: Sprite

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/ingredients.yml
@@ -10,17 +10,16 @@
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/cocoa.rsi
     state: produce-beans
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 14
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
-        - ReagentId: Vitamin
-          Quantity: 1
-        - ReagentId: CocoaPowderImitation
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 14
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 2
+      - ReagentId: Vitamin
+        Quantity: 1
+      - ReagentId: CocoaPowderImitation
+        Quantity: 2
   - type: Extractable
     juiceSolution:
       reagents:

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/meat.yml
@@ -12,12 +12,11 @@
   - type: Sprite
     sprite: _starcup/Objects/Consumable/Food/meat.rsi
     state: abyssalfish
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: CarpoToxin
-          Quantity: 8
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: CarpoToxin
+        Quantity: 8
   - type: Extractable
     juiceSolution:
       reagents:
@@ -43,12 +42,11 @@
   - type: Sprite
     sprite: _starcup/Objects/Consumable/Food/meat.rsi
     state: badfish
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: CarpoToxin
-          Quantity: 2
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: CarpoToxin
+        Quantity: 2
   - type: Extractable
     juiceSolution:
       reagents:
@@ -70,14 +68,13 @@
   components:
   - type: Sprite
     state: plain
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 9
-        - ReagentId: Fat
-          Quantity: 9
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 9
+      - ReagentId: Fat
+        Quantity: 9
   - type: ToolRefinable
     refineResult:
     - id: FoodMeatCapybaraCutlet
@@ -101,14 +98,13 @@
   - type: Sprite
     layers:
     - state: plain-cooked
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-        - ReagentId: Protein
-          Quantity: 5
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 10
+      - ReagentId: Protein
+        Quantity: 5
   - type: ToolRefinable
     refineResult:
     - id: FoodMeatCapybaraCutlet
@@ -130,11 +126,10 @@
     - Meat
   - type: Sprite
     state: cutlet-cooked
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
-        - ReagentId: Protein
-          Quantity: 2
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 2
+      - ReagentId: Protein
+        Quantity: 2

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/produce.yml
@@ -7,17 +7,16 @@
   - type: FlavorProfile
     flavors:
       - chocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 14
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
-        - ReagentId: Vitamin
-          Quantity: 1
-        - ReagentId: CocoaPowderImitation
-          Quantity: 1
+  - type: Solution
+    solution:
+      maxVol: 14
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 2
+      - ReagentId: Vitamin
+        Quantity: 1
+      - ReagentId: CocoaPowderImitation
+        Quantity: 1
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/cocoa.rsi
   - type: Produce

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Food/snacks.yml
@@ -26,15 +26,14 @@
   - type: FlavorProfile
     flavors:
       - imitationchocolate
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 30
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-        - ReagentId: CocoaPowderImitation
-          Quantity: 1
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 10
+      - ReagentId: CocoaPowderImitation
+        Quantity: 1
 
 - type: entity
   name: nano-treats

--- a/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -4,12 +4,11 @@
   parent: Cigarette
   name: cigarette
   components:
-  - type: SolutionContainerManager
-    solutions:
-      smokable:
-        maxVol: 40
-        reagents:
-          - ReagentId: Nicotine
-            Quantity: 10
-          - ReagentId: Omnizine
-            Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 40
+      reagents:
+      - ReagentId: Nicotine
+        Quantity: 10
+      - ReagentId: Omnizine
+        Quantity: 30

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
@@ -5,13 +5,12 @@
   components:
   - type: Label
     localizedLabel: reagent-name-ammonia
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Ammonia
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Ammonia
+        Quantity: 30
 
 - type: entity
   id: ChemistryBottleElectrolyticNanites
@@ -20,13 +19,12 @@
   components:
   - type: Label
     localizedLabel: reagent-name-electrolytic-nanites
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: ElectrolyticNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: ElectrolyticNanites
+        Quantity: 30
 
 - type: entity
   id: ChemistryBottleCrystalLatticeNanites
@@ -35,13 +33,12 @@
   components:
   - type: Label
     localizedLabel: reagent-name-crystal-lattice-nanites
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: CrystalLatticeNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: CrystalLatticeNanites
+        Quantity: 30
 
 - type: entity
   id: ChemistryBottleOpticalFiberNanites
@@ -50,13 +47,12 @@
   components:
   - type: Label
     localizedLabel: reagent-name-optical-fiber-nanites
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: OpticalFiberNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: OpticalFiberNanites
+        Quantity: 30
 
 - type: entity
   id: ChemistryBottleReconstructorNanites
@@ -65,13 +61,12 @@
   components:
   - type: Label
     localizedLabel: reagent-name-reconstructor-nanites
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: ReconstructorNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: ReconstructorNanites
+        Quantity: 30
 
 - type: entity
   id: ChemistryBottleOverclockNanites
@@ -80,10 +75,9 @@
   components:
   - type: Label
     localizedLabel: reagent-name-overclock-nanites
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: OverclockNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: OverclockNanites
+        Quantity: 30

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
@@ -5,13 +5,12 @@
   components:
   - type: Label
     localizedLabel: reagent-name-blood
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 10
-        reagents:
-        - ReagentId: Blood
-          Quantity: 10
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Blood
+        Quantity: 10
   - type: Tag
     tags:
     - CentrifugeCompatible

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
@@ -7,7 +7,7 @@
     localizedLabel: reagent-name-blood
   - type: Solution
     solution:
-      maxVol: 30
+      maxVol: 10
       reagents:
       - ReagentId: Blood
         Quantity: 10

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/healing.yml
@@ -11,7 +11,7 @@
     localizedLabel: pill-label-caramexinin-10u
   - type: Solution
     solution:
-      maxVol: 30
+      maxVol: 20
       reagents:
       - ReagentId: Caramexinin
         Quantity: 10

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/healing.yml
@@ -9,13 +9,12 @@
     pillType: 8
   - type: Label
     localizedLabel: pill-label-caramexinin-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Caramexinin
-          Quantity: 10
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: Caramexinin
+        Quantity: 10
 
 - type: entity
   parent: PillCanister
@@ -42,13 +41,12 @@
     pillType: 2
   - type: Label
     localizedLabel: pill-label-ethyloxyephedrine-10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Ethyloxyephedrine
-          Quantity: 10
+  - type: Solution
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Ethyloxyephedrine
+        Quantity: 10
 
 - type: entity
   parent: PillCanister

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/hypospray.yml
@@ -196,7 +196,7 @@
       map: [ "enum.SolutionContainerLayers.Fill" ]
   - type: Solution
     solution:
-      maxVol: 30
+      maxVol: 15
       reagents:
       - ReagentId: OverclockNanites
         Quantity: 15

--- a/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_starcup/Entities/Objects/Specific/Medical/hypospray.yml
@@ -88,13 +88,12 @@
     maxFillLevels: 1
     changeColor: false
     emptySpriteName: medipen_silicon_empty
-  - type: SolutionContainerManager
-    solutions:
-      pen:
-        maxVol: 15
-        reagents:
-        - ReagentId: RescueNanites
-          Quantity: 15
+  - type: Solution
+    solution:
+      maxVol: 15
+      reagents:
+      - ReagentId: RescueNanites
+        Quantity: 15
 
 - type: entity
   parent: [ChemicalMedipen, BaseTraitorContraband]
@@ -123,13 +122,12 @@
     maxFillLevels: 1
     changeColor: false
     emptySpriteName: morphen_silicon_empty
-  - type: SolutionContainerManager
-    solutions:
-      pen:
-        maxVol: 30
-        reagents:
-        - ReagentId: ReconstructorNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: ReconstructorNanites
+        Quantity: 30
   - type: StaticPrice
     price: 1500
 
@@ -158,13 +156,12 @@
     layers:
     - state: overclockpen
       map: [ "enum.SolutionContainerLayers.Fill" ]
-  - type: SolutionContainerManager
-    solutions:
-      pen:
-        maxVol: 30
-        reagents:
-        - ReagentId: OverclockNanites
-          Quantity: 30
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: OverclockNanites
+        Quantity: 30
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     changeColor: false
@@ -197,13 +194,12 @@
     layers:
     - state: microoverclockpen
       map: [ "enum.SolutionContainerLayers.Fill" ]
-  - type: SolutionContainerManager
-    solutions:
-      pen:
-        maxVol: 15
-        reagents:
-        - ReagentId: OverclockNanites
-          Quantity: 15
+  - type: Solution
+    solution:
+      maxVol: 30
+      reagents:
+      - ReagentId: OverclockNanites
+        Quantity: 15
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     changeColor: false

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/alien_trees.yml
@@ -270,13 +270,12 @@
         offset: 0
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: SolutionContainerManager
-    solutions:
-      vasculature:
-        maxVol: 15
-        reagents:
-        - ReagentId: Resin
-          Quantity: 15
+  - type: Solution
+    solution:
+      maxVol: 15
+      reagents:
+      - ReagentId: Resin
+        Quantity: 15
 
 - type: entity
   parent: BaseTreeLarge
@@ -336,13 +335,12 @@
         offset: 0
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: SolutionContainerManager
-    solutions:
-      vasculature:
-        maxVol: 15
-        reagents:
-        - ReagentId: Resin
-          Quantity: 15
+  - type: Solution
+    solution:
+      maxVol: 15
+      reagents:
+      - ReagentId: Resin
+        Quantity: 15
 
 - type: entity
   parent: BaseStumpStarcup

--- a/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/plant_debris.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Nature/Flora/plant_debris.yml
@@ -57,13 +57,12 @@
         Quantity: 5
       - ReagentId: Resin
         Quantity: 2
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
+  - type: Solution
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 2
   - type: Fixtures
     fixtures:
       fix1:
@@ -113,13 +112,12 @@
         Quantity: 4
       - ReagentId: Resin
         Quantity: 3
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 1
+  - type: Solution
+    solution:
+      maxVol: 5
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 1
 
 - type: entity
   parent: PlantDebrisGreen

--- a/Resources/Prototypes/_starcup/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/_starcup/Entities/Structures/Power/Generation/portable_generator.yml
@@ -25,10 +25,9 @@
   id: PortableGeneratorJrPacmanFilled
   suffix: Welding Fuel, 8 kW, Filled
   components:
-  - type: SolutionContainerManager
-    solutions:
-      tank:
-        maxVol: 50
-        reagents:
-        - ReagentId: WeldingFuel
-          Quantity: 50
+  - type: Solution
+    solution:
+      maxVol: 50
+      reagents:
+      - ReagentId: WeldingFuel
+        Quantity: 50


### PR DESCRIPTION
This PR just updates all containers we have to use the Solution component, rather than the SolutionContainerManager component, same as [upstream](https://github.com/space-wizards/space-station-14/pull/43412). SCM still technically works, but it's buggy, and it broke silicon medipens. It's on its way out.

I think my candy cigarettes and olive cigarettes wound up a bit hacky, but it works fine. I also added a couple new Solution parents for insects and candy.

## Test plan
I hopped in and tried messing with footprints, puddles, and the rescue nanite injector. Everything seemed happy!

I tested eating and smoking candy cigarettes, as well. Both actions put sugar right into your bloodstream, not metabolites like food would.

## Changelog
:cl:
- fix: (non-player-facing) Updated the solution components on various downstream foods, containers, hypopens, and creatures. Some reagent numbers have been increased.
- fix: Rescue nanite injectors and other reagent containers no longer spawn already spent.
- fix: Fixed a typo in the dragonfly's description.