### PR TITLE
feat: Nearly-Silent Felinid Footsteps

### DIFF
--- a/Resources/Prototypes/_DV/Body/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Body/Species/felinid.yml
@@ -99,7 +99,7 @@
 # begin starcup: silent footsteps
   - type: FootstepModifier
     footstepSoundCollection:
-      collection: BarestepCarpet # TODO: we should really give all species base sounds and all shoes modify them
+      collection: BarestepCarpet
       params:
        volume: -8
        variation: 0.17

--- a/Resources/Prototypes/_DV/Body/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Body/Species/felinid.yml
@@ -96,6 +96,15 @@
     speechSounds: FelinidSpeechSounds # starcup
     speechVerb: Felinid
     allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'Trill'] # starcup: added Trill
+# begin starcup: silent footsteps
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: BarestepCarpet # TODO: we should really give all species base sounds and all shoes modify them
+      params:
+       volume: -8
+       variation: 0.17
+
+# end starcup
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/ServerInfo/Guidebook/_starcup/Mobs/FelinidStarcup.xml
+++ b/Resources/ServerInfo/Guidebook/_starcup/Mobs/FelinidStarcup.xml
@@ -11,9 +11,9 @@
   - Damage Weaknesses: Blunt/Slash/Piercing +15%
   - Unarmed Attack: Claws, deal 5 Slash and 1 Piercing
   - Special Diet: Can eat raw meat and mice; poisoned by theobromine (tea, chocolate), caffeine (coffee, energy drinks), and allicin (garlic, onions)
-  - Slowed half as much as usual when injured
+  - 80% resistance to damage from high-speed impacts.
   - Lighter than most species
-  - Completely silent if walking without shoes
+  - Nearly-silent footsteps
 
   ## Species Abilities
   ### Duffel Critter


### PR DESCRIPTION
This PR adds a footstep sound modifier to felinids that makes their footsteps nearly-silent, no matter what they're wearing or walking on.

It also removes inaccuracies in the guidebook: our felinids have never been "silent while not wearing shoes", not have they ever (as far as I can tell) slowed down less from taking damage.

## Why / Balance
Felinids are a little undertuned at the moment! They're easier to cut down, easier to knock out, and all they really get for it is a slightly better unarmed attack, the ability to get stuffed into a bag, 80% resistance to high-speed impact damage, and cute nyaas.

The reduced slowdown from damage would totally be worth exploring, and I could see it as an alternative to this change. This PR is a little messy, and making tiny footstep sounds while wearing roller skates or walking through puddles might be a dealbreaker.

## Test plan
I walked around as a felinid on various surfaces (puddles, catwalk, plating) and wearing roller skates/ducky slippers.

## Changelog
:cl:
- add: Felinid footsteps are now nearly-inaudible!